### PR TITLE
Added support for error props and moved description for RadioGroup

### DIFF
--- a/.changeset/seven-chicken-type.md
+++ b/.changeset/seven-chicken-type.md
@@ -1,0 +1,8 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Minor changes to `<RadioGroup>`:
+
+ * moved `description` from under radio-buttons to over radio-buttons
+ * add support for `error` props

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -17,8 +17,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
       <input
         className={cx(
           'radio focus:border-blue-dark',
-          error && 'focus:border-red',
-          error && 'border-red',
+          error && 'focus:border-red border-red',
         )}
         defaultChecked={!isControlled ? rest.value === defaultValue : undefined}
         checked={isControlled ? rest.value === value : undefined}

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -15,10 +15,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   return (
     <label className={cx(className, 'flex cursor-pointer gap-2.5')}>
       <input
-        className={cx(
-          'radio focus:border-blue-dark',
-          error && 'focus:border-red border-red',
-        )}
+        className={cx('radio', error && 'border-red')}
         defaultChecked={!isControlled ? rest.value === defaultValue : undefined}
         checked={isControlled ? rest.value === value : undefined}
         name={name}

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -5,7 +5,7 @@ import { RadioContext } from './RadioContext';
 export interface RadioProps extends React.ComponentPropsWithoutRef<'input'> {
   children: React.ReactNode;
 
-  /** Render select as invalid. Sets `aria-invalid` to true */
+  /** Render radio as invalid. Sets `aria-invalid` to true */
   isInvalid?: boolean;
 }
 

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -4,24 +4,18 @@ import { RadioContext } from './RadioContext';
 
 export interface RadioProps extends React.ComponentPropsWithoutRef<'input'> {
   children: React.ReactNode;
-
-  /** Render radio as invalid. Sets `aria-invalid` to true */
-  isInvalid?: boolean;
 }
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
-  const { children, className, isInvalid, ...rest } = props;
+  const { children, className, ...rest } = props;
 
-  const { defaultValue, isControlled, name, onChange, required, value } =
+  const { defaultValue, isControlled, name, onChange, required, value, error } =
     useContext(RadioContext);
 
   return (
     <label className={cx(className, 'flex cursor-pointer gap-2.5')}>
       <input
-        className={cx(
-          'radio focus:border-blue-dark',
-          isInvalid && 'border-red',
-        )}
+        className={cx('radio focus:border-blue-dark', error && 'border-red')}
         defaultChecked={!isControlled ? rest.value === defaultValue : undefined}
         checked={isControlled ? rest.value === value : undefined}
         name={name}

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -4,10 +4,13 @@ import { RadioContext } from './RadioContext';
 
 export interface RadioProps extends React.ComponentPropsWithoutRef<'input'> {
   children: React.ReactNode;
+
+  /** Render select as invalid. Sets `aria-invalid` to true */
+  isInvalid?: boolean;
 }
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
-  const { children, className, ...rest } = props;
+  const { children, className, isInvalid, ...rest } = props;
 
   const { defaultValue, isControlled, name, onChange, required, value } =
     useContext(RadioContext);
@@ -15,7 +18,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   return (
     <label className={cx(className, 'flex cursor-pointer gap-2.5')}>
       <input
-        className="radio"
+        className={cx('radio', isInvalid && 'border-red')}
         defaultChecked={!isControlled ? rest.value === defaultValue : undefined}
         checked={isControlled ? rest.value === value : undefined}
         name={name}

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -15,7 +15,11 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   return (
     <label className={cx(className, 'flex cursor-pointer gap-2.5')}>
       <input
-        className={cx('radio focus:border-blue-dark', error && 'border-red')}
+        className={cx(
+          'radio focus:border-blue-dark',
+          error && 'focus:border-red',
+          error && 'border-red',
+        )}
         defaultChecked={!isControlled ? rest.value === defaultValue : undefined}
         checked={isControlled ? rest.value === value : undefined}
         name={name}

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -18,7 +18,10 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   return (
     <label className={cx(className, 'flex cursor-pointer gap-2.5')}>
       <input
-        className={cx('radio', isInvalid && 'border-red')}
+        className={cx(
+          'radio focus:border-blue-dark',
+          isInvalid && 'border-red',
+        )}
         defaultChecked={!isControlled ? rest.value === defaultValue : undefined}
         checked={isControlled ? rest.value === value : undefined}
         name={name}

--- a/packages/react/src/Radio/RadioContext.tsx
+++ b/packages/react/src/Radio/RadioContext.tsx
@@ -8,6 +8,7 @@ export const RadioContext = createContext<{
   onChange?(event: React.ChangeEvent<HTMLInputElement>): void;
   required?: boolean;
   value?: string;
+  error?: boolean;
 }>({
   defaultValue: undefined,
   isControlled: false,
@@ -15,4 +16,5 @@ export const RadioContext = createContext<{
   onChange: noop,
   required: false,
   value: undefined,
+  error: false,
 });

--- a/packages/react/src/Radio/RadioGroup.tsx
+++ b/packages/react/src/Radio/RadioGroup.tsx
@@ -12,9 +12,6 @@ export interface RadioGroupProps
   /** Help text for the radio group. */
   description?: React.ReactNode;
 
-  /** Disables the built in HTML5 validation. If using custom validation for an entire form, consider setting `noValidate` on the form element instead. @default false */
-  disableValidation?: boolean;
-
   /** Error message for the form control */
   error?: string;
 

--- a/packages/react/src/Radio/RadioGroup.tsx
+++ b/packages/react/src/Radio/RadioGroup.tsx
@@ -1,8 +1,7 @@
-import { useMemo, useCallback, forwardRef, useRef } from 'react';
+import { useMemo, useCallback, forwardRef } from 'react';
 import { cx } from '@/utils';
 import { useFallbackId } from '@/hooks';
 import { FormHelperText, FormLabel, FormErrorMessage } from '../';
-import { useFormControlValidity } from '../hooks';
 import { RadioContext } from './RadioContext';
 
 export interface RadioGroupProps
@@ -43,7 +42,6 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       className,
       defaultValue,
       description,
-      disableValidation = false,
       error,
       id: idProp,
       children,
@@ -71,15 +69,9 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
         onChange,
         required,
         value,
+        error: Boolean(error),
       }),
-      [defaultValue, isControlled, name, onChange, required, value],
-    );
-
-    const ownRef = useRef(null);
-
-    const { validity, validationMessage } = useFormControlValidity(
-      ownRef,
-      !disableValidation,
+      [defaultValue, isControlled, name, onChange, required, value, error],
     );
 
     const groupId = useFallbackId(idProp);
@@ -87,7 +79,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
     const helpTextId = `${groupId}:help`;
     const errorMsgId = groupId + 'err';
 
-    const errorMsg = error || validationMessage;
+    const errorMsg = error;
 
     return (
       <RadioContext.Provider value={group}>
@@ -98,7 +90,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
               [helpTextId]: description,
             }) || undefined
           }
-          aria-invalid={!!error || validity === 'invalid'}
+          aria-invalid={!!error}
           aria-labelledby={label ? labelId : undefined}
           className={cx(className, 'flex flex-col gap-4')}
           role="radiogroup"
@@ -106,11 +98,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
           {...rest}
         >
           {label && (
-            <FormLabel
-              id={labelId}
-              isRequired={required}
-              isInvalid={!!error || validity === 'invalid'}
-            >
+            <FormLabel id={labelId} isRequired={required} isInvalid={!!error}>
               {label}
             </FormLabel>
           )}

--- a/packages/react/src/Radio/RadioGroup.tsx
+++ b/packages/react/src/Radio/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useId, useCallback, forwardRef, useRef } from 'react';
+import { useMemo, useCallback, forwardRef, useRef } from 'react';
 import { cx } from '@/utils';
 import { useFallbackId } from '@/hooks';
 import { FormHelperText, FormLabel, FormErrorMessage } from '../';
@@ -82,11 +82,10 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       !disableValidation,
     );
 
-    const id = useFallbackId(idProp);
-    const groupId = useId();
+    const groupId = useFallbackId(idProp);
     const labelId = `${groupId}:label`;
     const helpTextId = `${groupId}:help`;
-    const errorMsgId = id + 'err';
+    const errorMsgId = groupId + 'err';
 
     const errorMsg = error || validationMessage;
 
@@ -99,6 +98,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
               [helpTextId]: description,
             }) || undefined
           }
+          aria-invalid={!!error || validity === 'invalid'}
           aria-labelledby={label ? labelId : undefined}
           className={cx(className, 'flex flex-col gap-4')}
           role="radiogroup"

--- a/packages/react/src/Radio/stories/Radio.stories.tsx
+++ b/packages/react/src/Radio/stories/Radio.stories.tsx
@@ -55,3 +55,21 @@ export const WithLongLabelThatBreaksLines = () => {
     </Radio>
   );
 };
+
+export const WithErrorText = () => {
+  const [value, setValue] = useState('');
+
+  return (
+    <RadioGroup
+      name="form-name"
+      description="Click on one of the options below to remove error-message"
+      value={value}
+      onChange={setValue}
+      error={!value ? 'Feltet er påkrevd' : ''}
+    >
+      <Radio value="1">Radio 1</Radio>
+      <Radio value="2">Radio 2</Radio>
+      <Radio value="3">Radio 3</Radio>
+    </RadioGroup>
+  );
+};

--- a/packages/react/src/Radio/stories/Radio.stories.tsx
+++ b/packages/react/src/Radio/stories/Radio.stories.tsx
@@ -67,9 +67,15 @@ export const WithErrorText = () => {
       onChange={setValue}
       error={!value ? 'Feltet er påkrevd' : ''}
     >
-      <Radio value="1">Radio 1</Radio>
-      <Radio value="2">Radio 2</Radio>
-      <Radio value="3">Radio 3</Radio>
+      <Radio value="1" isInvalid={!value ? true : false}>
+        Radio 1
+      </Radio>
+      <Radio value="2" isInvalid={!value ? true : false}>
+        Radio 2
+      </Radio>
+      <Radio value="3" isInvalid={!value ? true : false}>
+        Radio 3
+      </Radio>
     </RadioGroup>
   );
 };

--- a/packages/react/src/Radio/stories/Radio.stories.tsx
+++ b/packages/react/src/Radio/stories/Radio.stories.tsx
@@ -67,15 +67,9 @@ export const WithErrorText = () => {
       onChange={setValue}
       error={!value ? 'Feltet er påkrevd' : ''}
     >
-      <Radio value="1" isInvalid={!value ? true : false}>
-        Radio 1
-      </Radio>
-      <Radio value="2" isInvalid={!value ? true : false}>
-        Radio 2
-      </Radio>
-      <Radio value="3" isInvalid={!value ? true : false}>
-        Radio 3
-      </Radio>
+      <Radio value="1">Radio 1</Radio>
+      <Radio value="2">Radio 2</Radio>
+      <Radio value="3">Radio 3</Radio>
     </RadioGroup>
   );
 };


### PR DESCRIPTION
- RadioGroup-komponenten støtter en `error` prop som rendrer en feilmelding hvis en av alternativene ikke er valgt
- Hjelpetekst/beskrivelse er flyttet til før radio-knappene

https://www.figma.com/file/XRHRRytz9DqrDkWpE4IKVB/OBOS-DS?node-id=1198%3A11466&t=Lhq1VWRdKLW3ltef-0

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/18421112/209130575-b9125c9a-df40-4260-b686-d649af24ce48.png">

[AB#65940](https://dev.azure.com/obosbbl/Content%20hub/_boards/board/t/Team%20Nettsted%20og%20B2B/Stories/?workitem=65940)