### PR TITLE
Hide disclosure triangle in Safari for summary/details element

### DIFF
--- a/.changeset/giant-jeans-bathe.md
+++ b/.changeset/giant-jeans-bathe.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+hide discloure arrow in safari when `list-none` is applied to the `<summary>` element

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -189,6 +189,10 @@ module.exports = (opts = { useLegacyFont: false }) => {
             '@apply underline': {},
           },
           '::selection': { '@apply bg-green-light text-black': {} },
+          // Remove the disclosure triangle in Safari if apply the `list-none` utilit class to the summary element
+          'summary.list-none::-webkit-details-marker': {
+            display: 'none',
+          },
         });
         addComponents({
           '.container': {


### PR DESCRIPTION
when the list-none utility is applied