### PR TITLE
Tailwind: allow specifying font base path

### DIFF
--- a/.changeset/tame-foxes-smash.md
+++ b/.changeset/tame-foxes-smash.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": minor
+---
+
+Add configuration option fontBasePath

--- a/packages/tailwind/README.md
+++ b/packages/tailwind/README.md
@@ -26,14 +26,17 @@ module.exports = {
 
 // Usage with options
 module.exports = {
-  presets: [require('@obosbbl/grunnmuren-tailwind')({ useLegacyFont: true }),
+  presets: [require('@obosbbl/grunnmuren-tailwind')({ useLegacyFont: true, fontBasePath: '/mypath/myfonts' }),
   // content: [ ... ]
 };
 ```
 
 ### Fonts
 
-The preset includes font declarations. You'll have to setup your app so it serves the necessary [font files](../react/public/fonts/) at the path `/fonts/`. See the [preset implementation](./tailwind-base.cjs).
+The preset includes font declarations.
+You'll have to setup your app so it serves the necessary [font files](../react/public/fonts/).
+By default the fonts should be under `/fonts/` but you can override this with the config option `fontBasePath`.
+See the [preset implementation](./tailwind-base.cjs).
 
 ## Options
 
@@ -42,3 +45,4 @@ The preset supports the following options:
 | Name          | Default value | Description                                  |
 | ------------- | ------------- | -------------------------------------------- |
 | useLegacyFont | `false`       | Whether to use the fonts from the old design |
+| fontBasePath  | `/fonts`      | Path to where the fonts are hosted           |

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -5,22 +5,22 @@ const gorditaFonts = [
   {
     fontWeight: 400,
     fontStyle: 'normal',
-    url: '/fonts/gorditaregular-webfont.woff2',
+    url: '/gorditaregular-webfont.woff2',
   },
   {
     fontWeight: 400,
     fontStyle: 'italic',
-    url: '/fonts/gorditaregularitalic-webfont.woff2',
+    url: '/gorditaregularitalic-webfont.woff2',
   },
   {
     fontWeight: 500,
     fontStyle: 'normal',
-    url: '/fonts/gorditamedium-webfont.woff2',
+    url: '/gorditamedium-webfont.woff2',
   },
   {
     fontWeight: 700,
     fontStyle: 'normal',
-    url: '/fonts/gorditabold-webfont.woff2',
+    url: '/gorditabold-webfont.woff2',
   },
 ];
 
@@ -28,22 +28,22 @@ const obosFonts = [
   {
     fontWeight: 400,
     fontStyle: 'normal',
-    url: '/fonts/OBOSText-Regular.woff2',
+    url: '/OBOSText-Regular.woff2',
   },
   {
     fontWeight: 400,
     fontStyle: 'italic',
-    url: '/fonts/OBOSText-Italic.woff2',
+    url: '/OBOSText-Italic.woff2',
   },
   {
     fontWeight: 500,
     fontStyle: 'normal',
-    url: '/fonts/OBOSText-Medium.woff2',
+    url: '/OBOSText-Medium.woff2',
   },
   {
     fontWeight: 700,
     fontStyle: 'normal',
-    url: '/fonts/OBOSText-Bold.woff2',
+    url: '/OBOSText-Bold.woff2',
   },
 ];
 
@@ -157,7 +157,7 @@ const snackbar = plugin(function ({ addComponents, theme }) {
   });
 });
 
-module.exports = (opts = { useLegacyFont: false }) => {
+module.exports = (opts = { useLegacyFont: false, fontBasePath: '/fonts' }) => {
   let fontFamily = 'OBOSFont';
   let fonts = obosFonts;
   if (opts.useLegacyFont) {
@@ -245,7 +245,7 @@ module.exports = (opts = { useLegacyFont: false }) => {
               fontFamily,
               fontWeight: font.fontWeight,
               fontStyle: font.fontStyle,
-              src: `url('${font.url}') format('woff2')`,
+              src: `url('${opts.fontBasePath}${font.url}') format('woff2')`,
               fontDisplay: 'swap',
             },
           })),


### PR DESCRIPTION
With this the consuming application can host the fonts on a different
path than `/fonts`. We still assume the font file names.