### PR TITLE
Checkbox/Radio: Improve alignment for multiline labels

### DIFF
--- a/.changeset/lazy-cooks-melt.md
+++ b/.changeset/lazy-cooks-melt.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Checkbox: improve alignment of input when label spans multiple lines

--- a/.changeset/orange-avocados-enjoy.md
+++ b/.changeset/orange-avocados-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@obosbbl/grunnmuren-react': patch
+'@obosbbl/grunnmuren-tailwind': patch
+---
+
+Radio: improve alignment of input when label spans multiple lines

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -43,13 +43,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
     return (
       <div className="grid gap-2">
-        <label
-          className={cx(className, 'inline-flex cursor-pointer items-center')}
-        >
+        <label className={cx(className, 'flex cursor-pointer gap-2.5')}>
           <input
             id={id}
             className={cx(
-              'checkbox checked:bg-green checked:border-green mr-3 grid h-[1.25em] w-[1.25em] flex-none cursor-pointer appearance-none place-content-center rounded border-2 border-solid bg-white text-white focus:outline-none focus:ring-2',
+              'checkbox checked:bg-green checked:border-green grid h-[1.25em] w-[1.25em] flex-none translate-y-[0.1em] cursor-pointer appearance-none place-content-center rounded border-2 border-solid bg-white text-white focus:outline-none focus:ring-2',
               {
                 'border-gray-dark focus:ring-black': !error,
                 'border-red focus:ring-red': !!error,

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -13,7 +13,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
     useContext(RadioContext);
 
   return (
-    <label className={cx(className, 'cursor-pointer')}>
+    <label className={cx(className, 'flex cursor-pointer gap-2.5')}>
       <input
         className="radio"
         defaultChecked={!isControlled ? rest.value === defaultValue : undefined}

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -116,10 +116,13 @@ const radio = plugin(function ({ addComponents, theme }) {
       borderRadius: '50%',
       border: `2px solid ${theme('colors.gray.dark')}`,
       cursor: 'pointer',
-      marginRight: '0.75rem',
       // use grid to handle the checked:before styles
       display: 'inline-grid',
       placeContent: 'center',
+      // Prevent flex container from altering the size of the radio button
+      flex: '0 0 auto',
+      // magic number that tries to keep the input horizontally centered in relation to the first line of the label text
+      transform: 'translateY(0.095em)',
       '&:checked': {
         borderColor: theme('colors.green.DEFAULT'),
       },


### PR DESCRIPTION
Følger samme som checkboxes. Siden vi ikke har bestemt om det skal være top-aligned eller center-aligned så følger vi bare samme som checkbox i første omgang

![image](https://user-images.githubusercontent.com/4094284/205046175-bd8b700d-e393-4fc4-a7b8-2447c1313f96.png)
