### PR TITLE
fix font path for GH pages

### DIFF
--- a/packages/react/tailwind.config.cjs
+++ b/packages/react/tailwind.config.cjs
@@ -1,4 +1,11 @@
+const opts = {};
+
+// Fixes font loading for GH pages where the site path is {org}.github.io/{repo}
+if (process.env.GITHUB_ACTION) {
+  opts.fontBasePath = '/grunnmuren/fonts';
+}
+
 module.exports = {
-  presets: [require('@obosbbl/grunnmuren-tailwind')],
+  presets: [require('@obosbbl/grunnmuren-tailwind')(opts)],
   content: ['./src/**/*.{ts,tsx}'],
 };


### PR DESCRIPTION
The storybook on GH pages is hosted https://code-obos.github.io/grunnmuren/, so we need to include `grunnmuren` in the base path for the fonts to load correctly.