### PR TITLE
ensure StepListItem's bullet content is centered

### DIFF
--- a/.changeset/pink-items-leave.md
+++ b/.changeset/pink-items-leave.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+ensure the content of StepListItem's bullet is centered

--- a/packages/react/src/StepList/StepList.tsx
+++ b/packages/react/src/StepList/StepList.tsx
@@ -36,7 +36,7 @@ const StepListBullet = (props: StepListBulletProps) => {
     <span
       // By default we hide this from screen readers to prevent noise, as the steps are implemented using an ordered list
       aria-hidden
-      className="text-green border-gray-light after:bg-gray-light grid h-10 w-10 flex-none place-content-center rounded-full border-2 text-sm font-bold after:absolute after:left-5 after:top-10 after:bottom-0 after:w-0.5 group-last:after:hidden md:h-20 md:w-20 md:text-xl md:after:left-10 md:after:top-20"
+      className="text-green border-gray-light after:bg-gray-light grid h-10 w-10 flex-none place-content-center justify-items-center rounded-full border-2 text-sm font-bold after:absolute after:left-5 after:top-10 after:bottom-0 after:w-0.5 group-last:after:hidden md:h-20 md:w-20 md:text-xl md:after:left-10 md:after:top-20"
       {...props}
     />
   );


### PR DESCRIPTION
The content of the StepListItem's bullet point is supposed to be centered. If you rendered it with a custom image, that wasn't the case...

Before this change:

<img width="124" alt="Screenshot 2022-10-07 at 09 40 43" src="https://user-images.githubusercontent.com/81577/194499567-700c4ac9-8d9d-4adc-b1cf-a6c85c73c7e0.png">

After this change:
<img width="110" alt="Screenshot 2022-10-07 at 09 40 50" src="https://user-images.githubusercontent.com/81577/194499525-50ff5fca-53ac-4a8c-8f9e-d42716d7be2d.png">
