### PR TITLE
Banner fixes

### DIFF
--- a/.changeset/hip-singers-nail.md
+++ b/.changeset/hip-singers-nail.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+fix prose width after changing to the new font

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -26,9 +26,9 @@ export const Banner = (props: BannerProps) => {
       className={classNames(className, bgColor, 'py-8 px-4 md:py-14')}
       {...rest}
     >
-      <div className="<md:flex-wrap flex justify-center gap-4 md:flex-row md:gap-12">
+      <div className="<md:flex-wrap container flex gap-4 md:flex-row md:gap-12">
         {image}
-        <div className="w-prose flex-initial">
+        <div className="w-prose">
           {heading && <h2 className="mb-4">{heading}</h2>}
           {children}
         </div>

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -271,10 +271,10 @@ module.exports = (opts = { useLegacyFont: false }) => {
       extend: {
         maxWidth: {
           // Override Tailwinds default prose width of 60 chars to 48. Roughly 590 pixels
-          prose: '48ch',
+          prose: '590px',
         },
         width: {
-          prose: '48ch',
+          prose: '590px',
         },
         screens: {
           // replicate the smaller than breakpoint from Windi. Even though we are mobile first, it is really nice with an escape hatch sometimes
@@ -342,7 +342,7 @@ module.exports = (opts = { useLegacyFont: false }) => {
               '--tw-prose-headings': theme('colors.black'),
               '--tw-prose-lead': theme('colors.black'),
               color: theme('colors.black'),
-              maxWidth: '48ch',
+              maxWidth: theme('maxWidth.prose'),
               a: {
                 fontWeight: 400,
               },


### PR DESCRIPTION
The prose width was defined with the character width unit. The new font is smaller than the old one, so with the new font the maximum text width was suddenly 427px instead of 590px.


I also fixed the banner component. It should use the regular container instead of being centered. It was simply me who had misunderstood the design sketches.