### PR TITLE
Hero image changes

### DIFF
--- a/.changeset/tough-humans-smoke.md
+++ b/.changeset/tough-humans-smoke.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+remove rounded corners for hero images

--- a/packages/react/src/Hero/HeroContent.tsx
+++ b/packages/react/src/Hero/HeroContent.tsx
@@ -30,8 +30,8 @@ export const HeroContent = (props: HeroContentProps) => {
           'bg-blue-dark': bgColor === 'blue',
           'bg-white': bgColor === 'white',
           // vertical split
-          // vertically center the content, remove the border radius om the image side, left align the content
-          'md:-order-1 md:mt-0 md:justify-center md:rounded-r-none md:text-left':
+          // vertically center the content, remove the border radius on the edge, add some negative margin to pull the image beneath the hero content, left align the content
+          'md:z-10 md:-order-1 md:mt-0 md:-mr-5 md:justify-center md:rounded-l-none md:text-left':
             contentPosition === 'vertical-split',
           // below center/content header
           'justify-center md:mx-auto md:w-4/5':

--- a/packages/react/src/Hero/HeroContent.tsx
+++ b/packages/react/src/Hero/HeroContent.tsx
@@ -21,7 +21,7 @@ export const HeroContent = (props: HeroContentProps) => {
     <div
       className={cx(
         className,
-        '<md:mx-4 relative grid grid-flow-row grid-cols-[minmax(auto,_37rem)]  content-center gap-6 rounded-3xl py-10 px-6 text-center md:p-12',
+        '<md:mx-4 relative grid grid-flow-row grid-cols-[minmax(auto,_37rem)] content-center gap-6 rounded-3xl py-10 px-6 text-center md:p-12',
         {
           // On mobile we use negative margin on the content to pull the content up into the image
           '<md:-mt-18': hasImage,

--- a/packages/react/src/Hero/HeroImage.tsx
+++ b/packages/react/src/Hero/HeroImage.tsx
@@ -30,10 +30,7 @@ export const HeroImage = (props: HeroImageProps) => {
     >
       <source media="(min-width: 768px)" srcSet={props.mdSrc} />
       <img
-        className={cx(
-          'overflow-hidden rounded-t-3xl object-cover md:rounded-3xl',
-          { 'md:rounded-l-none': contentPosition === 'vertical-split' },
-        )}
+        className="object-cover"
         decoding="async"
         src={props.src}
         alt={props.alt}


### PR DESCRIPTION
Update the hero image after adjustments in Figma.

The images does no longer have round corners. Also updated the "vertical-split" layout to match Figma.