### PR TITLE
feat: add loading modifier to Button component

### DIFF
--- a/.changeset/nasty-cars-run.md
+++ b/.changeset/nasty-cars-run.md
@@ -1,0 +1,6 @@
+---
+"@obosbbl/grunnmuren-react": minor
+"@obosbbl/grunnmuren-tailwind": minor
+---
+
+add `loading` modifier to Button component

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, Ref, useContext } from 'react';
+import React, {
+  isValidElement,
+  Children,
+  forwardRef,
+  Ref,
+  useContext,
+  cloneElement,
+} from 'react';
 import classNames from 'clsx';
 import { ButtonColorContext } from '.';
 
@@ -10,6 +17,8 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   color?: 'standard' | 'white' | 'light-green';
   disabled?: boolean;
   href?: string;
+  /** Renders the button in a loading state */
+  loading?: boolean;
   /** @default button */
   type?: 'button' | 'submit' | 'reset';
   /** @default primary */
@@ -30,9 +39,11 @@ export const Button = forwardRef<
   ButtonProps
 >((props, ref) => {
   const {
+    children: childrenFromProp,
     className,
     color: colorFromProp,
     href,
+    loading,
     type = 'button',
     variant = 'primary',
     ...rest
@@ -46,23 +57,103 @@ export const Button = forwardRef<
 
   const classes = classNames(className, buttonVariation, 'button');
 
+  const children = loading ? (
+    <Loader>{childrenFromProp}</Loader>
+  ) : (
+    childrenFromProp
+  );
+
   return (
     <>
       {href /* @ts-expect-error Find a solutions later but not necessary now */ ? (
         <a
+          aria-busy={loading ? true : undefined}
           {...rest}
           href={href}
           ref={ref as Ref<HTMLAnchorElement>}
           className={classes}
-        />
+        >
+          {children}
+        </a>
       ) : (
         <button
+          aria-busy={loading ? true : undefined}
           {...rest}
           type={type}
           ref={ref as Ref<HTMLButtonElement>}
           className={classes}
-        />
+        >
+          {children}
+        </button>
       )}
     </>
   );
 });
+
+/**
+ * Creates a loading indicator overlay in the button. This is really hackish so an explainer is necessary.
+ *
+ * We don't want the button size to change when we're showing the loading indicator, so we must still "render"
+ * the regular content, even though we don't want it to be visible. Some of the button variations have transparent
+ * backgrounds, so we can't just set a bg color for the loading overlay either...
+ *
+ * As a workaround, we hide all the button's children (except the loader) using visibility: hidden, so it
+ * still takes space in the dom, and is accessible for screen readers.
+ *
+ * Children are deeply traversed to ensure that text nodes have a wrapper that can be targed by the visibility hidden rule
+ *
+ *
+ */
+const Loader = (props: { children: React.ReactNode }) => {
+  return (
+    <>
+      {deeplyWrapStrings(props.children)}
+      <span
+        // Notice the important modifier to visible here: we want it to escape the visibility hidden applied to the buttons children
+        className="!visible absolute top-1 bottom-1 left-1 right-1 grid place-items-center overflow-hidden bg-inherit"
+        aria-hidden
+      >
+        <LoadingIcon className="animate-spin" />
+      </span>
+    </>
+  );
+};
+
+// TODO: Load from icon lib when the icon is exported properly from Figma
+const LoadingIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="1.25em"
+    height="1.25em"
+    fill="none"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth={4}
+      d="M22 12C22 10.2897 21.5613 8.60798 20.726 7.11558C19.8906 5.62318 18.6864 4.36998 17.2285 3.47575C15.7706 2.58152 14.1077 2.07615 12.3988 2.00795C10.6898 1.93975 8.99195 2.311 7.46743 3.0862C5.9429 3.86141 4.64268 5.01466 3.69102 6.43575C2.73937 7.85683 2.1681 9.49824 2.0318 11.2031C1.89551 12.908 2.19875 14.6193 2.91255 16.1735C3.62634 17.7277 4.72684 19.0729 6.10884 20.0805"
+    />
+    <circle cx={21} cy={18} r={2} fill="currentColor" />
+  </svg>
+);
+
+/**
+ * Recurse children to wrap strings with spans so they're targeted by the visibility hidden rule
+ */
+function deeplyWrapStrings(children: React.ReactNode): React.ReactNode {
+  return Children.map(children, (child) => {
+    if (!isValidElement(child)) {
+      return typeof child === 'string' ? <span>{child}</span> : child;
+    }
+
+    if (child.props.children) {
+      const props = {
+        children: deeplyWrapStrings(child.props.children),
+      };
+      child = cloneElement(child, props);
+    }
+
+    return child;
+  });
+}

--- a/packages/react/src/Button/stories/Button.stories.tsx
+++ b/packages/react/src/Button/stories/Button.stories.tsx
@@ -21,6 +21,11 @@ export default {
     },
     disabled: {
       control: 'boolean',
+      defaultValue: false,
+    },
+    loading: {
+      control: 'boolean',
+      defaultValue: false,
     },
   },
 };
@@ -28,8 +33,9 @@ export default {
 export const Default = (props: {
   composition: CompositionValue;
   disabled: boolean;
+  loading: boolean;
 }) => {
-  const { composition, disabled } = props;
+  const { composition, disabled, loading } = props;
 
   // Helper component that allows us to change the contentof the button when toggling the composition control in Storybook
   const ButtonContent = ({ children }: { children: React.ReactNode }) => {
@@ -68,16 +74,20 @@ export const Default = (props: {
 
   return (
     <>
-      <ButtonsDisplayer buttonProps={{ disabled }}>{buttons}</ButtonsDisplayer>
+      <ButtonsDisplayer buttonProps={{ disabled, loading }}>
+        {buttons}
+      </ButtonsDisplayer>
 
       <div className="bg-green-dark py-4">
-        <ButtonsDisplayer buttonProps={{ color: 'light-green', disabled }}>
+        <ButtonsDisplayer
+          buttonProps={{ color: 'light-green', disabled, loading }}
+        >
           {buttons}
         </ButtonsDisplayer>
       </div>
 
       <div className="bg-blue py-4">
-        <ButtonsDisplayer buttonProps={{ color: 'white', disabled }}>
+        <ButtonsDisplayer buttonProps={{ color: 'white', disabled, loading }}>
           {buttons}
         </ButtonsDisplayer>
       </div>

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -48,6 +48,8 @@ const obosFonts = [
 ];
 
 const button = plugin(function ({ addComponents, theme }) {
+  const hoverLoadingBgColor = 'rgba(0, 0, 0, 0.1)';
+
   addComponents({
     '.button': {
       // The Tailwind utilities we use for focus styling are kinda hard to "translate", so using the @apply utility here, even though mixing styles are meh...
@@ -88,8 +90,15 @@ const button = plugin(function ({ addComponents, theme }) {
       // ideally this would be solved by just darkening the button background,
       // but that doesn't really work since some of the button variations have transparent backgrounds
       '&:hover::after': {
-        backgroundColor: 'rgba(0, 0, 0, 0.1)',
+        backgroundColor: hoverLoadingBgColor,
         transition: `all 200ms ${theme('transitionTimingFunction.DEFAULT')}`,
+      },
+      // We use aria-busy to indicate loading state
+      '&[aria-busy="true"] > *': {
+        visibility: 'hidden',
+      },
+      '&[aria-busy="true"]::after': {
+        backgroundColor: hoverLoadingBgColor,
       },
     },
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       require-from-string: 2.0.2
       rimraf: 3.0.2
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.16
       vite: 2.9.15
       webpack: 5.74.0
 
@@ -4992,7 +4992,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -9885,6 +9885,18 @@ packages:
       read-cache: 1.0.0
       resolve: 1.22.1
 
+  /postcss-import/14.1.0_postcss@8.4.16:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.16
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: true
+
   /postcss-js/4.0.0_postcss@8.4.14:
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
     engines: {node: ^12 || ^14 || >= 16}
@@ -9893,6 +9905,16 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.14
+
+  /postcss-js/4.0.0_postcss@8.4.16:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.16
+    dev: true
 
   /postcss-load-config/3.1.4_postcss@8.4.14:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -9909,6 +9931,23 @@ packages:
       lilconfig: 2.0.6
       postcss: 8.4.14
       yaml: 1.10.2
+
+  /postcss-load-config/3.1.4_postcss@8.4.16:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      postcss: 8.4.16
+      yaml: 1.10.2
+    dev: true
 
   /postcss-loader/4.3.0_gzaxsinx64nntyd3vmdqwl7coe:
     resolution: {integrity: sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==}
@@ -10023,6 +10062,16 @@ packages:
     dependencies:
       postcss: 8.4.14
       postcss-selector-parser: 6.0.10
+
+  /postcss-nested/5.0.6_postcss@8.4.16:
+    resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss: 8.4.16
+      postcss-selector-parser: 6.0.10
+    dev: true
 
   /postcss-selector-parser/6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -10141,17 +10190,6 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
-    dev: true
-
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
     dev: true
 
   /promise.allsettled/1.0.5:
@@ -11547,6 +11585,39 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
+  /tailwindcss/3.1.8_postcss@8.4.16:
+    resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.11
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.16
+      postcss-import: 14.1.0_postcss@8.4.16
+      postcss-js: 4.0.0_postcss@8.4.16
+      postcss-load-config: 3.1.4_postcss@8.4.16
+      postcss-nested: 5.0.6_postcss@8.4.16
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
+
   /tapable/1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
     engines: {node: '>=6'}
@@ -11953,6 +12024,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5


### PR DESCRIPTION
Denne PRen legger til en `loading` prop på Button komponenten.

https://user-images.githubusercontent.com/81577/185920449-2614ce64-068e-4e8e-a731-29e166d1991d.mp4

For å indikere loading state til skjermlesere har jeg brukt `aria-busy`, da ser at Entur har løst det på den måten: https://design.entur.org/komponenter/knapper/button

 
Dessverre er resten av implementasjonen litt meh... Vi vil ikke at knappen skal endre størrelse når man hopper mellom loading state og ikke, så knappens innhold må alltid "rendres". Dette er også mest skjermleservennlig.

Problemet er at noen av knappene har transparante bakgrunner. Det betyr at loading overlayet også må være transparent,  og da vil det i enkelte tilfeller være slik at man ikke kan skjule knappens innhold bak loading overlayet:

<img width="154" alt="Screenshot 2022-08-22 at 14 32 35" src="https://user-images.githubusercontent.com/81577/185922354-5eb89935-e0ba-4152-9662-c76d9d9a80e2.png">

For å fikse det, bruker vi `visibility: hidden` på knappens direkte barn. Problemet er bare at en slik CSS selector ikke påvirker tekstnoder, så hacken her er å rekursere barn for å passe på at tekstnoder har et wrapping element.




