### PR TITLE
Better support for custom validation in `<TextField>` and `<TextArea>`

### DIFF
--- a/.changeset/tidy-rivers-fail.md
+++ b/.changeset/tidy-rivers-fail.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+support `aria-required` in `<TextField>` and `<TextArea>`

--- a/.changeset/tidy-rivers-fail.md
+++ b/.changeset/tidy-rivers-fail.md
@@ -2,4 +2,4 @@
 '@obosbbl/grunnmuren-react': minor
 ---
 
-Better support for custom validation. Added `disableValidation` in `<TextField>` and `<TextArea>`, and support `noValidate` on the form element.
+Better support for custom validation. Added `disableValidation` in `<TextField>`, `<TextArea>` and `<Checkbox>`, and support `noValidate` on the form element.

--- a/.changeset/tidy-rivers-fail.md
+++ b/.changeset/tidy-rivers-fail.md
@@ -1,5 +1,5 @@
 ---
-'@obosbbl/grunnmuren-react': patch
+'@obosbbl/grunnmuren-react': minor
 ---
 
-support `aria-required` in `<TextField>` and `<TextArea>`
+Better support for custom validation. Added `disableValidation` in `<TextField>` and `<TextArea>`, and support `noValidate` on the form element.

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
-import { forwardRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import { cx } from '@/utils';
-import { useFallbackId } from '@/hooks';
+import { useFallbackId, useFormControlValidity } from '@/hooks';
 
 import { FormErrorMessage } from '..';
 
@@ -13,14 +13,33 @@ export interface CheckboxProps extends React.ComponentPropsWithRef<'input'> {
   className?: string;
   /** Error message for the form control */
   error?: string;
+
+  /** Disables the built in HTML5 validation. If using custom validation for an entire form, consider setting `noValidate` on the form element instead. @default false */
+  disableValidation?: boolean;
 }
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => {
-    const { children, className, error, id: idProp, ...rest } = props;
+    const {
+      children,
+      className,
+      error,
+      id: idProp,
+      disableValidation = false,
+      ...rest
+    } = props;
+
+    const ownRef = useRef(null);
+
+    const { validity, validationMessage } = useFormControlValidity(
+      ownRef,
+      !disableValidation,
+    );
 
     const id = useFallbackId(idProp);
     const errorMsgId = id + 'err';
+
+    const errorMsg = error ?? validationMessage;
 
     return (
       <div className="grid gap-2">
@@ -42,12 +61,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             aria-describedby={cx({
               [errorMsgId]: !!error,
             })}
-            aria-invalid={!!error}
+            aria-invalid={!!error || validity === 'invalid'}
           />
           {children}
         </label>
-        {!!error && (
-          <FormErrorMessage id={errorMsgId}>{error}</FormErrorMessage>
+        {!!errorMsg && (
+          <FormErrorMessage id={errorMsgId}>{errorMsg}</FormErrorMessage>
         )}
       </div>
     );

--- a/packages/react/src/Checkbox/stories/Checkbox.stories.tsx
+++ b/packages/react/src/Checkbox/stories/Checkbox.stories.tsx
@@ -1,13 +1,30 @@
+import { useState } from 'react';
 import { Checkbox } from '../';
+import { Button } from '../..';
 
 const metadata = { title: 'Checkbox', parameters: { layout: 'padded' } };
 export default metadata;
 
 export const Default = () => {
+  const [error, setError] = useState<string>();
   return (
     <div className="flex flex-col gap-4">
       <Checkbox>Check me</Checkbox>
       <Checkbox error="Du må bekrefte for å fortsette">Check me</Checkbox>
+
+      <div>
+        <h2 className="h4">with form</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            setError('Du må bekrefte for å fortsette');
+          }}
+        >
+          <Checkbox error={error}>Check me</Checkbox>
+
+          <Button type="submit">Submit</Button>
+        </form>
+      </div>
     </div>
   );
 };

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -9,9 +9,6 @@ export interface InputProps extends React.ComponentPropsWithoutRef<'input'> {
   rightAddon?: React.ReactNode;
   /** Render input as invalid. Sets `aria-invalid` to true */
   isInvalid?: boolean;
-
-  /* TODO: implement validation */
-  // valid?: boolean;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {

--- a/packages/react/src/TextArea/TextArea.tsx
+++ b/packages/react/src/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useRef } from 'react';
-import { cx, composeRefs, getRequiredness } from '@/utils';
+import { cx, composeRefs } from '@/utils';
 import { useFallbackId } from '@/hooks';
 import { Input, FormLabel, FormHelperText, FormErrorMessage } from '..';
 import { useFormControlValidity } from '../hooks';
@@ -13,8 +13,10 @@ export interface TextAreaProps
   error?: string;
   /**  Label for the form control */
   label: string;
-  /** Automatically valdiate the form control using the HTML constraint validation API. @default true */
-  validate?: boolean;
+  /** @deprecated. use `disableValidation` instead */
+  validate?: never;
+  /** Disables the built in HTML5 validation. If using custom validation for an entire form, consider setting `noValidate` on the form element instead. @default false */
+  disableValidation?: boolean;
 }
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
@@ -24,7 +26,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       error,
       id: idProp,
       label,
-      validate = true,
+      disableValidation = false,
       ...rest
     } = props;
 
@@ -32,7 +34,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     const { validity, validationMessage } = useFormControlValidity(
       ownRef,
-      validate,
+      !disableValidation,
     );
 
     const id = useFallbackId(idProp);
@@ -41,13 +43,11 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     const errorMsg = error ?? validationMessage;
 
-    const isRequired = getRequiredness(props.required, props['aria-required']);
-
     return (
       <div className="grid gap-2">
         <FormLabel
           htmlFor={id}
-          isRequired={isRequired}
+          isRequired={props.required}
           isInvalid={!!error || validity === 'invalid'}
         >
           {label}

--- a/packages/react/src/TextArea/TextArea.tsx
+++ b/packages/react/src/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useRef } from 'react';
-import { cx, composeRefs } from '@/utils';
+import { cx, composeRefs, getRequiredness } from '@/utils';
 import { useFallbackId } from '@/hooks';
 import { Input, FormLabel, FormHelperText, FormErrorMessage } from '..';
 import { useFormControlValidity } from '../hooks';
@@ -24,7 +24,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       error,
       id: idProp,
       label,
-      required,
       validate = true,
       ...rest
     } = props;
@@ -42,11 +41,13 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     const errorMsg = error ?? validationMessage;
 
+    const isRequired = getRequiredness(props.required, props['aria-required']);
+
     return (
       <div className="grid gap-2">
         <FormLabel
           htmlFor={id}
-          isRequired={required}
+          isRequired={isRequired}
           isInvalid={!!error || validity === 'invalid'}
         >
           {label}
@@ -61,7 +62,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           // @ts-expect-error fix this later
           ref={composeRefs(ownRef, ref)}
           id={id}
-          required={required}
           {...rest}
           // for accessibility reasons these cannot be overriden
           isInvalid={!!error || validity === 'invalid'}

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useRef } from 'react';
-import { cx, composeRefs } from '@/utils';
+import { cx, composeRefs, getRequiredness } from '@/utils';
 import { useFallbackId } from '@/hooks';
 import { Input, FormLabel, FormHelperText, FormErrorMessage } from '..';
 import { useFormControlValidity } from '../hooks';
@@ -28,7 +28,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       error,
       id: idProp,
       label,
-      required,
       type = 'text',
       validate = true,
       ...rest
@@ -47,11 +46,13 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     const errorMsg = error ?? validationMessage;
 
+    const isRequired = getRequiredness(props.required, props['aria-required']);
+
     return (
       <div className="grid gap-2">
         <FormLabel
           htmlFor={id}
-          isRequired={required}
+          isRequired={isRequired}
           isInvalid={!!error || validity === 'invalid'}
         >
           {label}
@@ -63,7 +64,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
         <Input
           id={id}
-          required={required}
           ref={composeRefs(ownRef, ref)}
           type={type}
           {...rest}

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useRef } from 'react';
-import { cx, composeRefs, getRequiredness } from '@/utils';
+import { cx, composeRefs } from '@/utils';
 import { useFallbackId } from '@/hooks';
 import { Input, FormLabel, FormHelperText, FormErrorMessage } from '..';
 import { useFormControlValidity } from '../hooks';
@@ -17,8 +17,10 @@ export interface TextFieldProps
   leftAddon?: React.ReactNode;
   /** React node on the left (ex. icon, text, component) */
   rightAddon?: React.ReactNode;
-  /** Automatically valdiate the form control using the HTML constraint validation API. @default true */
-  validate?: boolean;
+  /** @deprecated. use `disableValidation` instead */
+  validate?: never;
+  /** Disables the built in HTML5 validation. If using custom validation for an entire form, consider setting `noValidate` on the form element instead. @default false */
+  disableValidation?: boolean;
 }
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
@@ -29,7 +31,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       id: idProp,
       label,
       type = 'text',
-      validate = true,
+      disableValidation = false,
       ...rest
     } = props;
 
@@ -37,7 +39,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     const { validity, validationMessage } = useFormControlValidity(
       ownRef,
-      validate,
+      !disableValidation,
     );
 
     const id = useFallbackId(idProp);
@@ -46,13 +48,11 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     const errorMsg = error ?? validationMessage;
 
-    const isRequired = getRequiredness(props.required, props['aria-required']);
-
     return (
       <div className="grid gap-2">
         <FormLabel
           htmlFor={id}
-          isRequired={isRequired}
+          isRequired={props.required}
           isInvalid={!!error || validity === 'invalid'}
         >
           {label}

--- a/packages/react/src/TextField/stories/TextField.stories.tsx
+++ b/packages/react/src/TextField/stories/TextField.stories.tsx
@@ -26,3 +26,20 @@ export const Default = () => {
     </div>
   );
 };
+
+export const Validation = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <TextField label="Native validation enabled" required />
+      <TextField
+        label="Native validation disabled"
+        required
+        disableValidation
+      />
+
+      <form onSubmit={(evt) => evt.preventDefault()} noValidate>
+        <TextField label="noValidate attribute on the form element" required />
+      </form>
+    </div>
+  );
+};

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,17 +1,4 @@
-import { type AriaAttributes } from 'react';
-
 export { default as cx } from 'clsx';
 export { default as composeRefs } from '@seznam/compose-react-refs';
 
 export const noop = () => {};
-
-/**
- * There are two attributes in HTML that determines if the field is required.
- * This checks if either is set.
- */
-export function getRequiredness(
-  required: boolean | undefined,
-  ariaRequired: AriaAttributes['aria-required'],
-): boolean {
-  return required || ariaRequired === true || ariaRequired === 'true';
-}

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,4 +1,17 @@
+import { type AriaAttributes } from 'react';
+
 export { default as cx } from 'clsx';
 export { default as composeRefs } from '@seznam/compose-react-refs';
 
 export const noop = () => {};
+
+/**
+ * There are two attributes in HTML that determines if the field is required.
+ * This checks if either is set.
+ */
+export function getRequiredness(
+  required: boolean | undefined,
+  ariaRequired: AriaAttributes['aria-required'],
+): boolean {
+  return required || ariaRequired === true || ariaRequired === 'true';
+}


### PR DESCRIPTION
~~Endringen her gjør at label for TextField og TextArea komponentene viser "Påkrevd asterix" uansett om påkrevdhet er satt via `required` eller `aria-required`. Intensjonen er å enkleregjøre custom validering av påkrevde felter.~~

~~Usikker på om dette er beste måten å løse det på... Andre mulige alternativer som muligens kan oppnå det samme.~~

* ~~Benytte [`novalidate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-novalidate) på formet.~~
* ~~I stedet for at komponenten støtter både required og aria-required slår vi den sammen til en prop `isRequired?: boolean | 'sr-only';`.. Kanskje noe for v2 uansett?~~
* ~~At komponenten automatisk overfører `required` til `aria-required` når du setter `validate={false}` på komponenten.~~

Stryk forrige. Har tenkt litt mer på det, og man burde ikke sette aria-required for å komme seg rundt "requiredness" med custom validering. 

I et vanlig skjema ville du sannsynligvis brukt `<form noValidate />` dersom du kun vil ha custom validering i stedet for browseren sin native. Har nå lagt inn støtte for at TextField og TextArea støtter det. I tillegg kan du sette `disableValidation` på feltene dersom du har lyst til å skru det av per felt, eller ikke rendrer feltet ditt i et skjema.

Er dette en bedre approach synes dere? Og burde kanskje propnavnet være enda tydligere? Eg `disableNativeValidation`





