### PR TITLE
include typescript for stories and remove their type declarations

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "pnpm run build:lib && pnpm run build:types",
     "build:lib": "vite build",
-    "build:types": "tsc --emitDeclarationOnly --declaration",
+    "build:types": "tsc --emitDeclarationOnly --declaration && rimraf 'dist/**/stories/'",
     "dev": "start-storybook -p 6006 --ci",
     "build:storybook": "build-storybook"
   },
@@ -39,6 +39,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "require-from-string": "2.0.2",
+    "rimraf": "3.0.2",
     "tailwindcss": "3.1.8",
     "vite": "2.9.15",
     "webpack": "5.74.0"
@@ -48,8 +49,8 @@
     "clsx": "1.2.1"
   },
   "peerDependencies": {
-    "react": "^18",
-    "@obosbbl/grunnmuren-tailwind": "workspace:^0.5.0"
+    "@obosbbl/grunnmuren-tailwind": "workspace:^0.5.0",
+    "react": "^18"
   },
   "peerDependenciesMeta": {
     "@obosbbl/grunnmuren-tailwind": {

--- a/packages/react/src/Card/stories/Card.stories.tsx
+++ b/packages/react/src/Card/stories/Card.stories.tsx
@@ -1,4 +1,5 @@
 import {
+  CardProps,
   Card,
   CardContent,
   CardImage,
@@ -17,7 +18,7 @@ export default {
   },
 };
 
-export const Default = (props: unknown) => {
+export const Default = (props: CardProps<'div'>) => {
   return (
     <Card {...props}>
       <CardContent>
@@ -33,7 +34,7 @@ Default.args = {
   bgColor: 'white',
 };
 
-export const Link = (props: unknown) => {
+export const Link = (props: CardProps<'div'>) => {
   return (
     <Card {...props}>
       <CardContent>

--- a/packages/react/src/Hero/stories/Hero.stories.tsx
+++ b/packages/react/src/Hero/stories/Hero.stories.tsx
@@ -1,4 +1,11 @@
-import { Button, Hero, HeroContent, HeroImage, HeroActions } from '../../';
+import {
+  Button,
+  Hero,
+  HeroProps,
+  HeroContent,
+  HeroImage,
+  HeroActions,
+} from '../../';
 
 const metadata = {
   title: 'Hero',
@@ -36,7 +43,7 @@ const image = {
   alt: 'To personer finner svar på spørsmål via kundeservicesidene',
 };
 
-export function WithImage(props: unknown) {
+export function WithImage(props: HeroProps) {
   const heroImage = <HeroImage {...image} />;
 
   return (
@@ -56,7 +63,7 @@ WithImage.args = {
   bgColor: 'white',
 };
 
-export function WithoutImage(props: unknown) {
+export function WithoutImage(props: HeroProps) {
   return (
     <Hero {...props}>
       <HeroContent heading={heading} description={description}>

--- a/packages/react/src/Input/stories/Input.stories.tsx
+++ b/packages/react/src/Input/stories/Input.stories.tsx
@@ -34,7 +34,8 @@ export const Default = () => {
   );
 };
 
-const Div = ({ label, children }) => {
+const Div = (props: { label: string; children: React.ReactElement }) => {
+  const { label, children } = props;
   const id = useId();
   return (
     <div>

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
-  "exclude": ["**/stories/*", "**/__tests__/*"]
+  "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0
       require-from-string: 2.0.2
+      rimraf: 3.0.2
       tailwindcss: 3.1.8
       vite: 2.9.15
       webpack: 5.74.0
@@ -95,6 +96,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       require-from-string: 2.0.2
+      rimraf: 3.0.2
       tailwindcss: 3.1.8
       vite: 2.9.15
       webpack: 5.74.0
@@ -5428,7 +5430,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
 
   /concat-stream/1.6.2:


### PR DESCRIPTION
Improves editor experience by no longer excluding Storybook stories in the tsconfig. This has the additional benefit that TS errors in the stories also breaks CI.

However, that meant that the TS type declaration script generates typings for all the story files, which we don't want, so we remove them again using rimraf.