### PR TITLE
tailwind: headings follow styleguide when using prose

### DIFF
--- a/.changeset/serious-actors-drum.md
+++ b/.changeset/serious-actors-drum.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-tailwind': patch
+---
+
+typography(prose): headings follow the styleguide

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/code-obos/grunnmuren"
   },
   "scripts": {
+    "dev": "pnpm --filter './packages/react' dev",
     "build": "pnpm --filter './packages/*' build",
     "ci:publish": "pnpm build && changeset publish",
     "ci:version": "changeset version",

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -464,23 +464,39 @@ module.exports = (userOptions) => {
                 fontWeight: 400,
               },
               h1: {
-                fontWeight: 'bold',
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.3xl'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.5xl'),
+                },
               },
               h2: {
-                fontWeight: 'bold',
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.2xl'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.4xl'),
+                },
               },
               h3: {
-                fontWeight: 'bold',
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.xl'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.2xl'),
+                },
               },
               h4: {
-                fontWeight: 'bold',
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.lg'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.xl'),
+                },
               },
               li: {
                 marginTop: '1.5em',
                 marginBottom: '1.5em',
               },
               blockquote: {
-                fontWeight: '700',
+                fontWeight: theme('fontWeight.bold'),
                 fontStyle: 'normal',
               },
               'blockquote p:first-of-type::before': {
@@ -490,7 +506,7 @@ module.exports = (userOptions) => {
                 content: '"»"',
               },
               '[class~="lead"]': {
-                fontWeight: 500,
+                fontWeight: theme('fontWeight.medium'),
               },
             },
           },


### PR DESCRIPTION
trodde jeg kunne legge til `md` i configen til typography men da gjaldt det tydeligvis bare `prose-md` håndteringen. Så da ble det slik hentet fra https://github.com/tailwindlabs/tailwindcss/discussions/3060