### PR TITLE
Add lighter colors to tailwind

### DIFF
--- a/.changeset/spicy-planets-begin.md
+++ b/.changeset/spicy-planets-begin.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-tailwind': minor
+---
+
+Add lighter colors to tailwind

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -406,7 +406,9 @@ module.exports = (userOptions) => {
             light: '#E6E6E6',
           },
           blue: {
-            // light blue
+            // Pale sky
+            pale: '#EBF5F9',
+            // Haze sky
             lightest: '#DEEFF5',
             // OBOS Sky
             light: '#BEDFEC',
@@ -416,7 +418,9 @@ module.exports = (userOptions) => {
             dark: '#002169',
           },
           green: {
-            // light green
+            // Pale mint
+            pale: '#F0F9F6',
+            // Haze mint
             lightest: '#E6F5F0',
             // OBOS Mint
             light: '#CDECE2',


### PR DESCRIPTION
De lyseste fargene til OBOS mangler i tailwind. Vi bruker disse i banken, så tenkte vi like godt kan få de inn i tailwind.
For å ikke gjøre noen breaking changes med eksisterende navngivning har jeg kalt de to nye lyseste fargene for `pale` ettersom det er det de heter i designsystemet også, men kom gjerne med andre forslag.

![image](https://user-images.githubusercontent.com/46884914/231440525-fd556515-a27b-4068-8aca-d9a56d98ae36.png)
