### PR TITLE
use OBOS colors for blockquotes in prose class

### DIFF
--- a/.changeset/late-experts-begin.md
+++ b/.changeset/late-experts-begin.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-tailwind': patch
+---
+
+OBOS theme for blockquotes in prose class

--- a/packages/react/src/__stories__/Typography.stories.tsx
+++ b/packages/react/src/__stories__/Typography.stories.tsx
@@ -42,6 +42,9 @@ export const Prose = () => {
         <li>List 2</li>
         <li>List 3</li>
       </ul>
+      <blockquote>
+        <p>Quote. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </blockquote>
     </div>
   );
 };

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -439,6 +439,8 @@ module.exports = (userOptions) => {
             css: {
               '--tw-prose-headings': theme('colors.black'),
               '--tw-prose-lead': theme('colors.black'),
+              '--tw-prose-quotes': theme('colors.blue.dark'),
+              '--tw-prose-quote-borders': theme('colors.green.DEFAULT'),
               // TODO: Increase bullet size. See design sketches
               '--tw-prose-bullets': theme('colors.green.DEFAULT'),
               color: theme('colors.black'),
@@ -461,6 +463,16 @@ module.exports = (userOptions) => {
               li: {
                 marginTop: '1.5em',
                 marginBottom: '1.5em',
+              },
+              blockquote: {
+                fontWeight: '700',
+                fontStyle: 'normal',
+              },
+              'blockquote p:first-of-type::before': {
+                content: '"«"',
+              },
+              'blockquote p:last-of-type::after': {
+                content: '"»"',
               },
               '[class~="lead"]': {
                 fontWeight: 500,


### PR DESCRIPTION
Hadde denne liggende i en branch fra da jeg implementere QuoteBlock i appen. Kan like gjerne få den inn her.

Merk at denne kanskje ikke følger DS helt, da quotes der er mer ment som en CMS-blokk, ikke som en del av tekst som brukt her.

Før:

<img width="499" alt="Screenshot 2022-10-17 at 08 31 32" src="https://user-images.githubusercontent.com/81577/196104896-f42be3c4-fa05-433f-8671-8f3b1e1fe0ce.png">

Etter:
<img width="535" alt="Screenshot 2022-10-17 at 08 30 51" src="https://user-images.githubusercontent.com/81577/196104948-01e6f5f0-ad2c-4730-9865-66477b34e814.png">
