### PR TITLE
upgrade react-collapsed dependency

### DIFF
--- a/.changeset/metal-months-cover.md
+++ b/.changeset/metal-months-cover.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+upgrade react-collapsed dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,7 +49,7 @@
     "@obosbbl/grunnmuren-icons": "workspace:^",
     "@react-hook/merged-ref": "1.3.2",
     "clsx": "1.2.1",
-    "react-collapsed": "3.5.0",
+    "react-collapsed": "4.0.2",
     "react-use": "17.4.0"
   },
   "peerDependencies": {

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -1,9 +1,8 @@
 import React, { createContext, useContext } from 'react';
 import { ChevronDown } from '@obosbbl/grunnmuren-icons';
-import useCollapse from 'react-collapsed';
+import { useCollapse } from 'react-collapsed';
 
 import { cx, noop } from '@/utils';
-import { usePrefersReducedMotion } from '@/hooks';
 
 /**
  * See https://www.w3.org/WAI/ARIA/apg/patterns/accordion/ for how to make an accordion/disclousre accessible
@@ -48,15 +47,12 @@ export interface AccordionItemProps
 }
 
 export const AccordionItem = (props: AccordionItemProps) => {
-  const prefersReducedMotion = usePrefersReducedMotion();
-
   const { className, defaultOpen, onChange = noop, open, ...rest } = props;
 
   const collapseContext = useCollapse({
     defaultExpanded: defaultOpen,
     isExpanded: open,
     duration: DURATION_MS,
-    hasDisabledAnimation: prefersReducedMotion,
     easing: 'cubic-bezier(0.25, 0.1, 0.25, 1)',
   });
 
@@ -123,11 +119,7 @@ export const AccordionContent = (props: AccordionContentProps) => {
 
   // Must use two divs here for the animation to work properly. See https://github.com/roginfarrer/react-collapsed#faq
   return (
-    <div
-      {...collapseProps}
-      role="region"
-      aria-labelledby={getToggleId(collapseProps.id)}
-    >
+    <div {...collapseProps} aria-labelledby={getToggleId(collapseProps.id)}>
       <div className={cx(className, 'p-5 pb-10')} {...rest} />
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 1.2.1
         version: 1.2.1
       react-collapsed:
-        specifier: 3.5.0
-        version: 3.5.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 4.0.2
+        version: 4.0.2(react-dom@18.2.0)(react@18.2.0)
       react-use:
         specifier: 17.4.0
         version: 17.4.0(react-dom@18.2.0)(react@18.2.0)
@@ -7811,11 +7811,11 @@ packages:
       unpipe: 1.0.0
     dev: true
 
-  /react-collapsed@3.5.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-MtwlFoVfm1LdS1FFFNBQhMESSly0+ZaIouZHVbpVytM9gflLwUfPLbcqEuhzilT8upwzg45ect1zWC4Dbd5xpw==}
+  /react-collapsed@4.0.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-mzGhppOLzW3PGtU+RlSYPANpShYd5wt6LdFWnDgHy/asyIfQT8BHDognr5sYFPouXiHPwGWUtQ6ZfI5jd7bU6Q==}
     peerDependencies:
-      react: '>=16.8 || 18'
-      react-dom: '>=16.8 || 18'
+      react: ^16.9.0 || ^17 || ^18 || 18
+      react-dom: ^16.9.0 || ^17 || ^18 || 18
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
Upgrade [react-collapsed dependency](https://github.com/roginfarrer/collapsed).

* It no longer uses a default export
* [It sets `role="region"` for the collapsible panel now,](https://github.com/roginfarrer/collapsed/releases/tag/%40collapsed%2Freact%404.0.0) so we no longer need to do it ourselves
* [it actually checks if the user prefers reduced motion internally](https://github.com/roginfarrer/collapsed/blob/3a84a2a8ce2fd6f9ecab32eef447c4e61c6c8e2d/packages/react-collapsed/src/index.ts#L89), so we don't need to do it ourselves

According to the release notes, it should also handle setting aria-labelledby for the collapsibe panel, but I couldn't get that to work, so therefore we keep setting that ourselves.