### PR TITLE
add forwardRef to campaign and card components

### DIFF
--- a/.changeset/modern-turkeys-sing.md
+++ b/.changeset/modern-turkeys-sing.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Campaign/Card: add possibility to send refs to components

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -4,6 +4,8 @@ import {
   createContext,
   isValidElement,
   useContext,
+  forwardRef,
+  ForwardedRef,
 } from 'react';
 import { cx } from '@/utils';
 
@@ -25,9 +27,10 @@ interface CampaignProps<T extends React.ElementType> {
   rightAlignBody?: boolean;
 }
 
-const Campaign = <T extends React.ElementType = 'div'>(
+const CampaignInner = <T extends React.ElementType = 'div'>(
   props: CampaignProps<T> &
     Omit<React.ComponentPropsWithoutRef<T>, keyof CampaignProps<T>>,
+  ref: ForwardedRef<HTMLDivElement>,
 ) => {
   const {
     as: Component = 'div',
@@ -45,6 +48,7 @@ const Campaign = <T extends React.ElementType = 'div'>(
         'grid gap-8 md:grid-flow-col md:grid-cols-[50%,50%] md:gap-0',
       )}
       {...rest}
+      ref={ref}
     >
       <CampaignContext.Provider value={rightAlignBody}>
         {Image}
@@ -54,41 +58,54 @@ const Campaign = <T extends React.ElementType = 'div'>(
   );
 };
 
+const Campaign = forwardRef(CampaignInner);
+
 interface CampaignBodyProps extends React.ComponentPropsWithoutRef<'div'> {}
 
-const CampaignBody = (props: CampaignBodyProps) => {
-  const { className, ...rest } = props;
-  return <div className={cx(className, 'md:mx-18 self-center')} {...rest} />;
-};
+const CampaignBody = forwardRef<HTMLDivElement, CampaignBodyProps>(
+  (props, ref) => {
+    const { className, ...rest } = props;
+    return (
+      <div
+        className={cx(className, 'md:mx-18 self-center')}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
 
 interface CampaignImageProps extends React.ComponentPropsWithoutRef<'img'> {}
 
-const CampaignImage = (props: CampaignImageProps) => {
-  const { className: classNameProp, children, ...rest } = props;
+const CampaignImage = forwardRef<HTMLImageElement, CampaignImageProps>(
+  (props, ref) => {
+    const { className: classNameProp, children, ...rest } = props;
 
-  const bodyIsRightAligned = useContext(CampaignContext);
+    const bodyIsRightAligned = useContext(CampaignContext);
 
-  const className = cx(
-    classNameProp,
-    'max-md:rounded-b-3xl w-full',
-    bodyIsRightAligned ? 'md:rounded-r-3xl' : 'md:rounded-l-3xl md:order-1',
-  );
+    const className = cx(
+      classNameProp,
+      'max-md:rounded-b-3xl w-full',
+      bodyIsRightAligned ? 'md:rounded-r-3xl' : 'md:rounded-l-3xl md:order-1',
+    );
 
-  // If the component has children, clone it and apply our classes.
-  // Allows us to use custom image components (as long as they accept a className) such as next/image.
-  if (isValidElement(children)) {
-    const child = Children.only(children);
+    // If the component has children, clone it and apply our classes.
+    // Allows us to use custom image components (as long as they accept a className) such as next/image.
+    if (isValidElement(children)) {
+      const child = Children.only(children);
 
-    return cloneElement(child, {
-      // @ts-expect-error assume className prop is allowed
-      className,
-      ...rest,
-    });
-  }
+      return cloneElement(child, {
+        // @ts-expect-error assume className prop is allowed
+        className,
+        ref,
+        ...rest,
+      });
+    }
 
-  // Otherwise we fallback to rendering an img element ourselves.
-  return <img className={className} {...rest} />;
-};
+    // Otherwise we fallback to rendering an img element ourselves.
+    return <img className={className} ref={ref} {...rest} />;
+  },
+);
 
 Campaign.Body = CampaignBody;
 Campaign.Image = CampaignImage;

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -58,7 +58,7 @@ const CampaignInner = <T extends React.ElementType = 'div'>(
   );
 };
 
-const Campaign = forwardRef(CampaignInner);
+const CampaignBase = forwardRef(CampaignInner);
 
 interface CampaignBodyProps extends React.ComponentPropsWithoutRef<'div'> {}
 
@@ -107,6 +107,9 @@ const CampaignImage = forwardRef<HTMLImageElement, CampaignImageProps>(
   },
 );
 
-Campaign.Body = CampaignBody;
-Campaign.Image = CampaignImage;
+const Campaign = Object.assign({}, CampaignBase, {
+  Body: CampaignBody,
+  Image: CampaignImage,
+});
+
 export { Campaign };

--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -1,4 +1,5 @@
 import { cx } from '@/utils';
+import { forwardRef } from 'react';
 
 export interface CardProps<T extends React.ElementType> {
   /** @default div */
@@ -7,9 +8,10 @@ export interface CardProps<T extends React.ElementType> {
   bgColor?: 'white' | 'gray';
 }
 
-export const Card = <T extends React.ElementType = 'div'>(
+const CardInner = <T extends React.ElementType = 'div'>(
   props: CardProps<T> &
     Omit<React.ComponentPropsWithoutRef<T>, keyof CardProps<T>>,
+  ref: React.ForwardedRef<HTMLDivElement>,
 ) => {
   const {
     as: Component = 'div',
@@ -25,6 +27,9 @@ export const Card = <T extends React.ElementType = 'div'>(
         'bg-gray-light': bgColor === 'gray',
       })}
       {...rest}
+      ref={ref}
     />
   );
 };
+
+export const Card = forwardRef(CardInner);

--- a/packages/react/src/Card/CardContent.tsx
+++ b/packages/react/src/Card/CardContent.tsx
@@ -1,8 +1,13 @@
 import { cx } from '@/utils';
+import { forwardRef } from 'react';
 
 interface CardContentProps extends React.ComponentPropsWithoutRef<'div'> {}
 
-export const CardContent = (props: CardContentProps) => {
-  const { className, ...rest } = props;
-  return <div className={cx(className, 'p-8 md:px-10')} {...rest} />;
-};
+export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
+  (props, ref) => {
+    const { className, ...rest } = props;
+    return (
+      <div className={cx(className, 'p-8 md:px-10')} {...rest} ref={ref} />
+    );
+  },
+);

--- a/packages/react/src/Card/CardImage.tsx
+++ b/packages/react/src/Card/CardImage.tsx
@@ -1,18 +1,22 @@
 import { cx } from '@/utils';
+import { forwardRef } from 'react';
 
 interface CardImageProps extends React.ComponentPropsWithoutRef<'img'> {
   width: number;
   height: number;
 }
 
-export const CardImage = (props: CardImageProps) => {
-  const { className, ...rest } = props;
+export const CardImage = forwardRef<HTMLImageElement, CardImageProps>(
+  (props, ref) => {
+    const { className, ...rest } = props;
 
-  return (
-    <img
-      className={cx(className, 'w-full object-cover')}
-      loading="lazy"
-      {...rest}
-    />
-  );
-};
+    return (
+      <img
+        className={cx(className, 'w-full object-cover')}
+        loading="lazy"
+        {...rest}
+        ref={ref}
+      />
+    );
+  },
+);

--- a/packages/react/src/Card/CardList.tsx
+++ b/packages/react/src/Card/CardList.tsx
@@ -1,21 +1,25 @@
 import { cx } from '@/utils';
+import { forwardRef } from 'react';
 import { useBlockBackgroundColor, BlockBackgroundColor } from '../hooks';
 
 interface CardListProps extends React.ComponentPropsWithoutRef<'div'> {
   bgColor?: BlockBackgroundColor;
 }
 
-export const CardList = (props: CardListProps) => {
-  const { bgColor: bgColorProp, className, ...rest } = props;
+export const CardList = forwardRef<HTMLDivElement, CardListProps>(
+  (props, ref) => {
+    const { bgColor: bgColorProp, className, ...rest } = props;
 
-  const bgColor = useBlockBackgroundColor(bgColorProp);
+    const bgColor = useBlockBackgroundColor(bgColorProp);
 
-  return (
-    <div className={cx(bgColor, className)}>
-      <div
-        className="container grid grid-cols-1 gap-12 py-16 md:grid-cols-2 md:py-20 lg:py-24"
-        {...rest}
-      />
-    </div>
-  );
-};
+    return (
+      <div className={cx(bgColor, className)}>
+        <div
+          className="container grid grid-cols-1 gap-12 py-16 md:grid-cols-2 md:py-20 lg:py-24"
+          {...rest}
+          ref={ref}
+        />
+      </div>
+    );
+  },
+);


### PR DESCRIPTION
Legger til forwardRef på Campaign og Card kompontener. 

> Fortsatt en siste bug med generiske komponenter. Campaign funker ikke helt som det skal
EDIT: gjelder ikke lenger, se kommentarer. 


Minor eller bare patch? Endrer sånn set ikke noe for brukeren, men legger til ny funksjonalitet så kanskje en minor? 