### PR TITLE
feat: add `'use client';` directive for better RSC interop

### DIFF
--- a/.changeset/real-cows-tie.md
+++ b/.changeset/real-cows-tie.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+add `'use client';` directive for better RSC (Next 13 app directory) interop.

--- a/packages/react/vite.config.js
+++ b/packages/react/vite.config.js
@@ -11,6 +11,23 @@ export default defineConfig({
   plugins: [react({ fastRefresh: false })],
   // prevent copying the public folder meant for Storybook into the dist folder
   publicDir: false,
+  esbuild: {
+    // adds 'use client'; to top of every file processed by esbuild.
+    // This is so we're able to use the current version of Grunnmuren with
+    // React server components without wrapping every component.
+    //
+    // Note that this isn't "proper" RSC support.
+    // This just turns every Grunnmuren component into a client side component...
+    // There are plenty of components in Grunnmuren that doesn't use client hooks
+    // and could be server rendered, but that would require changing the
+    // setup of the package with own entrypoints for each component. We'll leave
+    // that for a new major version..
+    //
+    // This banner could also be added through rollup with the rollupOptions.banner
+    // option, but it seems we must add the directive using esbuild,
+    // otherwise it gets removed by esbuild's minifier
+    banner: "'use client';",
+  },
   build: {
     lib: {
       entry: './src/index.ts',
@@ -18,6 +35,19 @@ export default defineConfig({
       fileName: 'grunnmuren',
     },
     rollupOptions: {
+      onwarn(warning, warn) {
+        // Rollup warns that module level directives ( eg 'use client';) cause errors when bundled.
+        // We bundle Grunnmuren down to a single file, so it is okay in our case.
+        // See https://github.com/rollup/rollup/issues/4699#issuecomment-1299770973
+        if (
+          warning.code === 'MODULE_LEVEL_DIRECTIVE' ||
+          warning.code === 'SOURCEMAP_ERROR'
+        ) {
+          return;
+        }
+        warn(warning);
+      },
+
       // make sure to externalize deps that shouldn't be bundled
       external: [
         '@obosbbl/grunnmuren-icons',


### PR DESCRIPTION
Denne PRen forsøker å gjøre Grunnmuren enklere å ta i bruk med React server components / Next.js 13 app directory.

Siden vi bundler hele grunnmuren ned til én fil holder det at vi får inn et `'use client';` directive i toppen av den fila, så det er det endringen i denne PRen gjør.

Det gjør at hele react-grunnmuren blir client components, men det gjorde de jo strengt tatt før det var noe som het RSC også... Det er en del komponenter som ikke bruker client side effects som i teorien kunne vært RSC-er, men det ville krevd en omstrukturering av hele libbet, så det får vente til en ny major versjon.

For nå gjør disse endringen at alle som vil teste RSC med grunnmuren slipper å wrappe dem i egne client components (som beskrevet her https://beta.nextjs.org/docs/rendering/server-and-client-components#third-party-packages)

Les mer om hvordan dette funker her https://beta.nextjs.org/docs/rendering/server-and-client-components#convention