### PR TITLE
add radio buttons

### DIFF
--- a/.changeset/orange-laws-promise.md
+++ b/.changeset/orange-laws-promise.md
@@ -1,0 +1,6 @@
+---
+"@obosbbl/grunnmuren-react": minor
+"@obosbbl/grunnmuren-tailwind": minor
+---
+
+add radio group

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -1,0 +1,30 @@
+import classNames from 'clsx';
+import { useContext } from 'react';
+import { RadioContext } from './RadioContext';
+
+export interface RadioProps extends React.ComponentPropsWithoutRef<'input'> {
+  children: React.ReactNode;
+}
+
+export const Radio = (props: RadioProps) => {
+  const { children, className, ...rest } = props;
+
+  const { defaultValue, isControlled, name, onChange, required, value } =
+    useContext(RadioContext);
+
+  return (
+    <label className={classNames(className, 'cursor-pointer')}>
+      <input
+        className="radio"
+        defaultChecked={!isControlled ? rest.value === defaultValue : undefined}
+        checked={isControlled ? rest.value === value : undefined}
+        name={name}
+        onChange={isControlled ? onChange : undefined}
+        required={required}
+        type="radio"
+        {...rest}
+      />
+      {children}
+    </label>
+  );
+};

--- a/packages/react/src/Radio/RadioContext.tsx
+++ b/packages/react/src/Radio/RadioContext.tsx
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+
+export const RadioContext = createContext<{
+  defaultValue?: string;
+  isControlled: boolean;
+  name?: string;
+  onChange?(event: React.ChangeEvent<HTMLInputElement>): void;
+  required?: boolean;
+  value?: string;
+}>({
+  defaultValue: undefined,
+  isControlled: false,
+  name: undefined,
+  onChange() {},
+  required: false,
+  value: undefined,
+});

--- a/packages/react/src/Radio/RadioGroup.tsx
+++ b/packages/react/src/Radio/RadioGroup.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useId, useCallback } from 'react';
+import classNames from 'clsx';
+import { RadioContext } from './RadioContext';
+import { FormHelperText, FormLabel } from '../';
+
+export interface RadioGroupProps
+  extends Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
+  /** The value of the radio button to be initially selected. For uncontrolled usage */
+  defaultValue?: string;
+  /** Help text for the radio group. */
+  description?: string;
+  /** The `name` attribute for the radio buttons. */
+  name: string;
+  /** The label for the radio group. */
+  label?: string;
+  /** Event handler called when the value changes. */
+  onChange?(value: string): void;
+  /** Whether a value selection is required. */
+  required?: boolean;
+  /** The value of the selected radio button. For controlled usage */
+  value?: string;
+}
+
+export const RadioGroup = (props: RadioGroupProps) => {
+  const isControlled = 'value' in props;
+
+  const {
+    className,
+    defaultValue,
+    description,
+    children,
+    label,
+    name,
+    onChange: onChangeProp,
+    required,
+    value,
+    ...rest
+  } = props;
+
+  const onChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextValue = event.target.value;
+      onChangeProp?.(nextValue);
+    },
+    [onChangeProp],
+  );
+
+  const group = useMemo(
+    () => ({
+      defaultValue,
+      isControlled,
+      name,
+      onChange,
+      required,
+      value,
+    }),
+    [defaultValue, isControlled, name, onChange, required, value],
+  );
+
+  const groupId = useId();
+  const labelId = `${groupId}:label`;
+  const helpId = `${groupId}:help`;
+
+  return (
+    <RadioContext.Provider value={group}>
+      <div
+        aria-describedby={description ? helpId : undefined}
+        aria-labelledby={label ? labelId : undefined}
+        className={classNames(className, 'flex flex-col gap-4')}
+        role="radiogroup"
+        {...rest}
+      >
+        {label && (
+          <FormLabel id={labelId} isRequired={required}>
+            {label}
+          </FormLabel>
+        )}
+        {children}
+        <FormHelperText id={helpId}>{description}</FormHelperText>
+      </div>
+    </RadioContext.Provider>
+  );
+};

--- a/packages/react/src/Radio/index.ts
+++ b/packages/react/src/Radio/index.ts
@@ -1,0 +1,2 @@
+export * from './Radio';
+export * from './RadioGroup';

--- a/packages/react/src/Radio/stories/Radio.stories.tsx
+++ b/packages/react/src/Radio/stories/Radio.stories.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { RadioGroup, Radio } from '../../';
+
+const metadata = {
+  title: 'Radio',
+  parameters: {
+    layout: 'padded',
+  },
+};
+export default metadata;
+
+export const Uncontrolled = () => {
+  return (
+    <RadioGroup name="form-name" defaultValue="2">
+      <Radio value="1">Radio 1</Radio>
+      <Radio value="2">Radio 2</Radio>
+      <Radio value="3">Radio 3</Radio>
+    </RadioGroup>
+  );
+};
+
+export const Controlled = () => {
+  const [value, setValue] = useState('2');
+
+  return (
+    <RadioGroup name="form-name" value={value} onChange={setValue}>
+      <Radio value="1">Radio 1</Radio>
+      <Radio value="2">Radio 2</Radio>
+      <Radio value="3">Radio 3</Radio>
+    </RadioGroup>
+  );
+};
+
+export const WithLabelAndHelpText = () => {
+  return (
+    <RadioGroup
+      name="form-name"
+      label="Radio label"
+      required
+      description="Radio help text"
+    >
+      <Radio value="1">Radio 1</Radio>
+      <Radio value="2">Radio 2</Radio>
+      <Radio value="3">Radio 3</Radio>
+    </RadioGroup>
+  );
+};
+
+export const WithLongLabelThatBreaksLines = () => {
+  return (
+    <Radio value="1">
+      Very long label that spans multiple lines on very small screens. The radio
+      input should be vertically centered to the first line of the text, not the
+      center of the whole height of the text label
+    </Radio>
+  );
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,6 +10,7 @@ export * from './Hero';
 export * from './Input';
 export * from './Link';
 export * from './Navbar';
+export * from './Radio';
 export * from './Snackbar';
 export * from './StepList';
 export * from './TextArea';

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -73,6 +73,48 @@ const button = plugin(function ({ addComponents }) {
   });
 });
 
+const radio = plugin(function ({ addComponents, theme }) {
+  addComponents({
+    '.radio': {
+      // hide the native radio input
+      appearance: 'none',
+      // not removed via appeareance
+      margin: 0,
+      height: '1.25rem',
+      width: '1.25rem',
+      borderRadius: '50%',
+      border: `2px solid ${theme('colors.gray.dark')}`,
+      cursor: 'pointer',
+      marginRight: '0.75rem',
+      // use grid to handle the checked:before styles
+      display: 'inline-grid',
+      placeContent: 'center',
+      '&:checked': {
+        borderColor: theme('colors.green.DEFAULT'),
+      },
+      '&:focus-visible': {
+        outline: '1px solid currentColor',
+        outlineOffset: '4px',
+      },
+      '&::before': {
+        content: '""',
+        display: 'block',
+        borderRadius: '50%',
+        transform: 'scale(0)',
+        width: '0.65em',
+        height: '0.65em',
+        transition: '120ms transform ease-in-out',
+        boxShadow: `inset 1em 1em ${theme('colors.green.DEFAULT')}`,
+        /* Windows High Contrast Mode */
+        backgroundColor: 'CanvasText',
+      },
+      '&:checked::before': {
+        transform: 'scale(1)',
+      },
+    },
+  });
+});
+
 const checkbox = plugin(function ({ addComponents, theme }) {
   addComponents({
     '.checkbox': {
@@ -187,6 +229,7 @@ module.exports = (userOptions) => {
       headings,
       checkbox,
       snackbar,
+      radio,
       plugin(function ({ addBase, addUtilities, addComponents, theme }) {
         addBase({
           html: {


### PR DESCRIPTION
This PR implements Radio group buttons.

It is implemented following this guide: https://moderncss.dev/pure-css-custom-styled-radio-buttons/

The figma spec can be found [here](https://www.figma.com/file/XRHRRytz9DqrDkWpE4IKVB/OBOS-DS?node-id=2815%3A42817).


The component supports both controlled and uncontrolled mode, and label/help text. Note that an invalid state is not yet implemented.

<img width="173" alt="Screenshot 2022-08-02 at 12 26 32" src="https://user-images.githubusercontent.com/81577/182353222-e15c4059-c6c5-4274-86d5-efecb9d4b957.png">

