### PR TITLE
add Pagination component

### DIFF
--- a/.changeset/sharp-geckos-try.md
+++ b/.changeset/sharp-geckos-try.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+new Pagination component

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,6 +41,7 @@
     "require-from-string": "2.0.2",
     "rimraf": "3.0.2",
     "tailwindcss": "3.2.4",
+    "type-fest": "3.3.0",
     "vite": "2.9.15",
     "webpack": "5.75.0"
   },

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -1,0 +1,219 @@
+import { createContext, useContext, useMemo, forwardRef } from 'react';
+import { ChevronLeft, ChevronRight } from '@obosbbl/grunnmuren-icons';
+import { cx } from '@/utils';
+
+// Number of pagination items to show before and after the current page
+const SIBLING_COUNT = 2;
+
+const PaginationContext = createContext<{
+  currentPage: number;
+  pageCount: number;
+}>({ currentPage: 0, pageCount: 0 });
+
+interface PaginationProps
+  extends Omit<React.ComponentPropsWithoutRef<'nav'>, 'onChange'> {
+  /** The current page number.
+   * @note Starts at 1
+   */
+  page: number;
+
+  /** The total number of pages. */
+  count: number;
+
+  /**  Given a page number, should return a valid href string. */
+  createHref: (page: number) => string;
+
+  /**  Given a page number, should return a valid href string. */
+  createAriaLabel: (page: number) => string;
+  /** Aria label for the next page button link */
+  nextPageAriaLabel: string;
+  /** Aria label for the previous page button link */
+  prevPageAriaLabel: string;
+
+  /** Handler that is called with the page number to navigate to. `event.preventDefault` is called for you. Fallbacks to default browser behavior if undefined. */
+  onChange?: (page: number) => void;
+}
+
+export const Pagination = (props: PaginationProps) => {
+  const {
+    className,
+    page: currentPage,
+    count: pageCount,
+    onChange,
+    createHref,
+    createAriaLabel,
+    nextPageAriaLabel,
+    prevPageAriaLabel,
+    ...rest
+  } = props;
+
+  const context = useMemo(
+    () => ({
+      currentPage: Math.max(1, Math.min(currentPage, pageCount)),
+      pageCount: Math.max(1, pageCount),
+    }),
+    [currentPage, pageCount],
+  );
+
+  const handleClick =
+    (page: number) => (event: React.MouseEvent<HTMLAnchorElement>) => {
+      if (onChange) {
+        event.preventDefault();
+
+        onChange(page);
+      }
+    };
+
+  return (
+    <PaginationContext.Provider value={context}>
+      <nav
+        className={cx('flex justify-center gap-2 sm:gap-4', className)}
+        {...rest}
+      >
+        <PrevPage
+          aria-label={prevPageAriaLabel}
+          href={createHref(currentPage - 1)}
+          onClick={handleClick(currentPage - 1)}
+        />
+        {/* Always render the first page */}
+        <Page
+          page={1}
+          href={createHref(1)}
+          onClick={handleClick(1)}
+          aria-label={createAriaLabel(1)}
+          selected={currentPage === 1}
+        />
+        {pageCount > 2 + SIBLING_COUNT * 2 &&
+          currentPage > SIBLING_COUNT + 2 && <PaginationEllipsis />}
+        {/* @ts-expect-error gaaha ts, come on*/}
+        <Pages>
+          {(page) => (
+            <Page
+              href={createHref(page)}
+              onClick={handleClick(page)}
+              aria-label={createAriaLabel(page)}
+              page={page}
+              key={page}
+              selected={page === currentPage}
+            />
+          )}
+        </Pages>
+        <NextPage
+          aria-label={nextPageAriaLabel}
+          href={createHref(currentPage + 1)}
+          onClick={handleClick(currentPage + 1)}
+        />
+      </nav>
+    </PaginationContext.Provider>
+  );
+};
+
+const NextPage = forwardRef<HTMLAnchorElement, PageLinkProps>((props, ref) => {
+  const { currentPage, pageCount } = useContext(PaginationContext);
+
+  const hide = currentPage >= pageCount;
+
+  return (
+    <PageLink
+      aria-hidden={hide}
+      className={hide ? 'invisible' : undefined}
+      ref={ref}
+      rel="next"
+      {...props}
+    >
+      <ChevronRight />
+    </PageLink>
+  );
+});
+
+const PrevPage = forwardRef<HTMLAnchorElement, PageLinkProps>((props, ref) => {
+  const { currentPage } = useContext(PaginationContext);
+
+  const hide = currentPage <= 1;
+
+  return (
+    <PageLink
+      aria-hidden={hide}
+      className={hide ? 'invisible' : undefined}
+      ref={ref}
+      rel="prev"
+      {...props}
+    >
+      <ChevronLeft />
+    </PageLink>
+  );
+});
+
+interface PageLinkProps extends React.ComponentPropsWithoutRef<'a'> {
+  'aria-label': string;
+}
+
+const PageLink = forwardRef<HTMLAnchorElement, PageLinkProps>((props, ref) => {
+  const { className, ...rest } = props;
+  return (
+    <a
+      className={cx(
+        className,
+        'aria-[current]:border-green hover:bg-gray-concrete flex h-9 w-9 items-center justify-center rounded-lg border-2 border-transparent no-underline sm:h-10 sm:w-10',
+      )}
+      ref={ref}
+      {...rest}
+    />
+  );
+});
+
+const PaginationEllipsis = () => {
+  return (
+    <span className="flex h-9 w-9 cursor-default items-center justify-center border-2 border-transparent sm:h-10 sm:w-10">
+      ...
+    </span>
+  );
+};
+
+interface PagesProps {
+  children: (page: number) => React.ReactElement<PageProps>;
+}
+const Pages = ({ children }: PagesProps) => {
+  const { currentPage, pageCount } = useContext(PaginationContext);
+
+  const end = Math.min(
+    Math.max(2 + SIBLING_COUNT * 2, currentPage + SIBLING_COUNT),
+    pageCount,
+  );
+
+  let start = Math.max(
+    Math.min(currentPage - SIBLING_COUNT, end - SIBLING_COUNT * 2),
+    1,
+  );
+
+  // Since we are showing 6 items (+ arrow buttons)
+  // we don't necessarily have the same number of items to either side of the active
+  // page.. Therefore we need to special handling for that one particular case
+  if (start - SIBLING_COUNT === 0) {
+    start = start - 1;
+  }
+
+  const pages = Array.from({ length: end - start }, (_, i) => start + i + 1);
+
+  return pages.map((page) => children(page));
+};
+
+interface PageProps extends PageLinkProps {
+  page: number;
+  selected?: boolean;
+}
+
+const Page = forwardRef<HTMLAnchorElement, PageProps>((props, ref) => {
+  const { page, selected, ...rest } = props;
+
+  return (
+    <PageLink aria-current={selected ? 'page' : undefined} ref={ref} {...rest}>
+      {page}
+    </PageLink>
+  );
+});
+
+Pagination.NextPage = NextPage;
+Pagination.PrevPage = PrevPage;
+Pagination.Ellipsis = PaginationEllipsis;
+Pagination.Page = Page;

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useMemo, forwardRef } from 'react';
+import type { RequireAtLeastOne } from 'type-fest';
 import { ChevronLeft, ChevronRight } from '@obosbbl/grunnmuren-icons';
 import { cx } from '@/utils';
 
@@ -10,7 +11,7 @@ const PaginationContext = createContext<{
   pageCount: number;
 }>({ currentPage: 0, pageCount: 0 });
 
-interface PaginationProps
+interface BasePaginationProps
   extends Omit<React.ComponentPropsWithoutRef<'nav'>, 'onChange'> {
   /** The current page number.
    * @note Starts at 1
@@ -21,10 +22,10 @@ interface PaginationProps
   count: number;
 
   /**  Given a page number, should return a valid href string. */
-  createHref: (page: number) => string;
+  getItemHref: (page: number) => string;
 
   /**  Given a page number, should return a valid href string. */
-  createAriaLabel: (page: number) => string;
+  getItemAriaLabel: (page: number) => string;
   /** Aria label for the next page button link */
   nextPageAriaLabel: string;
   /** Aria label for the previous page button link */
@@ -34,14 +35,20 @@ interface PaginationProps
   onChange?: (page: number) => void;
 }
 
+// For accessibility reasons, aria-label or aria-labelledby is required.
+type PaginationProps = RequireAtLeastOne<
+  BasePaginationProps,
+  'aria-label' | 'aria-labelledby'
+>;
+
 export const Pagination = (props: PaginationProps) => {
   const {
     className,
     page: currentPage,
     count: pageCount,
     onChange,
-    createHref,
-    createAriaLabel,
+    getItemHref,
+    getItemAriaLabel,
     nextPageAriaLabel,
     prevPageAriaLabel,
     ...rest
@@ -72,15 +79,15 @@ export const Pagination = (props: PaginationProps) => {
       >
         <PrevPage
           aria-label={prevPageAriaLabel}
-          href={createHref(currentPage - 1)}
+          href={getItemHref(currentPage - 1)}
           onClick={handleClick(currentPage - 1)}
         />
         {/* Always render the first page */}
         <Page
           page={1}
-          href={createHref(1)}
+          href={getItemHref(1)}
           onClick={handleClick(1)}
-          aria-label={createAriaLabel(1)}
+          aria-label={getItemAriaLabel(1)}
           selected={currentPage === 1}
         />
         {pageCount > 2 + SIBLING_COUNT * 2 &&
@@ -89,9 +96,9 @@ export const Pagination = (props: PaginationProps) => {
         <Pages>
           {(page) => (
             <Page
-              href={createHref(page)}
+              href={getItemHref(page)}
               onClick={handleClick(page)}
-              aria-label={createAriaLabel(page)}
+              aria-label={getItemAriaLabel(page)}
               page={page}
               key={page}
               selected={page === currentPage}
@@ -100,7 +107,7 @@ export const Pagination = (props: PaginationProps) => {
         </Pages>
         <NextPage
           aria-label={nextPageAriaLabel}
-          href={createHref(currentPage + 1)}
+          href={getItemHref(currentPage + 1)}
           onClick={handleClick(currentPage + 1)}
         />
       </nav>

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -83,7 +83,7 @@ export const Pagination = (props: PaginationProps) => {
           onClick={handleClick(currentPage - 1)}
         />
         {/* Always render the first page */}
-        <Page
+        <PageItem
           page={1}
           href={getItemHref(1)}
           onClick={handleClick(1)}
@@ -95,7 +95,7 @@ export const Pagination = (props: PaginationProps) => {
         {/* @ts-expect-error gaaha ts, come on*/}
         <Pages>
           {(page) => (
-            <Page
+            <PageItem
               href={getItemHref(page)}
               onClick={handleClick(page)}
               aria-label={getItemAriaLabel(page)}
@@ -210,7 +210,7 @@ interface PageProps extends PageLinkProps {
   selected?: boolean;
 }
 
-const Page = forwardRef<HTMLAnchorElement, PageProps>((props, ref) => {
+const PageItem = forwardRef<HTMLAnchorElement, PageProps>((props, ref) => {
   const { page, selected, ...rest } = props;
 
   return (
@@ -219,8 +219,3 @@ const Page = forwardRef<HTMLAnchorElement, PageProps>((props, ref) => {
     </PageLink>
   );
 });
-
-Pagination.NextPage = NextPage;
-Pagination.PrevPage = PrevPage;
-Pagination.Ellipsis = PaginationEllipsis;
-Pagination.Page = Page;

--- a/packages/react/src/Pagination/index.ts
+++ b/packages/react/src/Pagination/index.ts
@@ -1,0 +1,1 @@
+export * from './Pagination';

--- a/packages/react/src/Pagination/stories/Pagination.stories.tsx
+++ b/packages/react/src/Pagination/stories/Pagination.stories.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { Pagination } from '../..';
+
+const metadata = {
+  title: 'Pagination',
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    pageCount: {
+      control: { type: 'number', min: 1, max: 30 },
+    },
+  },
+};
+export default metadata;
+
+export const Default = (props: any) => {
+  const [page, setPage] = useState(1);
+
+  return (
+    <Pagination
+      page={page}
+      count={props.pageCount}
+      createHref={(page) => `#${page}`}
+      onChange={setPage}
+      createAriaLabel={(page) => `Side ${page}`}
+      nextPageAriaLabel="Neste side"
+      prevPageAriaLabel="Forrige side"
+    />
+  );
+};
+
+Default.args = {
+  pageCount: 10,
+};

--- a/packages/react/src/Pagination/stories/Pagination.stories.tsx
+++ b/packages/react/src/Pagination/stories/Pagination.stories.tsx
@@ -14,7 +14,7 @@ const metadata = {
 };
 export default metadata;
 
-export const Default = (props: any) => {
+export const Default = (props: { pageCount: number }) => {
   const [page, setPage] = useState(1);
 
   return (

--- a/packages/react/src/Pagination/stories/Pagination.stories.tsx
+++ b/packages/react/src/Pagination/stories/Pagination.stories.tsx
@@ -19,11 +19,12 @@ export const Default = (props: any) => {
 
   return (
     <Pagination
+      aria-label="Sidepaginering"
       page={page}
       count={props.pageCount}
-      createHref={(page) => `#${page}`}
       onChange={setPage}
-      createAriaLabel={(page) => `Side ${page}`}
+      getItemHref={(page) => `#${page}`}
+      getItemAriaLabel={(page) => `Side ${page}`}
       nextPageAriaLabel="Neste side"
       prevPageAriaLabel="Forrige side"
     />

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,6 +12,7 @@ export * from './Hero';
 export * from './Input';
 export * from './Link';
 export * from './Navbar';
+export * from './Pagination';
 export * from './Radio';
 export * from './Select';
 export * from './Snackbar';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,7 @@ importers:
       require-from-string: 2.0.2
       rimraf: 3.0.2
       tailwindcss: 3.2.4
+      type-fest: 3.3.0
       vite: 2.9.15
       webpack: 5.75.0
     dependencies:
@@ -94,7 +95,7 @@ importers:
       '@storybook/addon-postcss': 2.0.0_webpack@5.75.0
       '@storybook/builder-webpack5': 6.5.13_biqbaboplfbrettd7655fr4n2y
       '@storybook/manager-webpack5': 6.5.13_biqbaboplfbrettd7655fr4n2y
-      '@storybook/react': 6.5.13_uyw6v47vvuxvcllu3lp4kt33nu
+      '@storybook/react': 6.5.13_tcprmjiu5ttazhofr6p3r5cz5e
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
       '@vitejs/plugin-react': 1.3.2
@@ -104,6 +105,7 @@ importers:
       require-from-string: 2.0.2
       rimraf: 3.0.2
       tailwindcss: 3.2.4_postcss@8.4.19
+      type-fest: 3.3.0
       vite: 2.9.15
       webpack: 5.75.0
 
@@ -2262,7 +2264,7 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.6_ohj47mxwagpoxvu7nhhwxzphqm:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.6_z7kvve7o35ocine6cyt5jvcfxm:
     resolution: {integrity: sha512-IIWxofIYt/AbMwoeBgj+O2aAXLrlCQVg+A4a2zfpXFNHgP8o8rvi3v+oe5t787Lj+KXlKOh8BAiUp9bhuELXhg==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -2298,6 +2300,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.3
+      type-fest: 3.3.0
       webpack: 5.75.0
     dev: true
 
@@ -3193,7 +3196,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.13_uyw6v47vvuxvcllu3lp4kt33nu:
+  /@storybook/react/6.5.13_tcprmjiu5ttazhofr6p3r5cz5e:
     resolution: {integrity: sha512-4gO8qihEkVZ8RNm9iQd7G2iZz4rRAHizJ6T5m58Sn21fxfyg9zAMzhgd0JzXuPXR8lTTj4AvRyPv1Qx7b43smg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -3224,7 +3227,7 @@ packages:
       '@babel/core': 7.20.2
       '@babel/preset-flow': 7.16.7_@babel+core@7.20.2
       '@babel/preset-react': 7.16.7_@babel+core@7.20.2
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.6_ohj47mxwagpoxvu7nhhwxzphqm
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.6_z7kvve7o35ocine6cyt5jvcfxm
       '@storybook/addons': 6.5.13_biqbaboplfbrettd7655fr4n2y
       '@storybook/builder-webpack5': 6.5.13_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.13
@@ -12162,6 +12165,11 @@ packages:
   /type-fest/0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /type-fest/3.3.0:
+    resolution: {integrity: sha512-gezeeOIZyQLGW5uuCeEnXF1aXmtt2afKspXz3YqoOcZ3l/YMJq1pujvgT+cz/Nw1O/7q/kSav5fihJHsC/AOUg==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /type-is/1.6.18:


### PR DESCRIPTION
Denne PRen legger til en pagineringskomponent.

Det er en litt mer polert versjon av den som benyttes nederst her https://nye.obos.no/boligforvaltning/tips-og-rad/.

[Figma spec](https://www.figma.com/file/XRHRRytz9DqrDkWpE4IKVB/OBOS-DS?node-id=777%3A10087&t=K4bNyvVmARPA0Bbz-0)

Video demo:
https://user-images.githubusercontent.com/81577/204568974-2a68f43d-afcd-4ec0-986b-c595b27ca6d7.mp4

Jeg har lagt til [type-fest](https://github.com/sindresorhus/type-fest), er egentlig ikke fan fordi typesignaturene den genererer er ofte veldig vanskelige å forstå... Men dersom du har flere nav-elementer på en side må du gi dem labels for at en skjermleser skal kunne skille på dem. Jeg har brukt type-fest til å sikre at du enten spesifiser `aria-label` eller `aria-labelledby` for pagineringen.

