### PR TITLE
refact: use tw ARIA variants in Accordion

### DIFF
--- a/.changeset/small-timers-pump.md
+++ b/.changeset/small-timers-pump.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+refactor Accordion to use Tailwind ARIA attribute variants

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -97,7 +97,7 @@ export const AccordionHeader = <T extends React.ElementType = 'h3'>(
       <button
         className={cx(
           className,
-          'focus-visible:outline-blue-dark aria-expanded:bg-green-dark aria-expanded:text-white group flex min-h-[4rem] w-full items-center justify-between px-5 py-4 text-left text-lg font-semibold focus:outline-none focus-visible:outline-4 focus-visible:outline-offset-0',
+          'focus-visible:outline-blue-dark aria-expanded:bg-green-dark group flex min-h-[4rem] w-full items-center justify-between px-5 py-4 text-left text-lg font-semibold focus:outline-none focus-visible:outline-4 focus-visible:outline-offset-0 aria-expanded:text-white',
         )}
         {...rest}
         {...toggleProps}

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -97,8 +97,7 @@ export const AccordionHeader = <T extends React.ElementType = 'h3'>(
       <button
         className={cx(
           className,
-          'focus-visible:outline-blue-dark flex min-h-[4rem] w-full items-center justify-between px-5 py-4 text-left text-lg font-semibold focus:outline-none focus-visible:outline-4 focus-visible:outline-offset-0',
-          isExpanded ? 'bg-green-dark text-white' : undefined,
+          'focus-visible:outline-blue-dark aria-expanded:bg-green-dark aria-expanded:text-white group flex min-h-[4rem] w-full items-center justify-between px-5 py-4 text-left text-lg font-semibold focus:outline-none focus-visible:outline-4 focus-visible:outline-offset-0',
         )}
         {...rest}
         {...toggleProps}
@@ -106,11 +105,7 @@ export const AccordionHeader = <T extends React.ElementType = 'h3'>(
       >
         {children}
         <ChevronDown
-          className={cx(
-            'shrink-0 text-sm',
-            DURATION_TW,
-            isExpanded ? 'rotate-180' : undefined,
-          )}
+          className={`shrink-0 text-sm ${DURATION_TW} group-aria-expanded:rotate-180`}
         />
       </button>
     </Heading>


### PR DESCRIPTION
This is probably a micro optimization, but with [Tailwind 3.2](https://tailwindcss.com/blog/tailwindcss-v3-2#aria-attribute-variants) we can use the ARIA variants instead of cslx to apply the appropriate classes