### PR TITLE
add Campaign component

### DIFF
--- a/.changeset/curvy-rockets-invent.md
+++ b/.changeset/curvy-rockets-invent.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+add Campaign component

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -1,0 +1,65 @@
+import { cloneElement, Children, isValidElement } from 'react';
+import classNames from 'clsx';
+
+interface CampaignProps<T extends React.ElementType> {
+  /** @default div */
+  as?: T;
+}
+
+const Campaign = <T extends React.ElementType = 'div'>(
+  props: CampaignProps<T> &
+    Omit<React.ComponentPropsWithoutRef<T>, keyof CampaignProps<T>>,
+) => {
+  const { as: Component = 'div', className, ...rest } = props;
+
+  return (
+    <Component
+      className={classNames(
+        className,
+        'grid gap-8 md:grid-flow-col md:grid-cols-[50%,50%] md:gap-0',
+      )}
+      {...rest}
+    />
+  );
+};
+
+interface CampaignBodyProps extends React.ComponentPropsWithoutRef<'div'> {}
+
+const CampaignBody = (props: CampaignBodyProps) => {
+  const { className, ...rest } = props;
+  return (
+    <div className={classNames(className, 'md:mx-18 self-center')} {...rest} />
+  );
+};
+
+interface CampaignImageProps extends React.ComponentPropsWithoutRef<'img'> {
+  /** Applies CSS order to move the image to the right on > medium sceens. Use this
+   * to alternate the image's positon with lists of Campaigns.
+   */
+  rightAlign?: boolean;
+}
+
+const CampaignImage = (props: CampaignImageProps) => {
+  const { className: classNameProp, children, rightAlign, ...rest } = props;
+
+  const className = classNames(
+    classNameProp,
+    '<md:rounded-b-3xl w-full',
+    rightAlign ? 'md:rounded-l-3xl md:order-1' : 'md:rounded-r-3xl',
+  );
+
+  // If the component has children, clone it and apply our classes.
+  // Allows us to use custom image components (as long as they accept a className) such as next/image.
+  if (isValidElement(children)) {
+    const child = Children.only(children);
+
+    return cloneElement(child, { className, ...rest });
+  }
+
+  // Otherwise we fallback to rendering an img element ourselves.
+  return <img className={className} {...rest} />;
+};
+
+Campaign.Body = CampaignBody;
+Campaign.Image = CampaignImage;
+export { Campaign };

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -4,6 +4,8 @@ import classNames from 'clsx';
 interface CampaignProps<T extends React.ElementType> {
   /** @default div */
   as?: T;
+  /** A CampaignImage and a CampaignBody */
+  children: [React.ReactElement, React.ReactElement];
 }
 
 const Campaign = <T extends React.ElementType = 'div'>(

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -1,18 +1,42 @@
-import { cloneElement, Children, isValidElement } from 'react';
+import {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+} from 'react';
 import classNames from 'clsx';
+
+// The context controls the alignment of the body vs the image
+const CampaignContext = createContext(true);
 
 interface CampaignProps<T extends React.ElementType> {
   /** @default div */
   as?: T;
-  /** A CampaignImage and a CampaignBody */
-  children: [React.ReactElement, React.ReactElement];
+  body: React.ReactElement;
+  /** Use the `body` and `image` props. */
+  children?: never;
+  image: React.ReactElement;
+  /**
+   * Setting this to false changes the ordering of the body and the image on >= medium sceens.
+   * Use this to alternate the image's positon with lists of Campaigns.
+   * @default true
+   */
+  rightAlignBody?: boolean;
 }
 
 const Campaign = <T extends React.ElementType = 'div'>(
   props: CampaignProps<T> &
     Omit<React.ComponentPropsWithoutRef<T>, keyof CampaignProps<T>>,
 ) => {
-  const { as: Component = 'div', className, ...rest } = props;
+  const {
+    as: Component = 'div',
+    body: Body,
+    className,
+    image: Image,
+    rightAlignBody = true,
+    ...rest
+  } = props;
 
   return (
     <Component
@@ -21,7 +45,12 @@ const Campaign = <T extends React.ElementType = 'div'>(
         'grid gap-8 md:grid-flow-col md:grid-cols-[50%,50%] md:gap-0',
       )}
       {...rest}
-    />
+    >
+      <CampaignContext.Provider value={rightAlignBody}>
+        {Image}
+      </CampaignContext.Provider>
+      {Body}
+    </Component>
   );
 };
 
@@ -34,20 +63,17 @@ const CampaignBody = (props: CampaignBodyProps) => {
   );
 };
 
-interface CampaignImageProps extends React.ComponentPropsWithoutRef<'img'> {
-  /** Applies CSS order to move the image to the right on > medium sceens. Use this
-   * to alternate the image's positon with lists of Campaigns.
-   */
-  rightAlign?: boolean;
-}
+interface CampaignImageProps extends React.ComponentPropsWithoutRef<'img'> {}
 
 const CampaignImage = (props: CampaignImageProps) => {
-  const { className: classNameProp, children, rightAlign, ...rest } = props;
+  const { className: classNameProp, children, ...rest } = props;
+
+  const bodyIsRightAligned = useContext(CampaignContext);
 
   const className = classNames(
     classNameProp,
     '<md:rounded-b-3xl w-full',
-    rightAlign ? 'md:rounded-l-3xl md:order-1' : 'md:rounded-r-3xl',
+    bodyIsRightAligned ? 'md:rounded-r-3xl' : 'md:rounded-l-3xl md:order-1',
   );
 
   // If the component has children, clone it and apply our classes.

--- a/packages/react/src/Campaign/index.ts
+++ b/packages/react/src/Campaign/index.ts
@@ -1,0 +1,1 @@
+export * from './Campaign';

--- a/packages/react/src/Campaign/stories/Campaign.stories.tsx
+++ b/packages/react/src/Campaign/stories/Campaign.stories.tsx
@@ -1,0 +1,52 @@
+import { Campaign } from '../../';
+
+export default {
+  title: 'Campaign',
+  parameters: { layout: 'padded' },
+};
+
+const images = [
+  'https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/w_780/f_auto,q_auto/v1611759995/Block%20Watne/Fluks/Mennesker/Bygge-hus-Fluks-arkitekt-ra%CC%8Adgiver',
+  'https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/w_780/f_auto,q_auto/v1614347690/Block%20Watne/Fluks/Interi%C3%B8r/interi%C3%B8r-standard-ferdighus',
+  'https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/w_780/f_auto,q_auto/v1612349703/Block%20Watne/Fluks/Illustrasjoner/Bygge-hus-inspirasjon',
+];
+
+export const Default = () => {
+  return (
+    <div className="container flex flex-col gap-16">
+      {images.map((imageSrc, index) => (
+        <Campaign key={index}>
+          <Campaign.Image src={imageSrc} alt="" rightAlign={index % 2 !== 0} />
+          <Campaign.Body>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel
+            leo et metus aliquet egestas quis vel lorem. Pellentesque in
+            fermentum orci, eget pharetra ex. In maximus dolor id dolor
+            vulputate, a placerat nulla sollicitudin. Sed viverra nisl ac nisi
+            sodales, eu porttitor felis vulputate. Nulla volutpat rutrum dictum.
+            Mauris augue odio, dignissim ac nibh porttitor, accumsan facilisis
+            dui. Mauris ultrices elit in orci scelerisque feugiat.
+          </Campaign.Body>
+        </Campaign>
+      ))}
+    </div>
+  );
+};
+
+export const WithCustomImageComponent = () => {
+  return (
+    <Campaign className="container">
+      <Campaign.Image>
+        <img src={images[0]} alt="" />
+      </Campaign.Image>
+      <Campaign.Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel leo
+        et metus aliquet egestas quis vel lorem. Pellentesque in fermentum orci,
+        eget pharetra ex. In maximus dolor id dolor vulputate, a placerat nulla
+        sollicitudin. Sed viverra nisl ac nisi sodales, eu porttitor felis
+        vulputate. Nulla volutpat rutrum dictum. Mauris augue odio, dignissim ac
+        nibh porttitor, accumsan facilisis dui. Mauris ultrices elit in orci
+        scelerisque feugiat.
+      </Campaign.Body>
+    </Campaign>
+  );
+};

--- a/packages/react/src/Campaign/stories/Campaign.stories.tsx
+++ b/packages/react/src/Campaign/stories/Campaign.stories.tsx
@@ -15,38 +15,44 @@ export const Default = () => {
   return (
     <div className="container flex flex-col gap-16">
       {images.map((imageSrc, index) => (
-        <Campaign key={index}>
-          <Campaign.Image src={imageSrc} alt="" rightAlign={index % 2 !== 0} />
-          <Campaign.Body>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel
-            leo et metus aliquet egestas quis vel lorem. Pellentesque in
-            fermentum orci, eget pharetra ex. In maximus dolor id dolor
-            vulputate, a placerat nulla sollicitudin. Sed viverra nisl ac nisi
-            sodales, eu porttitor felis vulputate. Nulla volutpat rutrum dictum.
-            Mauris augue odio, dignissim ac nibh porttitor, accumsan facilisis
-            dui. Mauris ultrices elit in orci scelerisque feugiat.
-          </Campaign.Body>
-        </Campaign>
+        <Campaign
+          rightAlignBody={index % 2 === 0}
+          key={index}
+          body={
+            <Campaign.Body>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel
+              leo et metus aliquet egestas quis vel lorem. Pellentesque in
+              fermentum orci, eget pharetra ex. In maximus dolor id dolor
+              vulputate, a placerat nulla sollicitudin. Sed viverra nisl ac nisi
+              sodales, eu porttitor felis vulputate. Nulla volutpat rutrum
+              dictum. Mauris augue odio, dignissim ac nibh porttitor, accumsan
+              facilisis dui. Mauris ultrices elit in orci scelerisque feugiat.
+            </Campaign.Body>
+          }
+          image={<Campaign.Image src={imageSrc} alt="" />}
+        />
       ))}
     </div>
   );
 };
 
 export const WithCustomImageComponent = () => {
-  return (
-    <Campaign className="container">
-      <Campaign.Image>
-        <img src={images[0]} alt="" />
-      </Campaign.Image>
-      <Campaign.Body>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel leo
-        et metus aliquet egestas quis vel lorem. Pellentesque in fermentum orci,
-        eget pharetra ex. In maximus dolor id dolor vulputate, a placerat nulla
-        sollicitudin. Sed viverra nisl ac nisi sodales, eu porttitor felis
-        vulputate. Nulla volutpat rutrum dictum. Mauris augue odio, dignissim ac
-        nibh porttitor, accumsan facilisis dui. Mauris ultrices elit in orci
-        scelerisque feugiat.
-      </Campaign.Body>
-    </Campaign>
+  const image = (
+    <Campaign.Image>
+      <img src={images[0]} alt="" />
+    </Campaign.Image>
   );
+
+  const body = (
+    <Campaign.Body>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel leo et
+      metus aliquet egestas quis vel lorem. Pellentesque in fermentum orci, eget
+      pharetra ex. In maximus dolor id dolor vulputate, a placerat nulla
+      sollicitudin. Sed viverra nisl ac nisi sodales, eu porttitor felis
+      vulputate. Nulla volutpat rutrum dictum. Mauris augue odio, dignissim ac
+      nibh porttitor, accumsan facilisis dui. Mauris ultrices elit in orci
+      scelerisque feugiat.
+    </Campaign.Body>
+  );
+  return <Campaign className="container" body={body} image={image} />;
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Alert';
 export * from './Banner';
 export * from './Button';
+export * from './Campaign';
 export * from './Card';
 export * from './Checkbox';
 export * from './Footer';


### PR DESCRIPTION
This PR implements the [Campaign component from Figma](https://www.figma.com/file/XRHRRytz9DqrDkWpE4IKVB/OBOS-DS?node-id=571%3A9357)

It is used as this:
```jsx
<Campaign>
  <Campaign.Image src="..." />
  <Campaign.Body>
    Lorem ipsum
  </Campaign.Body>
</Campaign>
```

The image component supports a prop `rightAlign`, that uses the [CSS order property](https://developer.mozilla.org/en-US/docs/Web/CSS/order) to move the image to the right.

Even though `order` is kind of frowned upon, I think it's okay in this case since it's not the default, an image isn't tabbable and it only happens on desktop. The use case here is to support alternating the image on the left/right side of the content when multiple campaigns are rendered in succession (see Figma).


The image component also supports custom components, such as the new [Next.js image component](https://nextjs.org/blog/next-12-2#improvements-to-nextimage) (that supports className):
```jsx
<Campaign.Image>
  <Image loader={...} />
</Campaign.Image>
```

