### PR TITLE
Place content of banner in center.

### DIFF
--- a/.changeset/rude-parrots-report.md
+++ b/.changeset/rude-parrots-report.md
@@ -1,0 +1,7 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+- Place content of banner in center.
+- Make icon and heading smaller.
+- Place icon in center on mobile.

--- a/.changeset/rude-parrots-report.md
+++ b/.changeset/rude-parrots-report.md
@@ -1,5 +1,5 @@
 ---
-'@obosbbl/grunnmuren-react': minor
+'@obosbbl/grunnmuren-react': patch
 ---
 
 - Place content of banner in center.

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -23,10 +23,10 @@ export const Banner = (props: BannerProps) => {
 
   return (
     <article className={cx(className, bgColor, 'py-8 px-4 md:py-14')} {...rest}>
-      <div className="container flex w-fit gap-4 max-md:flex-wrap md:gap-12">
+      <div className="container flex max-w-fit gap-4 max-md:flex-wrap md:gap-12">
         {image}
         <div className="w-prose">
-          {heading && <h2 className="mb-4">{heading}</h2>}
+          {heading && <h2 className="h3 mb-4">{heading}</h2>}
           {children}
         </div>
       </div>

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -23,7 +23,7 @@ export const Banner = (props: BannerProps) => {
 
   return (
     <article className={cx(className, bgColor, 'py-8 px-4 md:py-14')} {...rest}>
-      <div className="container flex max-w-fit gap-4 max-md:flex-wrap md:gap-12">
+      <div className="container flex flex-col justify-center gap-4 md:flex-row md:gap-12">
         {image}
         <div className="w-prose">
           {heading && <h2 className="h3 mb-4">{heading}</h2>}

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -23,7 +23,7 @@ export const Banner = (props: BannerProps) => {
 
   return (
     <article className={cx(className, bgColor, 'py-8 px-4 md:py-14')} {...rest}>
-      <div className="container w-fit flex gap-4 max-md:flex-wrap md:gap-12">
+      <div className="container flex w-fit gap-4 max-md:flex-wrap md:gap-12">
         {image}
         <div className="w-prose">
           {heading && <h2 className="mb-4">{heading}</h2>}

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -23,7 +23,7 @@ export const Banner = (props: BannerProps) => {
 
   return (
     <article className={cx(className, bgColor, 'py-8 px-4 md:py-14')} {...rest}>
-      <div className="container flex gap-4 max-md:flex-wrap md:gap-12">
+      <div className="container w-fit flex gap-4 max-md:flex-wrap md:gap-12">
         {image}
         <div className="w-prose">
           {heading && <h2 className="mb-4">{heading}</h2>}

--- a/packages/react/src/Banner/BannerImage.tsx
+++ b/packages/react/src/Banner/BannerImage.tsx
@@ -11,7 +11,7 @@ export const BannerImage = (props: BannerImageProps) => {
     <img
       loading="lazy"
       decoding="async"
-      className="w-24 flex-none self-center md:w-40 md:self-start"
+      className="mx-auto w-20 flex-none self-start md:m-0 md:w-32"
       {...props}
     />
   );

--- a/packages/react/src/Banner/BannerImage.tsx
+++ b/packages/react/src/Banner/BannerImage.tsx
@@ -11,7 +11,7 @@ export const BannerImage = (props: BannerImageProps) => {
     <img
       loading="lazy"
       decoding="async"
-      className="mx-auto w-20 flex-none self-start md:m-0 md:w-32"
+      className="w-20 flex-none self-center md:w-32 md:self-start"
       {...props}
     />
   );


### PR DESCRIPTION
Banner tweaks from Hanne:
* Place content of banner in center
* Smaller icon and heading.
* Align icon center on mobile. 

<img width="1447" alt="Skjermbilde 2023-02-24 kl  09 23 36" src="https://user-images.githubusercontent.com/11062151/221128929-8a766e23-8d9e-4ae9-ac37-c7fca48699f4.png">
