### PR TITLE
new layout components. moved curved corners to footer and navbar

### DIFF
--- a/.changeset/red-ladybugs-collect.md
+++ b/.changeset/red-ladybugs-collect.md
@@ -1,0 +1,6 @@
+---
+'@obosbbl/grunnmuren-react': minor
+'@obosbbl/grunnmuren-tailwind': minor
+---
+
+new layout classes to work with footer and navbar

--- a/packages/react/src/Footer/Footer.tsx
+++ b/packages/react/src/Footer/Footer.tsx
@@ -11,7 +11,13 @@ export const Footer = (props: FooterProps) => {
 
   return (
     <ButtonColorContext.Provider value="white">
-      <footer className={cx(className, 'bg-blue py-12 text-white')} {...rest}>
+      <footer
+        className={cx(
+          className,
+          'bg-blue pt-18 relative pb-12 text-white before:absolute before:top-0 before:left-0 before:right-0 before:h-6 before:rounded-b-3xl before:bg-white',
+        )}
+        {...rest}
+      >
         <div className="container">{children}</div>
       </footer>
     </ButtonColorContext.Provider>

--- a/packages/react/src/Hero/stories/Hero.stories.tsx
+++ b/packages/react/src/Hero/stories/Hero.stories.tsx
@@ -61,7 +61,7 @@ export function WithImage(props: HeroProps) {
 WithImage.args = {
   contentPosition: 'below-center',
   bgColor: 'white',
-};
+} as const;
 
 export function WithoutImage(props: HeroProps) {
   return (

--- a/packages/react/src/Navbar/Navbar.tsx
+++ b/packages/react/src/Navbar/Navbar.tsx
@@ -23,7 +23,10 @@ export const Navbar = (props: NavbarProps) => {
     <ButtonColorContext.Provider value="white">
       <NavbarContext.Provider value={expandedContext}>
         <div
-          className={cx(className, 'bg-blue py-6 text-white md:py-8')}
+          className={cx(
+            className,
+            'bg-blue relative pt-6 pb-12 text-white before:absolute before:bottom-0 before:left-0 before:right-0 before:h-6 before:rounded-t-3xl before:bg-white md:pt-8 md:pb-14',
+          )}
           {...rest}
         >
           <div className="container">{children}</div>

--- a/packages/react/src/PageLayout/stories/PageLayout.stories.tsx
+++ b/packages/react/src/PageLayout/stories/PageLayout.stories.tsx
@@ -1,0 +1,32 @@
+import { Default as Navbar } from '../../Navbar/stories/Navbar.stories';
+import { WithImage as Hero } from '../../Hero/stories/Hero.stories';
+import { Default as Footer } from '../../Footer/stories/Footer.stories';
+
+const metadata = {
+  title: 'Pagelayout',
+};
+export default metadata;
+
+export const Default = () => {
+  return (
+    <div className="page-layout">
+      <Navbar />
+      <main className="page-layout-main">
+        <div>
+          {/* @ts-expect-error we don't want to provide children as we reuse a story */}
+          <Hero {...Hero.args} />
+          <div className="prose container-prose">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -312,13 +312,22 @@ module.exports = (userOptions) => {
             zIndex: '100',
           },
           /**
-           * Round the corners of our main content.
-           * Protip: Use this together with navbar, footer and `bg-blue` class on the body.
+           * @deprecated use page-layout and page-layout-main instead
            */
           '.pagemain': {
             backgroundColor: '#fff',
             borderRadius: '1.5rem',
             overflow: 'hidden',
+          },
+
+          '.page-layout': {
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: '100vh',
+          },
+          '.page-layout-main': {
+            backgroundColor: '#fff',
+            flexGrow: '1',
           },
         });
         addUtilities({


### PR DESCRIPTION
Denne endringen fikser litt på hvordan vi bygger opp sidelayouten med footer og navbar. Tidligere måtte man passe på å bruke riktig utility klasser selv for å få til layouten vi ønsker.

Ny måte blir nå:

```jsx
<body class="page-layout">
  <Navbar />
  <main className="page-layout-main">
    <h1>Hello world</h1>
  <Footer />
</body>
```

Fant også ut at med litt triksing så kan man bygge inn de hvite kurvene rett i navbar og footer med pseudoelementer. Dette gjør at vi slipper å styre med border radius på main contentet, så bruke negative marginer til å pushe det innholdet inn i footer/navbar.