### PR TITLE
feat: automatic validation using validation constraint API

### DIFF
--- a/.changeset/quick-walls-taste.md
+++ b/.changeset/quick-walls-taste.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+add in built validation using HTML validation constraint API

--- a/.changeset/quick-walls-taste.md
+++ b/.changeset/quick-walls-taste.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": minor
 ---
 
-add in built validation using HTML validation constraint API
+add in built validation to TextField and TextArea using HTML validation constraint API

--- a/packages/react/src/TextArea/TextArea.tsx
+++ b/packages/react/src/TextArea/TextArea.tsx
@@ -16,19 +16,34 @@ export interface TextAreaProps
   error?: string;
   /**  Label for the form control */
   label: string;
+  /** Automatically valdiate the form control using the HTML constraint validation API. @default true */
+  validate?: boolean;
 }
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (props, ref) => {
-    const { description, error, id: idProp, label, required, ...rest } = props;
+    const {
+      description,
+      error,
+      id: idProp,
+      label,
+      required,
+      validate = true,
+      ...rest
+    } = props;
 
     const ownRef = useRef(null);
 
-    const { validity } = useFormControlValidity(ownRef);
+    const { validity, validationMessage } = useFormControlValidity(
+      ownRef,
+      validate,
+    );
 
     const id = useFallbackId(idProp);
-    const helpTextId = id + '-help';
-    const errorMsgId = id + '-err-msg';
+    const helpTextId = id + 'help';
+    const errorMsgId = id + 'err';
+
+    const errorMsg = error ?? validationMessage;
 
     return (
       <div className="grid gap-2">
@@ -54,7 +69,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         {description && (
           <FormHelperText id={helpTextId}>{description}</FormHelperText>
         )}
-        {error && <FormErrorMessage id={errorMsgId}>{error}</FormErrorMessage>}
+        {errorMsg && (
+          <FormErrorMessage id={errorMsgId}>{errorMsg}</FormErrorMessage>
+        )}
       </div>
     );
   },

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -47,8 +47,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     const errorMsg = error ?? validationMessage;
 
-    console.log(errorMsg);
-
     return (
       <div className="grid gap-2">
         <FormLabel htmlFor={id} isRequired={required}>

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -17,6 +17,8 @@ export interface TextFieldProps
   /**  Label for the form control */
   label: string;
   prefix?: string;
+  /** Automatically valdiate the form control using the HTML constraint validation API. @default true */
+  validate?: boolean;
 }
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
@@ -28,16 +30,24 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       label,
       required,
       type = 'text',
+      validate = true,
       ...rest
     } = props;
 
     const ownRef = useRef(null);
 
-    const { validity } = useFormControlValidity(ownRef);
+    const { validity, validationMessage } = useFormControlValidity(
+      ownRef,
+      validate,
+    );
 
     const id = useFallbackId(idProp);
-    const helpTextId = id + '-help';
-    const errorMsgId = id + '-err';
+    const helpTextId = id + 'help';
+    const errorMsgId = id + 'err';
+
+    const errorMsg = error ?? validationMessage;
+
+    console.log(errorMsg);
 
     return (
       <div className="grid gap-2">
@@ -62,7 +72,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         {description && (
           <FormHelperText id={helpTextId}>{description}</FormHelperText>
         )}
-        {error && <FormErrorMessage id={errorMsgId}>{error}</FormErrorMessage>}
+        {errorMsg && (
+          <FormErrorMessage id={errorMsgId}>{errorMsg}</FormErrorMessage>
+        )}
       </div>
     );
   },

--- a/packages/react/src/hooks/useFormControlValidity.ts
+++ b/packages/react/src/hooks/useFormControlValidity.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, RefObject } from 'react';
+import { useState, useEffect, RefObject, useCallback } from 'react';
 
 type Validity = 'indeterminate' | 'invalid' | 'valid';
 
@@ -15,36 +15,45 @@ export function useFormControlValidity(
   const [validity, setValidity] = useState<Validity>('indeterminate');
   const [validationMessage, setValidationMessage] = useState<string>();
 
-  const onBlur = (event: FocusEvent) => {
-    // this triggers an invalid event, so if it's invalid it's handled by the `onInvalid` handler
-    const isValid = (event.target as HTMLInputElement).checkValidity();
-
-    if (isValid && enabled) {
-      setValidity('valid');
-      setValidationMessage(undefined);
-    }
-  };
-
-  const onInput = (event: Event) => {
-    if (enabled && validity !== 'indeterminate') {
+  const onBlur = useCallback(
+    (event: FocusEvent) => {
       // this triggers an invalid event, so if it's invalid it's handled by the `onInvalid` handler
       const isValid = (event.target as HTMLInputElement).checkValidity();
 
-      if (isValid) {
+      if (isValid && enabled) {
         setValidity('valid');
         setValidationMessage(undefined);
       }
-    }
-  };
+    },
+    [enabled],
+  );
 
-  const onInvalid = (event: Event) => {
-    if (enabled) {
-      event.preventDefault();
-      const message = (event.target as HTMLInputElement).validationMessage;
-      setValidationMessage(message);
-      setValidity('invalid');
-    }
-  };
+  const onInput = useCallback(
+    (event: Event) => {
+      if (enabled && validity !== 'indeterminate') {
+        // this triggers an invalid event, so if it's invalid it's handled by the `onInvalid` handler
+        const isValid = (event.target as HTMLInputElement).checkValidity();
+
+        if (isValid) {
+          setValidity('valid');
+          setValidationMessage(undefined);
+        }
+      }
+    },
+    [enabled, validity],
+  );
+
+  const onInvalid = useCallback(
+    (event: Event) => {
+      if (enabled) {
+        event.preventDefault();
+        const message = (event.target as HTMLInputElement).validationMessage;
+        setValidationMessage(message);
+        setValidity('invalid');
+      }
+    },
+    [enabled],
+  );
 
   useEffect(() => {
     const { current } = ref;

--- a/packages/react/src/hooks/useFormControlValidity.ts
+++ b/packages/react/src/hooks/useFormControlValidity.ts
@@ -10,31 +10,40 @@ type Validity = 'indeterminate' | 'invalid' | 'valid';
  */
 export function useFormControlValidity(
   ref: RefObject<HTMLElement & { checkValidity(): boolean }>,
+  enabled = true,
 ) {
   const [validity, setValidity] = useState<Validity>('indeterminate');
+  const [validationMessage, setValidationMessage] = useState<string>();
 
   const onBlur = (event: FocusEvent) => {
     // this triggers an invalid event, so if it's invalid it's handled by the `onInvalid` handler
     const isValid = (event.target as HTMLInputElement).checkValidity();
 
-    if (isValid) {
+    if (isValid && enabled) {
       setValidity('valid');
+      setValidationMessage(undefined);
     }
   };
 
   const onInput = (event: Event) => {
-    if (validity !== 'indeterminate') {
+    if (enabled && validity !== 'indeterminate') {
       // this triggers an invalid event, so if it's invalid it's handled by the `onInvalid` handler
       const isValid = (event.target as HTMLInputElement).checkValidity();
 
       if (isValid) {
         setValidity('valid');
+        setValidationMessage(undefined);
       }
     }
   };
 
-  const onInvalid = (/*event: Event*/) => {
-    setValidity('invalid');
+  const onInvalid = (event: Event) => {
+    if (enabled) {
+      event.preventDefault();
+      const message = (event.target as HTMLInputElement).validationMessage;
+      setValidationMessage(message);
+      setValidity('invalid');
+    }
   };
 
   useEffect(() => {
@@ -50,5 +59,5 @@ export function useFormControlValidity(
     };
   });
 
-  return { validity };
+  return { validity, validationMessage };
 }


### PR DESCRIPTION
The browser built in validation has some problems:

- It renders differently in every browser.
- It only renders for a single field at a time.
- It often renders using a tooltip.

We want to render the error messages with our own design. In theory it could be done by using fully controlled inputs, and then checking everything yourself, but we would rather take advantage of the [constraint validation API](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) and the browser built ins.

This PR adds support for "extracting" the error message from the [`invalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event) event, then render it using our own error component. This is what it looks like:

https://user-images.githubusercontent.com/81577/168575875-102e2126-a266-4ec3-ab91-63423c99baab.mp4





Currently the message is rendered using the browser language. In the future we'll add support for providing translations for the messages through app context. Then we can match [the validity type](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api) to a custom message:

```jsx
const validationMessages = {
  valueMissing: 'Påkrevd',
};

<FormValidationMessages={validationMessages}>
  <form>
    <TextField label="Navn" required />
    <Button type="submit" />
  </form>
</FormValidationMessages>
```

This allows you to define language and app, or even form specific custom error messages, all while relying on the browser's native attributes such as `required`, `minlength=X` etc. 
