### PR TITLE
StepList: support top and center alignment for bullet items

### DIFF
--- a/.changeset/hip-hounds-wait.md
+++ b/.changeset/hip-hounds-wait.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+StepList: support both top and center alignment of the bullets

--- a/packages/react/src/StepList/StepList.tsx
+++ b/packages/react/src/StepList/StepList.tsx
@@ -1,42 +1,79 @@
+import { Children, cloneElement } from 'react';
 import { cx } from '@/utils';
 
-interface StepListProps extends React.ComponentPropsWithoutRef<'ol'> {}
+type Alignment = 'center' | 'top';
+
+export interface StepListProps extends React.ComponentPropsWithoutRef<'ol'> {
+  /**
+   * Determines the vertical alignment of the bullets
+   * @default 'center'
+   */
+  align?: Alignment;
+  /**
+   * <StepList> items
+   */
+  children: React.ReactNode;
+}
 
 const StepList = (props: StepListProps) => {
-  return <ol {...props} />;
+  const { align = 'center', children, className, ...rest } = props;
+
+  return (
+    <ol className={cx(className, 'flex flex-col gap-8 md:gap-12')} {...rest}>
+      {Children.map(children, (child) => {
+        return cloneElement(child as React.ReactElement<StepListItemProps>, {
+          align,
+        });
+      })}
+    </ol>
+  );
 };
 
-interface StepListItemProps extends React.ComponentPropsWithoutRef<'li'> {
+export interface StepListItemProps
+  extends React.ComponentPropsWithoutRef<'li'> {
   /** Content for the StepListItem's bullet */
   bullet: React.ReactNode;
+  /** @private this is set by the parent StepList component */
+  align?: Alignment;
 }
 
 export const StepListItem = (props: StepListItemProps) => {
-  const { className, children, bullet, ...rest } = props;
+  const { className, children, bullet, align = 'center', ...rest } = props;
 
   return (
     <li
       className={cx(
         className,
-        'group relative flex items-center gap-4 pb-8 text-sm last:pb-0 md:gap-8 md:pb-12 md:text-base',
+        'group relative flex gap-4 text-sm md:gap-8 md:text-base',
+        { 'items-center': align === 'center' },
       )}
       {...rest}
     >
-      <StepListBullet>{bullet}</StepListBullet>
+      <StepListBullet align={align}>{bullet}</StepListBullet>
       {children}
     </li>
   );
 };
 
-interface StepListBulletProps extends React.ComponentPropsWithoutRef<'span'> {}
+interface StepListBulletProps extends React.ComponentPropsWithoutRef<'span'> {
+  align: Alignment;
+}
 
 // Don't export this, as it is for internal use by StepListItem only
-const StepListBullet = (props: StepListBulletProps) => {
+const StepListBullet = ({ align, ...props }: StepListBulletProps) => {
   return (
     <span
       // By default we hide this from screen readers to prevent noise, as the steps are implemented using an ordered list
       aria-hidden
-      className="text-green after:bg-gray-light grid h-10 w-10 flex-none place-content-center justify-items-center rounded-full border-2 text-sm font-bold after:absolute after:left-5 after:top-10 after:bottom-0 after:w-0.5 group-last:after:hidden md:h-20 md:w-20 md:text-xl md:after:left-10 md:after:top-20"
+      className={cx(
+        'text-green after:bg-gray-light before:bg-gray-light grid h-10 w-10 flex-none place-content-center justify-items-center rounded-full border-2 text-sm font-bold after:absolute after:bottom-0 after:w-0.5 after:translate-x-1/2 group-last:after:hidden md:h-20 md:w-20 md:text-xl  ',
+        {
+          'before:absolute before:top-0 before:bottom-1/2 before:w-0.5 before:-translate-y-5 before:translate-x-1/2 after:top-1/2 after:translate-y-5 group-first:before:hidden before:md:-translate-y-10 after:md:translate-y-10':
+            align === 'center',
+          'after:top-10 after:-bottom-8 after:md:-bottom-12 after:md:top-20':
+            align === 'top',
+        },
+      )}
       {...props}
     />
   );

--- a/packages/react/src/StepList/stories/StepList.stories.tsx
+++ b/packages/react/src/StepList/stories/StepList.stories.tsx
@@ -1,14 +1,24 @@
 import { Documents, Parking, File, House } from '@obosbbl/grunnmuren-icons';
-import { StepList } from '../..';
+import { StepList, StepListProps } from '../..';
 
-const metadata = { title: 'StepList', parameters: { layout: 'padded' } };
+const metadata = {
+  title: 'StepList',
+  parameters: { layout: 'padded' },
+  argTypes: {
+    align: {
+      defaultValue: 'center',
+      options: ['center', 'top'],
+      control: { type: 'radio' },
+    },
+  },
+};
 export default metadata;
 
-export const Numbered = () => {
+export const Numbered = (props: StepListProps) => {
   const numbers = Array.from({ length: 4 }, (v, k) => k + 1);
 
   return (
-    <StepList>
+    <StepList {...props}>
       {numbers.map((n) => (
         <StepList.Item key={n} bullet={n + '.'}>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam
@@ -19,10 +29,10 @@ export const Numbered = () => {
   );
 };
 
-export const Icons = () => {
+export const Icons = (props: StepListProps) => {
   const icons = [Documents, Parking, File, House];
   return (
-    <StepList>
+    <StepList {...props}>
       {icons.map((Icon, i) => (
         <StepList.Item key={i} bullet={<Icon />}>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam


### PR DESCRIPTION
Denne PRen legger til støtte for at man selv kan velge alignment av sirklene i StepList-komponenten. Enten `top` eller `center`.  Dersom man har lengre tekster ser `top` bedre ut, mens `center` blir bedre for korte...

```tsx
// default for backwards compatibility
<StepList align="center" />

<StepList align="top" />
```

- Bruk flex og gap i StepList
- Fikser også en bug hvor strekene var off dersom det var lengre tekster for hvert item
![image](https://user-images.githubusercontent.com/81577/206676489-1104dc36-c512-44a9-839b-074e350a4de5.png)
