### PR TITLE
use default export for React icons

### DIFF
--- a/.changeset/khaki-jars-retire.md
+++ b/.changeset/khaki-jars-retire.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-icons": minor
+---
+
+use default export for React icons

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -12,7 +12,7 @@ npm install @obosbbl/grunnmuren-icons
 
 ```jsx
 // React
-import { House } from '@obosbbl/grunnmuren-icons/react';
+import { House } from '@obosbbl/grunnmuren-icons';
 
 // SVG
 import House from '@obosbbl/grunnmuren-icons/svg/House.svg';

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/icons"
   },
   "exports": {
-    "./react": "./dist/icons.es.js",
+    ".": "./dist/icons.es.js",
     "./svg/*": "./svg/*"
   },
   "files": [


### PR DESCRIPTION
use default export for React icons instead of subpath export `/react`.

TS doesn't support type declaration for subpath exports (coming in version 4.7, which is currently in beta) 