### PR TITLE
Accordion: add `overflow-hidden` for the rounded corners to work

### DIFF
--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -60,7 +60,7 @@ export const AccordionItem = (props: AccordionItemProps) => {
       <div
         className={cx(
           className,
-          'border-b-gray-concrete rounded-sm border-b-2 border-l-4 border-solid',
+          'border-b-gray-concrete overflow-hidden rounded-sm border-b-2 border-l-4 border-solid',
           collapseContext.isExpanded ? 'border-l-green-dark' : 'border-l-green',
         )}
         {...rest}


### PR DESCRIPTION
without this property, the right side of the accordion header isn't rounded:
<img width="64" alt="Screenshot 2022-09-22 at 11 59 07" src="https://user-images.githubusercontent.com/81577/191718394-ded11d39-b05f-4b10-9f1a-a64aed433cca.png">
