### PR TITLE
renovatebot: group all @svgr packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "extends": [
     "config:base"
   ],
-  "schedule": ["on saturday"]
+  "schedule": ["on saturday"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^@svgr/"],
+      "groupName": "svgr packages"
+    }
+  ]
 }


### PR DESCRIPTION
Add renovate configuration to group all svgr packages in the same PR, to prevent this:

<img width="574" alt="Screenshot 2022-08-08 at 08 29 07" src="https://user-images.githubusercontent.com/81577/183353635-980321f8-1f91-432e-a93f-87932d07d6cf.png">

See [renovate docs for package rules](https://docs.renovatebot.com/configuration-options/#packagerules)
