### PR TITLE
Changes: Input/Textfield/TextArea

### DIFF
--- a/.changeset/stupid-eagles-nail.md
+++ b/.changeset/stupid-eagles-nail.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+add prefix/suffix to input and update design

--- a/.changeset/stupid-eagles-nail.md
+++ b/.changeset/stupid-eagles-nail.md
@@ -2,4 +2,4 @@
 '@obosbbl/grunnmuren-react': minor
 ---
 
-add prefix/suffix to input and update design
+add leftAddon/rightAddon to input and update design

--- a/packages/react/src/Form/FormLabel.tsx
+++ b/packages/react/src/Form/FormLabel.tsx
@@ -17,10 +17,10 @@ export const FormLabel = (props: LabelProps) => {
       {isRequired && (
         <span
           aria-hidden
-          className={cx('mr-px select-none', {
-            'text-red': isInvalid,
-            'text-blue': !isInvalid,
-          })}
+          className={cx(
+            'mr-px select-none',
+            isInvalid ? 'text-red' : 'text-blue',
+          )}
         >
           *
         </span>

--- a/packages/react/src/Form/FormLabel.tsx
+++ b/packages/react/src/Form/FormLabel.tsx
@@ -17,12 +17,12 @@ export const FormLabel = (props: LabelProps) => {
       {isRequired && (
         <span
           aria-hidden
-          className={cx('ml-px select-none', {
+          className={cx('mr-px select-none', {
             'text-red': isInvalid,
             'text-blue': !isInvalid,
           })}
         >
-          *{' '}
+          *
         </span>
       )}
       {children}

--- a/packages/react/src/Form/FormLabel.tsx
+++ b/packages/react/src/Form/FormLabel.tsx
@@ -3,22 +3,29 @@ import { cx } from '@/utils';
 export interface LabelProps extends React.ComponentPropsWithoutRef<'label'> {
   children: React.ReactNode;
   isRequired?: boolean;
+  isInvalid?: boolean;
 }
 
 export const FormLabel = (props: LabelProps) => {
-  const { className, children, isRequired, ...rest } = props;
+  const { className, children, isRequired, isInvalid, ...rest } = props;
 
   return (
     <label
-      className={cx(className, 'block cursor-pointer font-medium')}
+      className={cx(className, 'block cursor-pointer font-semibold')}
       {...rest}
     >
-      {children}
       {isRequired && (
-        <span aria-hidden className="ml-px select-none">
-          *
+        <span
+          aria-hidden
+          className={cx('ml-px select-none', {
+            'text-red': isInvalid,
+            'text-blue': !isInvalid,
+          })}
+        >
+          *{' '}
         </span>
       )}
+      {children}
     </label>
   );
 };

--- a/packages/react/src/Hero/HeroImage.tsx
+++ b/packages/react/src/Hero/HeroImage.tsx
@@ -30,7 +30,9 @@ export const HeroImage = (props: HeroImageProps) => {
     >
       <source media="(min-width: 768px)" srcSet={props.mdSrc} />
       <img
-        className="object-cover"
+        className={cx('overflow-hidden object-cover', {
+          'md:rounded-l-none': contentPosition === 'vertical-split',
+        })}
         decoding="async"
         src={props.src}
         alt={props.alt}

--- a/packages/react/src/Hero/HeroImage.tsx
+++ b/packages/react/src/Hero/HeroImage.tsx
@@ -30,9 +30,7 @@ export const HeroImage = (props: HeroImageProps) => {
     >
       <source media="(min-width: 768px)" srcSet={props.mdSrc} />
       <img
-        className={cx('overflow-hidden object-cover', {
-          'md:rounded-l-none': contentPosition === 'vertical-split',
-        })}
+        className="object-cover"
         decoding="async"
         src={props.src}
         alt={props.alt}

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -4,7 +4,9 @@ import { cx } from '@/utils';
 export interface InputProps
   extends Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix'> {
   as?: string;
+  /** Prefix a React node (ex. icon, text, component) */
   prefix?: React.ReactNode;
+  /** Suffix a React node (ex. icon, text, component) */
   suffix?: React.ReactNode;
   /** Render input as invalid. Sets `aria-invalid` to true */
   isInvalid?: boolean;

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -4,7 +4,8 @@ import { cx } from '@/utils';
 export interface InputProps
   extends Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix'> {
   as?: string;
-  prefix: React.ReactNode;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
   /** Render input as invalid. Sets `aria-invalid` to true */
   isInvalid?: boolean;
 
@@ -18,6 +19,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     isInvalid,
     size,
     prefix,
+    suffix,
     as,
     type: typeProp,
     ...rest
@@ -40,7 +42,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         },
       )}
     >
-      {prefix && <span className="text-gray pl-4">{prefix}</span>}
+      {prefix}
+
       <Component
         aria-invalid={isInvalid}
         // @ts-expect-error figure out how to get ref working with an `as` prop
@@ -50,7 +53,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         type={type}
         {...rest}
       />
-      {/* {valid && <Icon className="text-green absolute right-1" name="check" />} */}
+
+      {suffix}
     </div>
   );
 });

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -35,7 +35,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         className,
         'relative flex items-center rounded-md border-[1px] border-b-[3px] focus-within:-ml-[2px] focus-within:-mt-[2px] focus-within:border-[3px] focus-within:shadow',
         {
-          'focus-within:border-blue border-black': !isInvalid,
+          'focus-within:border-blue-dark border-black': !isInvalid,
           'border-red focus-within:border-red': isInvalid,
           'w-fit': size != null,
           'w-full': size == null,

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -1,9 +1,10 @@
 import { forwardRef } from 'react';
 import { cx } from '@/utils';
 
-export interface InputProps extends React.ComponentPropsWithoutRef<'input'> {
+export interface InputProps
+  extends Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix'> {
   as?: string;
-  prefix?: string;
+  prefix: React.ReactNode;
   /** Render input as invalid. Sets `aria-invalid` to true */
   isInvalid?: boolean;
 
@@ -32,7 +33,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         className,
         'relative flex items-center rounded-md border-[1px] border-b-[3px] focus-within:-ml-[2px] focus-within:-mt-[2px] focus-within:border-[3px] focus-within:shadow',
         {
-          'border-gray-dark focus-within:border-blue': !isInvalid,
+          'focus-within:border-blue border-black': !isInvalid,
           'border-red focus-within:border-red': isInvalid,
           'w-fit': size != null,
           'w-full': size == null,
@@ -44,7 +45,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         aria-invalid={isInvalid}
         // @ts-expect-error figure out how to get ref working with an `as` prop
         ref={ref}
-        className="focus:none placeholder-gray w-full rounded-md border-none px-4 py-3 outline-none"
+        className="focus:none placeholder-gray w-full rounded-md border-none px-4 py-3.5 outline-none"
         size={size}
         type={type}
         {...rest}

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -1,13 +1,12 @@
 import { forwardRef } from 'react';
 import { cx } from '@/utils';
 
-export interface InputProps
-  extends Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix'> {
+export interface InputProps extends React.ComponentPropsWithoutRef<'input'> {
   as?: string;
-  /** Prefix a React node (ex. icon, text, component) */
-  prefix?: React.ReactNode;
-  /** Suffix a React node (ex. icon, text, component) */
-  suffix?: React.ReactNode;
+  /** React node on the left (ex. icon, text, component) */
+  leftAddon?: React.ReactNode;
+  /** React node on the left (ex. icon, text, component) */
+  rightAddon?: React.ReactNode;
   /** Render input as invalid. Sets `aria-invalid` to true */
   isInvalid?: boolean;
 
@@ -20,10 +19,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     className,
     isInvalid,
     size,
-    prefix,
-    suffix,
     as,
     type: typeProp,
+    rightAddon,
+    leftAddon,
     ...rest
   } = props;
 
@@ -41,22 +40,24 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
           'border-red focus-within:border-red': isInvalid,
           'w-fit': size != null,
           'w-full': size == null,
+          'pl-4': leftAddon,
+          'pr-4': rightAddon,
         },
       )}
     >
-      {prefix}
+      {leftAddon}
 
       <Component
         aria-invalid={isInvalid}
         // @ts-expect-error figure out how to get ref working with an `as` prop
         ref={ref}
-        className="focus:none placeholder-gray w-full rounded-md border-none px-4 py-3.5 outline-none"
+        className="focus:none placeholder-gray w-full rounded-md border-none px-4 py-3.5 focus:outline-none"
         size={size}
         type={type}
         {...rest}
       />
 
-      {suffix}
+      {rightAddon}
     </div>
   );
 });

--- a/packages/react/src/Input/stories/Input.stories.tsx
+++ b/packages/react/src/Input/stories/Input.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useId } from 'react';
 import { Input, FormLabel } from '../..';
+import { Search } from '@obosbbl/grunnmuren-icons';
 
 const metadata = { title: 'Input', parameters: { layout: 'padded' } };
 export default metadata;
@@ -19,8 +20,20 @@ export const Default = () => {
         <Input prefix="kr" />
       </Div>
 
+      <Div label="Prefix icon">
+        <Input prefix={<Search className="text-green" />} />
+      </Div>
+
       <Div label="Prefixed placeholder">
         <Input prefix="kr" placeholder="100 000" />
+      </Div>
+
+      <Div label="Suffix icon">
+        <Input suffix={<Search className="text-green" />} />
+      </Div>
+
+      <Div label="Suffix and prefix icon">
+        <Input suffix={<Search className="text-green" />} prefix={<Search />} />
       </Div>
 
       <Div label="Size: (10)">

--- a/packages/react/src/Input/stories/Input.stories.tsx
+++ b/packages/react/src/Input/stories/Input.stories.tsx
@@ -17,23 +17,26 @@ export const Default = () => {
       </Div>
 
       <Div label="Prefix">
-        <Input prefix="kr" />
+        <Input leftAddon="kr" />
       </Div>
 
       <Div label="Prefix icon">
-        <Input prefix={<Search className="text-green" />} />
+        <Input leftAddon={<Search className="text-green" />} />
       </Div>
 
       <Div label="Prefixed placeholder">
-        <Input prefix="kr" placeholder="100 000" />
+        <Input leftAddon="kr" placeholder="100 000" />
       </Div>
 
       <Div label="Suffix icon">
-        <Input suffix={<Search className="text-green" />} />
+        <Input rightAddon={<Search className="text-green" />} />
       </Div>
 
       <Div label="Suffix and prefix icon">
-        <Input suffix={<Search className="text-green" />} prefix={<Search />} />
+        <Input
+          rightAddon={<Search className="text-green" />}
+          leftAddon={<Search />}
+        />
       </Div>
 
       <Div label="Size: (10)">

--- a/packages/react/src/TextArea/TextArea.tsx
+++ b/packages/react/src/TextArea/TextArea.tsx
@@ -52,6 +52,10 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           {label}
         </FormLabel>
 
+        {description && (
+          <FormHelperText id={helpTextId}>{description}</FormHelperText>
+        )}
+
         <Input
           as="textarea"
           // @ts-expect-error fix this later
@@ -67,9 +71,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           })}
         />
 
-        {description && (
-          <FormHelperText id={helpTextId}>{description}</FormHelperText>
-        )}
         {errorMsg && (
           <FormErrorMessage id={errorMsgId}>{errorMsg}</FormErrorMessage>
         )}

--- a/packages/react/src/TextArea/TextArea.tsx
+++ b/packages/react/src/TextArea/TextArea.tsx
@@ -44,7 +44,11 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     return (
       <div className="grid gap-2">
-        <FormLabel htmlFor={id} isRequired={required}>
+        <FormLabel
+          htmlFor={id}
+          isRequired={required}
+          isInvalid={!!error || validity === 'invalid'}
+        >
           {label}
         </FormLabel>
 

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -5,7 +5,7 @@ import { Input, FormLabel, FormHelperText, FormErrorMessage } from '..';
 import { useFormControlValidity } from '../hooks';
 
 export interface TextFieldProps
-  extends Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix'> {
+  extends React.ComponentPropsWithoutRef<'input'> {
   children?: never;
   /** Help text for the form control */
   description?: string;
@@ -13,10 +13,10 @@ export interface TextFieldProps
   error?: string;
   /**  Label for the form control */
   label: string;
-  /** Prefix a React node (ex. icon, text, component) */
-  prefix?: React.ReactNode;
-  /** Suffix a React node (ex. icon, text, component) */
-  suffix?: React.ReactNode;
+  /** React node on the left (ex. icon, text, component) */
+  leftAddon?: React.ReactNode;
+  /** React node on the left (ex. icon, text, component) */
+  rightAddon?: React.ReactNode;
   /** Automatically valdiate the form control using the HTML constraint validation API. @default true */
   validate?: boolean;
 }

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -46,9 +46,17 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     return (
       <div className="grid gap-2">
-        <FormLabel htmlFor={id} isRequired={required}>
+        <FormLabel
+          htmlFor={id}
+          isRequired={required}
+          isInvalid={!!error || validity === 'invalid'}
+        >
           {label}
         </FormLabel>
+
+        {description && (
+          <FormHelperText id={helpTextId}>{description}</FormHelperText>
+        )}
 
         <Input
           id={id}
@@ -64,9 +72,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           })}
         />
 
-        {description && (
-          <FormHelperText id={helpTextId}>{description}</FormHelperText>
-        )}
         {errorMsg && (
           <FormErrorMessage id={errorMsgId}>{errorMsg}</FormErrorMessage>
         )}

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -13,7 +13,9 @@ export interface TextFieldProps
   error?: string;
   /**  Label for the form control */
   label: string;
+  /** Prefix a React node (ex. icon, text, component) */
   prefix?: React.ReactNode;
+  /** Suffix a React node (ex. icon, text, component) */
   suffix?: React.ReactNode;
   /** Automatically valdiate the form control using the HTML constraint validation API. @default true */
   validate?: boolean;

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -5,7 +5,7 @@ import { Input, FormLabel, FormHelperText, FormErrorMessage } from '..';
 import { useFormControlValidity } from '../hooks';
 
 export interface TextFieldProps
-  extends React.ComponentPropsWithoutRef<'input'> {
+  extends Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix'> {
   children?: never;
   /** Help text for the form control */
   description?: string;
@@ -13,7 +13,8 @@ export interface TextFieldProps
   error?: string;
   /**  Label for the form control */
   label: string;
-  prefix?: string;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
   /** Automatically valdiate the form control using the HTML constraint validation API. @default true */
   validate?: boolean;
 }


### PR DESCRIPTION
Changes done to Input, FormLabel, TextField and TextArea. 

Har testa endringene lokalt i medlemsteamet hvor vi legger til en country code select som prefix, og det funker fortsatt likt som tidligere

### Endringer

Input:
- Added suffix
- Added prefix
- dark blue color on focues border
- black border unfocused
- Small padding change to be more aligned with figma

Textfield: 
- Added prefix/suffix
- Send inValid prop to FormLabel
- Moved description between input and label

TextArea:
- Send inValid prop to FormLabel
- Moved description between input and label

Formlabel:
- Move required-char to front of label
- Change color on required-char if invalid or not
- semibold label