### PR TITLE
Add flex-none to Checkbox to avoid shape-squeeze

### DIFF
--- a/.changeset/silver-singers-swim.md
+++ b/.changeset/silver-singers-swim.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Add flex-none to Checkbox to avoid non-quadratic shape when used with text wrapping multiple lines

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -31,7 +31,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           <input
             id={id}
             className={classNames(
-              'checkbox checked:bg-green checked:border-green bg-whit mr-3 grid h-[1.25em] w-[1.25em] cursor-pointer appearance-none place-content-center rounded border-2 border-solid text-white focus:outline-none focus:ring-2',
+              'checkbox checked:bg-green checked:border-green bg-whit mr-3 grid h-[1.25em] w-[1.25em] flex-none cursor-pointer appearance-none place-content-center rounded border-2 border-solid text-white focus:outline-none focus:ring-2',
               {
                 'border-gray-dark focus:ring-black': !error,
                 'border-red focus:ring-red': !!error,


### PR DESCRIPTION
When using Checkbox along with a text that wraps, the checkbox is squeezed so that the shape looks weird. This PR adds a flex-none class to the input in order no avoid this squeeze.

Example of previous behavior:
<img width="489" alt="image" src="https://user-images.githubusercontent.com/31652936/177292485-28bf1c1b-a55c-46b8-b1f7-ab8e34c86d05.png">

I also know that the nærkontor-team has encountered this problem.