### PR TITLE
Update campaign styling for iPad and mobile.

### DIFF
--- a/.changeset/twelve-humans-agree.md
+++ b/.changeset/twelve-humans-agree.md
@@ -1,0 +1,8 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+- Keep horizontal view down to sm screen size.
+- Change to a vertical image size for iPad.
+- Move images to the edge of the screen for smaller screen sizes.
+- Images has rounded edges on the side for all screen sizes.

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -45,10 +45,10 @@ const CampaignInner = <T extends React.ElementType = 'div'>(
     <Component
       className={cx(
         className,
-        'grid gap-8 sm:grid-flow-col sm:gap-0 sm:p-0 lg:grid-cols-[50%,50%] lg:p-4 ',
+        'container grid gap-8 sm:grid-flow-col sm:gap-0 sm:p-0 lg:grid-cols-[50%,50%] lg:p-4',
         rightAlignBody
-          ? 'pr-4 sm:grid-cols-[40%,auto]'
-          : 'pl-4 sm:grid-cols-[auto,40%]',
+          ? 'pl-0 sm:grid-cols-[40%,auto]'
+          : 'pr-0 sm:grid-cols-[auto,40%]',
       )}
       {...rest}
       ref={ref}
@@ -94,7 +94,7 @@ const CampaignImage = forwardRef<HTMLImageElement, CampaignImageProps>(
 
     const className = cx(
       classNameProp,
-      'sm:h-[420px] object-cover lg:h-unset',
+      'sm:h-[420px] object-cover lg:h-auto',
       bodyIsRightAligned ? 'rounded-r-3xl' : 'rounded-l-3xl sm:order-1',
     );
 

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -45,15 +45,18 @@ const CampaignInner = <T extends React.ElementType = 'div'>(
     <Component
       className={cx(
         className,
-        'grid gap-8 md:grid-flow-col md:grid-cols-[50%,50%] md:gap-0',
+        'grid gap-8 sm:grid-flow-col sm:gap-0 sm:p-0 lg:grid-cols-[50%,50%] lg:p-4 ',
+        rightAlignBody
+          ? 'pr-4 sm:grid-cols-[40%,auto]'
+          : 'pl-4 sm:grid-cols-[auto,40%]',
       )}
       {...rest}
       ref={ref}
     >
       <CampaignContext.Provider value={rightAlignBody}>
         {Image}
+        {Body}
       </CampaignContext.Provider>
-      {Body}
     </Component>
   );
 };
@@ -65,9 +68,15 @@ interface CampaignBodyProps extends React.ComponentPropsWithoutRef<'div'> {}
 const CampaignBody = forwardRef<HTMLDivElement, CampaignBodyProps>(
   (props, ref) => {
     const { className, ...rest } = props;
+    const bodyIsRightAligned = useContext(CampaignContext);
+
     return (
       <div
-        className={cx(className, 'md:mx-18 self-center')}
+        className={cx(
+          className,
+          'lg:mx-18 self-center sm:mx-8',
+          bodyIsRightAligned ? 'ml-4' : 'mr-4',
+        )}
         ref={ref}
         {...rest}
       />
@@ -85,8 +94,8 @@ const CampaignImage = forwardRef<HTMLImageElement, CampaignImageProps>(
 
     const className = cx(
       classNameProp,
-      'max-md:rounded-b-3xl w-full',
-      bodyIsRightAligned ? 'md:rounded-r-3xl' : 'md:rounded-l-3xl md:order-1',
+      'sm:h-[420px] object-cover lg:h-unset',
+      bodyIsRightAligned ? 'rounded-r-3xl' : 'rounded-l-3xl sm:order-1',
     );
 
     // If the component has children, clone it and apply our classes.

--- a/packages/react/src/Campaign/stories/Campaign.stories.tsx
+++ b/packages/react/src/Campaign/stories/Campaign.stories.tsx
@@ -13,7 +13,7 @@ const images = [
 
 export const Default = () => {
   return (
-    <div className="container flex flex-col gap-16 px-0">
+    <div className="flex flex-col gap-16">
       {images.map((imageSrc, index) => (
         <Campaign
           rightAlignBody={index % 2 === 0}

--- a/packages/react/src/Campaign/stories/Campaign.stories.tsx
+++ b/packages/react/src/Campaign/stories/Campaign.stories.tsx
@@ -13,7 +13,7 @@ const images = [
 
 export const Default = () => {
   return (
-    <div className="container flex flex-col gap-16">
+    <div className="container flex flex-col gap-16 px-0">
       {images.map((imageSrc, index) => (
         <Campaign
           rightAlignBody={index % 2 === 0}
@@ -32,6 +32,22 @@ export const Default = () => {
           image={<Campaign.Image src={imageSrc} alt="" />}
         />
       ))}
+      <Campaign
+        rightAlignBody={false}
+        key={'quote'}
+        body={
+          <Campaign.Body>
+            <h2 className="mb-6">
+              Regnestykket til Elise – sånn ser det ut med OBOS Deleie
+            </h2>
+            <p className="mb-8">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur
+              sit amet porta metus, quis dictum quam.
+            </p>
+          </Campaign.Body>
+        }
+        image={<Campaign.Image src={images[0]} alt="" />}
+      />
     </div>
   );
 };


### PR DESCRIPTION
* Keep horizontal view down to sm screen size.
* Change to a vertical image size for iPad.
* Move images to the edge of the screen for smaller screen sizes.
* Images has rounded edges on the side for all screen sizes.
* In order for the styling to work correctly, the campaign should from now on _not_ be wrapped in a container. This is kind of a breaking change, as the styling implementation should be changes when updating. 

*Mobil* 
![Skjermbilde 2023-02-23 kl  12 23 38](https://user-images.githubusercontent.com/11062151/220894459-d25d3304-427f-4894-976d-2bc46c6b1456.png)

*iPad* 
![Skjermbilde 2023-02-23 kl  12 21 30](https://user-images.githubusercontent.com/11062151/220894481-77ee65d3-024c-4490-a6d1-f46070db2528.png)
