### PR TITLE
fix SSR warning for useMedia hook

### DIFF
--- a/packages/react/src/Navbar/NavbarExpandedMobileContent.tsx
+++ b/packages/react/src/Navbar/NavbarExpandedMobileContent.tsx
@@ -14,7 +14,7 @@ export const NavbarExpandedMobileContent = (
   props: NavbarExpandedMobileContentProps,
 ) => {
   const { isExpanded } = useContext(NavbarContext);
-  const isMobileScreen = useScreenMaxWidthMd();
+  const isMobileScreen = useScreenMaxWidthMd(false);
 
   if (!isExpanded || !isMobileScreen) return null;
 

--- a/packages/react/src/hooks/useScreenMaxWidthMd.ts
+++ b/packages/react/src/hooks/useScreenMaxWidthMd.ts
@@ -1,3 +1,4 @@
 import { useMedia } from '@/hooks';
 
-export const useScreenMaxWidthMd = () => useMedia('(max-width: 767.9px)');
+export const useScreenMaxWidthMd = (defaultState: boolean) =>
+  useMedia('(max-width: 767.9px)', defaultState);


### PR DESCRIPTION
`useMedia` from react-use requires a default state, otherwise it logs console messages during SSR