### PR TITLE
fix: aria-describedby was always set for form components

### DIFF
--- a/.changeset/fair-beds-push.md
+++ b/.changeset/fair-beds-push.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+fix accessibility issue for form components

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -39,7 +39,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const id = useFallbackId(idProp);
     const errorMsgId = id + 'err';
 
-    const errorMsg = error ?? validationMessage;
+    const errorMsg = error || validationMessage;
 
     return (
       <div className="grid gap-2">
@@ -58,14 +58,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             ref={ref}
             type="checkbox"
             {...rest}
-            aria-describedby={cx({
-              [errorMsgId]: !!error,
-            })}
+            aria-describedby={errorMsg ? errorMsgId : undefined}
             aria-invalid={!!error || validity === 'invalid'}
           />
           {children}
         </label>
-        {!!errorMsg && (
+        {errorMsg && (
           <FormErrorMessage id={errorMsgId}>{errorMsg}</FormErrorMessage>
         )}
       </div>

--- a/packages/react/src/TextArea/TextArea.tsx
+++ b/packages/react/src/TextArea/TextArea.tsx
@@ -41,7 +41,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const helpTextId = id + 'help';
     const errorMsgId = id + 'err';
 
-    const errorMsg = error ?? validationMessage;
+    const errorMsg = error || validationMessage;
 
     return (
       <div className="grid gap-2">
@@ -65,10 +65,12 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           {...rest}
           // for accessibility reasons these cannot be overriden
           isInvalid={!!error || validity === 'invalid'}
-          aria-describedby={cx({
-            [errorMsgId]: !!error,
-            [helpTextId]: description,
-          })}
+          aria-describedby={
+            cx({
+              [errorMsgId]: errorMsg,
+              [helpTextId]: description,
+            }) || undefined
+          }
         />
 
         {errorMsg && (

--- a/packages/react/src/TextField/TextField.tsx
+++ b/packages/react/src/TextField/TextField.tsx
@@ -46,7 +46,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     const helpTextId = id + 'help';
     const errorMsgId = id + 'err';
 
-    const errorMsg = error ?? validationMessage;
+    const errorMsg = error || validationMessage;
 
     return (
       <div className="grid gap-2">
@@ -69,10 +69,12 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           {...rest}
           // for accessibility reasons these cannot be overriden
           isInvalid={!!error || validity === 'invalid'}
-          aria-describedby={cx({
-            [errorMsgId]: !!error,
-            [helpTextId]: description,
-          })}
+          aria-describedby={
+            cx({
+              [errorMsgId]: errorMsg,
+              [helpTextId]: description,
+            }) || undefined
+          }
         />
 
         {errorMsg && (


### PR DESCRIPTION
even if the form control didn't have an error or description associated with it, the resulting HTML was `aria-describedby=""`, which breaks accessibility.

Side note: we should really look into extracting some of the common stuff to helper instead of repeating for each form control type -.-