### PR TITLE
match unordered lists more closely to design

### DIFF
--- a/.changeset/eleven-apricots-wave.md
+++ b/.changeset/eleven-apricots-wave.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+fix bullet list colors and spacing in prose class

--- a/packages/react/src/Typography/stories/Typography.stories.tsx
+++ b/packages/react/src/Typography/stories/Typography.stories.tsx
@@ -23,3 +23,25 @@ export const Default = () => {
     </div>
   );
 };
+
+export const Prose = () => {
+  return (
+    <div className="prose">
+      <h1>Prose</h1>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </p>
+      <ul>
+        <li>List 1</li>
+        <li>List 2</li>
+        <li>List 3</li>
+      </ul>
+    </div>
+  );
+};

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -339,6 +339,8 @@ module.exports = (opts = { useLegacyFont: false }) => {
             css: {
               '--tw-prose-headings': theme('colors.black'),
               '--tw-prose-lead': theme('colors.black'),
+              // TODO: Increase bullet size. See design sketches
+              '--tw-prose-bullets': theme('colors.green.DEFAULT'),
               color: theme('colors.black'),
               maxWidth: theme('maxWidth.prose'),
               a: {
@@ -355,6 +357,10 @@ module.exports = (opts = { useLegacyFont: false }) => {
               },
               h4: {
                 fontWeight: 'bold',
+              },
+              li: {
+                marginTop: '1.5em',
+                marginBottom: '1.5em',
               },
               '[class~="lead"]': {
                 fontWeight: 500,


### PR DESCRIPTION
Update the prose component class so unordered lists looks more like the [design sketches](https://www.figma.com/file/XRHRRytz9DqrDkWpE4IKVB/OBOS-DS?node-id=1%3A362)

The bullet point size and spacing needs to be adjusted some more to look like the design, but that requires some more work than simply changing the color and margin for the list items. Baby steps etc.