### PR TITLE
refactor: button as Tailwind component

### DIFF
--- a/.changeset/spotty-jokes-call.md
+++ b/.changeset/spotty-jokes-call.md
@@ -1,0 +1,6 @@
+---
+"@obosbbl/grunnmuren-react": patch
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+refactor button styling to a Tailwind component

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -44,11 +44,7 @@ export const Button = forwardRef<
 
   const buttonVariation = buttonVariations[`${color}-${variant}`];
 
-  const classes = classNames(
-    className,
-    buttonVariation,
-    'button relative no-underline inline-block border-solid border-2 px-6 py-2 rounded-xl transition-all duration-200 font-medium w-fit disabled:pointer-events-none disabled:text-black disabled:bg-gray-light disabled:border-gray-light hover:rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-black ring-offset-2',
-  );
+  const classes = classNames(className, buttonVariation, 'button');
 
   return (
     <>

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -47,12 +47,30 @@ const obosFonts = [
   },
 ];
 
-const button = plugin(function ({ addComponents }) {
-  // adds a shade on the button when hovered
-  // ideally this would be solved by just darkening the button background,
-  // but that doesn't really work since some of the button variations have transparent backgrounds
+const button = plugin(function ({ addComponents, theme }) {
   addComponents({
     '.button': {
+      // The Tailwind utilities we use for focus styling are kinda hard to "translate", so using the @apply utility here, even though mixing styles are meh...
+      '@apply focus:outline-none focus-visible:ring-2 focus-visible:ring-black ring-offset-2':
+        {},
+      position: 'relative',
+      textDecorationLine: 'none',
+      display: 'inline-block',
+      border: '2px solid',
+      padding: `${theme('spacing.2')} ${theme('spacing.6')}`,
+      borderRadius: '0.75rem',
+      transition: `all 200ms ${theme('transitionTimingFunction.DEFAULT')}`,
+      fontWeight: theme('fontWeight.medium'),
+      width: 'fit-content',
+      '&:disabled': {
+        backgroundColor: theme('colors.gray.light'),
+        borderColor: theme('colors.gray.light'),
+        color: theme('colors.black'),
+        pointerEvents: 'none',
+      },
+      '&:hover': {
+        borderRadius: '0.375rem',
+      },
       '&::after': {
         content: '""',
         position: 'absolute',
@@ -64,10 +82,13 @@ const button = plugin(function ({ addComponents }) {
         bottom: '-2px',
         borderRadius: '0.75rem',
       },
+      // adds a shade on the button when hovered
+      // ideally this would be solved by just darkening the button background,
+      // but that doesn't really work since some of the button variations have transparent backgrounds
       '&:hover::after': {
         backgroundColor: 'rgba(0, 0, 0, 0.1)',
         borderRadius: '0.375rem',
-        transition: 'all 200ms cubic-bezier(0.4, 0, 0.2, 1)',
+        transition: `all 200ms ${theme('transitionTimingFunction.DEFAULT')}`,
       },
     },
   });


### PR DESCRIPTION
Denne PRen flytter over større deler av Button sin styling fra Tailwind utilities til en Tailwind component. Det gjør det enklere dersom du har tilfeller der du må overstyre default stylingen. For å få til dette før denne PRen måtte du bruke important modifieren.

Før:
```jsx
<Button className="!absolute top-0 left-0" />
```

Etter:
```jsx
<Button className="absolute top-0 left-0" />
```