### PR TITLE
added dark-green background-color to Button

### DIFF
--- a/.changeset/witty-numbers-live.md
+++ b/.changeset/witty-numbers-live.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+add dark-green background-color to Button

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -10,12 +10,12 @@ import { LoadingSpinner } from '@obosbbl/grunnmuren-icons';
 import { cx } from '@/utils';
 import { ButtonColorContext } from '.';
 
-export type ButtonColor = 'standard' | 'white' | 'light-green';
+export type ButtonColor = 'standard' | 'white' | 'light-green' | 'dark-green';
 
 export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   children: React.ReactNode;
   className?: string;
-  color?: 'standard' | 'white' | 'light-green';
+  color?: 'standard' | 'white' | 'light-green' | 'dark-green';
   disabled?: boolean;
   href?: string;
   /** Renders the button in a loading state */
@@ -33,6 +33,8 @@ const buttonVariations = {
   'light-green-secondary': 'bg-transparent border-green-light text-green-light',
   'white-primary': 'bg-white border-white text-black',
   'white-secondary': 'bg-transparent border-white text-white',
+  'dark-green-primary': 'bg-green-dark border-green-dark text-white',
+  'dark-green-secondary': 'bg-white border-green-dark text-black',
 } as const;
 
 export const Button = forwardRef<

--- a/packages/react/src/Button/stories/Button.stories.tsx
+++ b/packages/react/src/Button/stories/Button.stories.tsx
@@ -91,6 +91,14 @@ export const Default = (props: {
           {buttons}
         </ButtonsDisplayer>
       </div>
+
+      <div className="bg-white py-4">
+        <ButtonsDisplayer
+          buttonProps={{ color: 'dark-green', disabled, loading }}
+        >
+          {buttons}
+        </ButtonsDisplayer>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
Kategori-filtreringsknappene på "Boligforvaltning - Tips og råd" på ny stack skal ha mørkegrønn bakgrunn, og ikke OBOS-grønn (nåværende farge).

![image](https://user-images.githubusercontent.com/18421112/199958024-7e37a780-12ff-4e01-a93d-734d8de4a3cf.png)

[AB#62807](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/62807)