### PR TITLE
Add className forwarding to CardLinkOverlay

### DIFF
--- a/.changeset/early-shrimps-pretend.md
+++ b/.changeset/early-shrimps-pretend.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+CardLinkOverlay: forward className

--- a/.changeset/six-seahorses-compete.md
+++ b/.changeset/six-seahorses-compete.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+CardLinkOverlay: remove unecessary custom before content class

--- a/packages/react/src/Card/CardLinkOverlay.tsx
+++ b/packages/react/src/Card/CardLinkOverlay.tsx
@@ -1,4 +1,6 @@
+import classNames from 'clsx';
 import { forwardRef } from 'react';
+
 export interface CardLinkOverlayProps
   extends React.ComponentPropsWithoutRef<'a'> {}
 
@@ -6,11 +8,16 @@ export const CardLinkOverlay = forwardRef<
   HTMLAnchorElement,
   CardLinkOverlayProps
 >((props, ref) => {
+  const { className, ...rest } = props;
+
   return (
     <a
-      className="no-underline before:absolute before:top-0 before:left-0 before:block before:h-full before:w-full before:content-[''] hover:underline"
+      className={classNames(
+        className,
+        "no-underline before:absolute before:top-0 before:left-0 before:block before:h-full before:w-full before:content-[''] hover:underline",
+      )}
       ref={ref}
-      {...props}
+      {...rest}
     />
   );
 });

--- a/packages/react/src/Card/CardLinkOverlay.tsx
+++ b/packages/react/src/Card/CardLinkOverlay.tsx
@@ -14,7 +14,7 @@ export const CardLinkOverlay = forwardRef<
     <a
       className={classNames(
         className,
-        "no-underline before:absolute before:top-0 before:left-0 before:block before:h-full before:w-full before:content-[''] hover:underline",
+        'no-underline before:absolute before:top-0 before:left-0 before:block before:h-full before:w-full hover:underline',
       )}
       ref={ref}
       {...rest}


### PR DESCRIPTION
* Add support for `className` prop to CardLinkOverlay.
* Remove unecessary class `before:content-['']`. All of Tailwind's classes with the `before:` modifier sets this automatically.
