### PR TITLE
set light gray as the default border color

### DIFF
--- a/.changeset/twelve-zebras-relate.md
+++ b/.changeset/twelve-zebras-relate.md
@@ -1,0 +1,6 @@
+---
+'@obosbbl/grunnmuren-react': patch
+'@obosbbl/grunnmuren-tailwind': patch
+---
+
+set light gray (#e6e6e6) as the default border color

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -65,7 +65,7 @@ export const AccordionItem = (props: AccordionItemProps) => {
       <div
         className={cx(
           className,
-          'border-b-gray-concrete rounded-sm border-b-2 border-l-4 border-solid',
+          'rounded-sm border-b-2 border-l-4 border-solid',
           collapseContext.isExpanded ? 'border-l-green-dark' : 'border-l-green',
         )}
         {...rest}

--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -21,8 +21,7 @@ export const Card = <T extends React.ElementType = 'div'>(
   return (
     <Component
       className={cx(className, 'relative overflow-hidden rounded-3xl', {
-        'border-gray-concrete border-2 border-solid bg-white':
-          bgColor === 'white',
+        'border-2 border-solid bg-white': bgColor === 'white',
         'bg-gray-light': bgColor === 'gray',
       })}
       {...rest}

--- a/packages/react/src/StepList/StepList.tsx
+++ b/packages/react/src/StepList/StepList.tsx
@@ -36,7 +36,7 @@ const StepListBullet = (props: StepListBulletProps) => {
     <span
       // By default we hide this from screen readers to prevent noise, as the steps are implemented using an ordered list
       aria-hidden
-      className="text-green border-gray-light after:bg-gray-light grid h-10 w-10 flex-none place-content-center justify-items-center rounded-full border-2 text-sm font-bold after:absolute after:left-5 after:top-10 after:bottom-0 after:w-0.5 group-last:after:hidden md:h-20 md:w-20 md:text-xl md:after:left-10 md:after:top-20"
+      className="text-green after:bg-gray-light grid h-10 w-10 flex-none place-content-center justify-items-center rounded-full border-2 text-sm font-bold after:absolute after:left-5 after:top-10 after:bottom-0 after:w-0.5 group-last:after:hidden md:h-20 md:w-20 md:text-xl md:after:left-10 md:after:top-20"
       {...props}
     />
   );

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -428,6 +428,9 @@ module.exports = (userOptions) => {
             DEFAULT: '#fff5d2',
           },
         },
+        borderColor: ({ theme }) => ({
+          DEFAULT: theme('colors.gray.light', 'currentColor'),
+        }),
         fontFamily: {
           sans: [fontFamily, 'sans-serif'],
         },


### PR DESCRIPTION
Oppdaget ved en tilfeldighet at man kan sette en default border color. Setter denne til light gray, så det matcher design systemet https://www.figma.com/file/XRHRRytz9DqrDkWpE4IKVB/OBOS-DS?node-id=1%3A228

Vi hadde også feil gråfarge på Accordionen...