### PR TITLE
tailwind: add 2rem to container/container-prose

### DIFF
--- a/.changeset/itchy-goats-fix.md
+++ b/.changeset/itchy-goats-fix.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+Add 2rem extra to container and container-prose to get correct width because we use 1rem padding on both sides as well

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -167,14 +167,14 @@ module.exports = (userOptions) => {
   const opts = userOptions ? { ...defaultOpts, ...userOptions } : defaultOpts;
   let fontFamily = 'OBOSFont';
   let fonts = obosFonts;
-  let containerSize = '90rem';
+  let containerSize = '92rem';
   if (opts.useLegacyFont) {
     fontFamily = 'Gordita';
     fonts = gorditaFonts;
   }
 
   if (opts.useLegacyContainerSize) {
-    containerSize = '80rem';
+    containerSize = '82rem';
   }
 
   return {
@@ -221,7 +221,7 @@ module.exports = (userOptions) => {
             paddingRight: '1rem',
             marginLeft: 'auto',
             marginRight: 'auto',
-            maxWidth: '37rem',
+            maxWidth: '39rem',
           },
           // that thin blue line at the top
           '.topline::before': {


### PR DESCRIPTION
We have to add 2rem to the container and container-prose classes because we also use 1rem padding on both left and right side, this means that the container is actually 32px smaller than it should be.

1440px width:
<img width="270" alt="image" src="https://user-images.githubusercontent.com/4094284/175901842-a9955b10-8991-4b6d-833d-5caf49e7fa33.png">

1280px width:
<img width="244" alt="image" src="https://user-images.githubusercontent.com/4094284/175902157-795fd179-0fc7-43c9-a358-886133fdb93c.png">

container-prose:
<img width="214" alt="image" src="https://user-images.githubusercontent.com/4094284/175902340-f5e29d46-bea5-4a23-b0b0-24f51fc83b57.png">
