### PR TITLE
Tailwind new colors

### DIFF
--- a/.changeset/curly-walls-clap.md
+++ b/.changeset/curly-walls-clap.md
@@ -1,0 +1,20 @@
+---
+'@obosbbl/grunnmuren-tailwind': minor
+'@obosbbl/grunnmuren-react': minor
+---
+
+Add new colors mint and sky. Old colors are deprecated
+
+`blue-light` -> `sky`
+`blue-lightest` -> `sky-light`
+
+`green-light` -> `mint`
+`green-lightest` -> `mint-light`
+
+`gray-concrete` -> -> `gray-lightest`
+
+`<Button>` has a new Color-prop `mint` which is the same as `light-green`.
+
+`<Chip>` has a new Color-props `mint` and `sky` which are the same as `green-light` and `blue-light` respectively.
+
+The old props and colors are deprecated and will be removed in the next major version. 

--- a/.changeset/curly-walls-clap.md
+++ b/.changeset/curly-walls-clap.md
@@ -15,6 +15,8 @@ Add new colors mint and sky. Old colors are deprecated
 
 `<Button>` has a new Color-prop `mint` which is the same as `light-green`.
 
-`<Chip>` has a new Color-props `mint` and `sky` which are the same as `green-light` and `blue-light` respectively.
+`<Chip>` has new Color-props `mint` and `sky` which are the same as `green-light` and `blue-light` respectively.
+
+`<CardList> | <Banner>` have new Color-props `mint` and `sky` which are the same as `green` and `blue` respectively
 
 The old props and colors are deprecated and will be removed in the next major version. 

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -8,11 +8,6 @@ module.exports = {
     '@storybook/addon-controls',
     {
       name: '@storybook/addon-styling',
-      options: {
-        postCss: {
-          implementation: require('postcss'),
-        },
-      },
     },
   ],
   framework: {

--- a/packages/react/src/Banner/stories/Banner.stories.tsx
+++ b/packages/react/src/Banner/stories/Banner.stories.tsx
@@ -11,7 +11,7 @@ const img = {
   width: 520,
 };
 
-const bgcColors = ['gray', 'green', 'yellow', 'blue'] as const;
+const bgcColors = ['gray', 'green', 'yellow', 'blue', 'mint', 'sky'] as const;
 
 export const Default = () => {
   return (

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -29,8 +29,8 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
 const buttonVariations = {
   'standard-primary': 'bg-green border-green text-white',
   'standard-secondary': 'bg-white border-green text-black',
-  'light-green-primary': 'bg-green-light border-green-light text-black',
-  'light-green-secondary': 'bg-transparent border-green-light text-green-light',
+  'light-green-primary': 'bg-mint border-mint text-black',
+  'light-green-secondary': 'bg-transparent border-mint text-mint',
   'white-primary': 'bg-white border-white text-black',
   'white-secondary': 'bg-transparent border-white text-white',
 } as const;

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -10,12 +10,12 @@ import { LoadingSpinner } from '@obosbbl/grunnmuren-icons';
 import { cx } from '@/utils';
 import { ButtonColorContext } from '.';
 
-export type ButtonColor = 'standard' | 'white' | 'light-green';
+export type ButtonColor = 'standard' | 'white' | 'light-green' | 'mint';
 
 export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   children: React.ReactNode;
   className?: string;
-  color?: 'standard' | 'white' | 'light-green';
+  color?: 'standard' | 'white' | 'light-green' | 'mint';
   disabled?: boolean;
   href?: string;
   /** Renders the button in a loading state */
@@ -29,10 +29,12 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
 const buttonVariations = {
   'standard-primary': 'bg-green border-green text-white',
   'standard-secondary': 'bg-white border-green text-black',
-  'light-green-primary': 'bg-mint border-mint text-black',
-  'light-green-secondary': 'bg-transparent border-mint text-mint',
+  'mint-primary': 'bg-mint border-mint text-black',
+  'mint-secondary': 'bg-transparent border-mint text-mint',
   'white-primary': 'bg-white border-white text-black',
   'white-secondary': 'bg-transparent border-white text-white',
+  'light-green-primary': 'bg-green-light border-green-light text-black',
+  'light-green-secondary': 'bg-transparent border-green-light text-green-light',
 } as const;
 
 export const Button = forwardRef<

--- a/packages/react/src/Button/stories/Button.stories.tsx
+++ b/packages/react/src/Button/stories/Button.stories.tsx
@@ -79,9 +79,7 @@ export const Default = (props: {
       </ButtonsDisplayer>
 
       <div className="bg-green-dark py-4">
-        <ButtonsDisplayer
-          buttonProps={{ color: 'light-green', disabled, loading }}
-        >
+        <ButtonsDisplayer buttonProps={{ color: 'mint', disabled, loading }}>
           {buttons}
         </ButtonsDisplayer>
       </div>

--- a/packages/react/src/Chip/Chip.tsx
+++ b/packages/react/src/Chip/Chip.tsx
@@ -1,6 +1,12 @@
 import { cx } from '@/utils';
 
-export type ChipColor = 'sky' | 'mint' | 'red-light' | 'orange-light';
+export type ChipColor =
+  | 'sky'
+  | 'mint'
+  | 'red-light'
+  | 'orange-light'
+  | 'green-light'
+  | 'blue-light';
 
 export interface ChipProps {
   icon?: React.ReactNode;
@@ -18,6 +24,8 @@ const chipVariations = {
   'red-light': 'bg-red-light border-red-light',
   mint: 'bg-mint border-mint',
   'orange-light': 'bg-orange-light border-orange-light',
+  'green-light': 'bg-green-light border-green-light',
+  'blue-light': 'bg-blue-light border-blue-light',
 } as const;
 
 const iconColors = {
@@ -25,6 +33,8 @@ const iconColors = {
   'red-light': 'text-red',
   mint: 'text-green',
   'orange-light': 'text-black',
+  'green-light': 'text-green',
+  'blue-light': 'text-blue-dark',
 };
 
 export const Chip = (props: ChipProps) => {

--- a/packages/react/src/Chip/Chip.tsx
+++ b/packages/react/src/Chip/Chip.tsx
@@ -1,10 +1,6 @@
 import { cx } from '@/utils';
 
-export type ChipColor =
-  | 'blue-light'
-  | 'green-light'
-  | 'red-light'
-  | 'orange-light';
+export type ChipColor = 'sky' | 'mint' | 'red-light' | 'orange-light';
 
 export interface ChipProps {
   icon?: React.ReactNode;
@@ -18,16 +14,16 @@ export interface ChipProps {
 }
 
 const chipVariations = {
-  'blue-light': 'bg-blue-light border-blue-light',
+  sky: 'bg-sky border-sky',
   'red-light': 'bg-red-light border-red-light',
-  'green-light': 'bg-green-light border-green-light',
+  mint: 'bg-mint border-mint',
   'orange-light': 'bg-orange-light border-orange-light',
 } as const;
 
 const iconColors = {
-  'blue-light': 'text-blue-dark',
+  sky: 'text-blue-dark',
   'red-light': 'text-red',
-  'green-light': 'text-green',
+  mint: 'text-green',
   'orange-light': 'text-black',
 };
 

--- a/packages/react/src/Chip/stories/Chip.stories.tsx
+++ b/packages/react/src/Chip/stories/Chip.stories.tsx
@@ -10,10 +10,10 @@ export const Default = () => {
     <>
       <div className="mx-4 my-8 flex gap-4">
         <div className="flex flex-col gap-4">
-          <Chip color="blue-light" variant="outline" icon={<InfoCircle />}>
+          <Chip color="sky" variant="outline" icon={<InfoCircle />}>
             Frist for forkjøp 00. måned
           </Chip>
-          <Chip color="green-light" variant="outline" icon={<Star />}>
+          <Chip color="mint" variant="outline" icon={<Star />}>
             Medlemstilbud
           </Chip>
           <Chip color="red-light" variant="outline" icon={<Warning />}>
@@ -31,8 +31,8 @@ export const Default = () => {
           </Chip>
         </div>
         <div className="flex flex-col gap-4">
-          <Chip color="blue-light">Frist for forkjøp 00. måned</Chip>
-          <Chip color="green-light">Medlemstilbud</Chip>
+          <Chip color="sky">Frist for forkjøp 00. måned</Chip>
+          <Chip color="mint">Medlemstilbud</Chip>
           <Chip color="red-light">Alert</Chip>
           <Chip color="orange-light">Informasjon</Chip>
           <Chip className="border-red bg-red text-white">

--- a/packages/react/src/Form/FormSuccess.tsx
+++ b/packages/react/src/Form/FormSuccess.tsx
@@ -12,7 +12,7 @@ export const FormSuccess = (props: FormSuccessProps) => {
     <div
       className={cx(
         className,
-        'bg-gray-concrete flex flex-col gap-8 p-8 text-center',
+        'bg-gray-lightest flex flex-col gap-8 p-8 text-center',
       )}
       {...rest}
     >

--- a/packages/react/src/Hero/Hero.tsx
+++ b/packages/react/src/Hero/Hero.tsx
@@ -60,7 +60,7 @@ export const Hero = forwardRef<HTMLDivElement, HeroProps>((props, ref) => {
 
   return (
     <ButtonColorContext.Provider
-      value={bgColor === 'white' ? 'standard' : 'light-green'}
+      value={bgColor === 'white' ? 'standard' : 'mint'}
     >
       <HeroContext.Provider value={context}>
         <div

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -161,7 +161,7 @@ const PageLink = forwardRef<HTMLAnchorElement, PageLinkProps>((props, ref) => {
     <a
       className={cx(
         className,
-        'aria-[current]:border-green hover:bg-gray-concrete flex h-9 w-9 items-center justify-center rounded-lg border-2 border-transparent no-underline sm:h-10 sm:w-10',
+        'aria-[current]:border-green hover:bg-gray-lightest flex h-9 w-9 items-center justify-center rounded-lg border-2 border-transparent no-underline sm:h-10 sm:w-10',
       )}
       ref={ref}
       {...rest}

--- a/packages/react/src/hooks/useBlockBackgroundColor.ts
+++ b/packages/react/src/hooks/useBlockBackgroundColor.ts
@@ -1,4 +1,10 @@
-export type BlockBackgroundColor = 'yellow' | 'gray' | 'blue' | 'green';
+export type BlockBackgroundColor =
+  | 'yellow'
+  | 'gray'
+  | 'blue'
+  | 'green'
+  | 'mint'
+  | 'sky';
 
 export function useBlockBackgroundColor(
   blockBgColor: BlockBackgroundColor | undefined,
@@ -7,10 +13,12 @@ export function useBlockBackgroundColor(
     case 'gray':
       return 'bg-gray-lightest';
     case 'green':
+    case 'mint':
       return 'bg-mint-light';
     case 'yellow':
       return 'bg-yellow';
     case 'blue':
+    case 'sky':
       return 'bg-sky-light';
   }
 }

--- a/packages/react/src/hooks/useBlockBackgroundColor.ts
+++ b/packages/react/src/hooks/useBlockBackgroundColor.ts
@@ -5,12 +5,12 @@ export function useBlockBackgroundColor(
 ): string | undefined {
   switch (blockBgColor) {
     case 'gray':
-      return 'bg-gray-concrete';
+      return 'bg-gray-lightest';
     case 'green':
-      return 'bg-green-lightest';
+      return 'bg-mint-light';
     case 'yellow':
       return 'bg-yellow';
     case 'blue':
-      return 'bg-blue-lightest';
+      return 'bg-sky-light';
   }
 }

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -278,7 +278,7 @@ module.exports = (userOptions) => {
           a: {
             '@apply underline': {},
           },
-          '::selection': { '@apply bg-green-light text-black': {} },
+          '::selection': { '@apply bg-mint text-black': {} },
           // Remove the disclosure triangle in Safari if apply the `list-none` utility to the summary element
           'summary.list-none::-webkit-details-marker': {
             display: 'none',
@@ -396,19 +396,30 @@ module.exports = (userOptions) => {
           black: '#333',
           white: '#fff',
           gray: {
-            // TODO: Figure out how to work this into the color scale
-            concrete: '#f1f1f1',
-            // Gray
+            // Dark Gray
             dark: '#595959',
-            // Medium gray
+            // gray
             DEFAULT: '#818181',
             // Light gray
             light: '#E6E6E6',
+            // Lightest gray
+            lightest: '#f1f1f1',
+            concrete: '#f1f1f1',
+          },
+          sky: {
+            DEFAULT: '#BEDFEC',
+            light: '#DEEFF5',
+            lightest: '#EBF5F9',
+          },
+          mint: {
+            DEFAULT: '#CDECE2',
+            light: '#E6F5F0',
+            lightest: '#F0F9F6',
           },
           blue: {
-            // light blue
+            // DEPRECRECATED light blue
             lightest: '#DEEFF5',
-            // OBOS Sky
+            // DEPRECRECATED OBOS Sky
             light: '#BEDFEC',
             // OBOS Blue/Primary brand
             DEFAULT: '#0047BA',
@@ -416,9 +427,9 @@ module.exports = (userOptions) => {
             dark: '#002169',
           },
           green: {
-            // light green
+            // DEPRECRECATED light green
             lightest: '#E6F5F0',
-            // OBOS Mint
+            // DEPRECRECATED OBOS Mint
             light: '#CDECE2',
             // OBOS Green/Primary brand
             DEFAULT: '#008761',

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -417,9 +417,9 @@ module.exports = (userOptions) => {
             lightest: '#F0F9F6',
           },
           blue: {
-            // DEPRECRECATED light blue
+            // DEPRECATED light blue
             lightest: '#DEEFF5',
-            // DEPRECRECATED OBOS Sky
+            // DEPRECATED OBOS Sky
             light: '#BEDFEC',
             // OBOS Blue/Primary brand
             DEFAULT: '#0047BA',
@@ -427,9 +427,9 @@ module.exports = (userOptions) => {
             dark: '#002169',
           },
           green: {
-            // DEPRECRECATED light green
+            // DEPRECATED light green
             lightest: '#E6F5F0',
-            // DEPRECRECATED OBOS Mint
+            // DEPRECATED OBOS Mint
             light: '#CDECE2',
             // OBOS Green/Primary brand
             DEFAULT: '#008761',

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -404,6 +404,7 @@ module.exports = (userOptions) => {
             light: '#E6E6E6',
             // Lightest gray
             lightest: '#f1f1f1',
+            // DEPRECATED concrete
             concrete: '#f1f1f1',
           },
           sky: {
@@ -421,6 +422,7 @@ module.exports = (userOptions) => {
             lightest: '#DEEFF5',
             // DEPRECATED OBOS Sky
             light: '#BEDFEC',
+
             // OBOS Blue/Primary brand
             DEFAULT: '#0047BA',
             // OBOS Ocean
@@ -431,6 +433,7 @@ module.exports = (userOptions) => {
             lightest: '#E6F5F0',
             // DEPRECATED OBOS Mint
             light: '#CDECE2',
+
             // OBOS Green/Primary brand
             DEFAULT: '#008761',
             // OBOS Forest


### PR DESCRIPTION
Add new colors mint and sky. Old colors are deprecated

`blue-light` -> `sky`
`blue-lightest` -> `sky-light`

`green-light` -> `mint`
`green-lightest` -> `mint-light`

`gray-concrete` -> `gray-lightest`

`<Button>` has a new Color-prop `mint` which is the same as `light-green`.

`<Chip>` has a new Color-props `mint` and `sky` which are the same as `green-light` and `blue-light` respectively.

`<CardList> | <Banner>` have new Color-props `mint` and `sky` which are the same as `green` and `blue` respectively