### PR TITLE
Remove items-center from checkbox to align checkbox to top of text

### DIFF
--- a/.changeset/shy-nails-play.md
+++ b/.changeset/shy-nails-play.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+removed items-center on label for Checkbox

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -43,9 +43,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
     return (
       <div className="grid gap-2">
-        <label
-          className={cx(className, 'inline-flex cursor-pointer items-center')}
-        >
+        <label className={cx(className, 'inline-flex cursor-pointer')}>
           <input
             id={id}
             className={cx(


### PR DESCRIPTION
Har avklart med Ingeborg at vi endrer designet til CheckBox slik at boksen er alignet på toppen sammen med starten av tilhørende tekst.

Før: 
![image](https://user-images.githubusercontent.com/18421112/203274740-3fc798bf-f8e7-44f1-9a2e-62d4c2159500.png)

Etter:
![image](https://user-images.githubusercontent.com/18421112/203274635-43fccef0-dd64-4fa9-802b-1bf0c82400fd.png)
