### PR TITLE
renovatebot: group all vite packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
     {
       "matchPackagePatterns": ["^@svgr/"],
       "groupName": "svgr packages"
+    },
+    {
+      "matchPackagePatterns": ["^@vitejs/", "vite"],
+      "groupName": "vite packages"
     }
   ]
 }


### PR DESCRIPTION
add renovate config to group together vite packages to prevent this:
<img width="576" alt="Screenshot 2022-08-17 at 10 12 18" src="https://user-images.githubusercontent.com/81577/185068830-2c1ae102-b211-4ab4-abcc-9e79b0b72321.png">

