### PR TITLE
Tailwind:  Configuration option for legacy container size

### DIFF
--- a/.changeset/lovely-bulldogs-attack.md
+++ b/.changeset/lovely-bulldogs-attack.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": minor
+---
+
+Add configuration option for container size (80rem or 90rem)

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -157,15 +157,24 @@ const snackbar = plugin(function ({ addComponents, theme }) {
   });
 });
 
-const defaultOpts = { useLegacyFont: false, fontBasePath: '/fonts' };
+const defaultOpts = {
+  useLegacyFont: false,
+  fontBasePath: '/fonts',
+  useLegacyContainerSize: false,
+};
 
 module.exports = (userOptions) => {
   const opts = userOptions ? { ...defaultOpts, ...userOptions } : defaultOpts;
   let fontFamily = 'OBOSFont';
   let fonts = obosFonts;
+  let containerSize = '90rem';
   if (opts.useLegacyFont) {
     fontFamily = 'Gordita';
     fonts = gorditaFonts;
+  }
+
+  if (opts.useLegacyContainerSize) {
+    containerSize = '80rem';
   }
 
   return {
@@ -204,7 +213,7 @@ module.exports = (userOptions) => {
             paddingRight: '1rem',
             marginLeft: 'auto',
             marginRight: 'auto',
-            maxWidth: '90rem',
+            maxWidth: containerSize,
           },
           '.container-prose': {
             width: '100%',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4883,7 +4883,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -10052,17 +10052,6 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
-    dev: true
-
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
     dev: true
 
   /promise.allsettled/1.0.5:


### PR DESCRIPTION
Add option for users to change containersize to 80rem instead of 90rem. 

80rem is the legacy width size of a container.