### PR TITLE
Feature: FormStep

### DIFF
--- a/.changeset/twenty-starfishes-marry.md
+++ b/.changeset/twenty-starfishes-marry.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Add support for FormStep aka MultiStep

--- a/packages/react/src/Form/FormLabel.tsx
+++ b/packages/react/src/Form/FormLabel.tsx
@@ -16,7 +16,6 @@ export const FormLabel = (props: LabelProps) => {
     >
       {isRequired && (
         <span
-          aria-hidden
           className={cx(
             'mr-1 select-none',
             isInvalid ? 'text-red' : 'text-blue',

--- a/packages/react/src/Form/MultiStep/FormStep.tsx
+++ b/packages/react/src/Form/MultiStep/FormStep.tsx
@@ -1,0 +1,72 @@
+import { FormEventHandler, useCallback, useRef } from 'react';
+import { FormProps } from '..';
+import classNames from 'clsx';
+
+import { FormStepHeader } from './FormStepHeader';
+import { useFormStepContext } from './FormStepContext';
+import { useUpdateEffect } from 'react-use';
+
+interface FormStepProps extends FormProps {
+  step: number;
+  heading: string;
+  formStatus: FormStatus;
+  onSubmit: FormEventHandler<HTMLFormElement>;
+}
+
+export interface FormStepData<T> {
+  formId: string;
+  status: FormStatus;
+  formData?: T;
+}
+
+export type FormStatus = 'blank' | 'completed';
+
+export const FormStep = (props: FormStepProps) => {
+  const {
+    children,
+    heading,
+    step,
+    formStatus = 'blank',
+    onSubmit,
+    ...rest
+  } = props;
+  const { isActive, setActiveStep, activeStep } = useFormStepContext(step);
+
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleHeaderClick = useCallback(() => {
+    if (step < activeStep) {
+      setActiveStep(step);
+    }
+  }, [activeStep, step, setActiveStep]);
+
+  // When switching steps, scroll the newly active one into view
+  useUpdateEffect(() => {
+    if (isActive) {
+      formRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [isActive]);
+
+  return (
+    <form
+      className={classNames(
+        'border-blue-dark block overflow-hidden rounded-lg border-2',
+        { 'rounded-t-2xl md:rounded-t-3xl': step === 1 },
+        { 'border-none': formStatus === 'completed' && !isActive },
+      )}
+      onSubmit={onSubmit}
+      ref={formRef}
+      {...rest}
+    >
+      <FormStepHeader
+        step={step}
+        formStatus={formStatus}
+        collapsed={!isActive}
+        onClick={handleHeaderClick}
+      >
+        {heading}
+      </FormStepHeader>
+      {isActive && <div className="p-6 md:p-10">{children}</div>}
+    </form>
+  );
+};

--- a/packages/react/src/Form/MultiStep/FormStepContext.tsx
+++ b/packages/react/src/Form/MultiStep/FormStepContext.tsx
@@ -1,0 +1,114 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  Dispatch,
+  useReducer,
+  useCallback,
+} from 'react';
+
+// TODO: Improve typing here. How can we express the type of the whole form while typing each step?
+
+export type FieldValues = Record<string, unknown>;
+
+const FormStepContext = createContext<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly [state: State<any>, dispatch: Dispatch<Action>]
+>([
+  {
+    activeStep: 1,
+    formData: {},
+  },
+  () => {},
+]);
+
+export function useFormStepContext<FormStepData extends FieldValues>(
+  formStep: number,
+) {
+  const [state, dispatch] = useContext(FormStepContext);
+
+  const previousFormStep = useCallback(async () => {
+    dispatch({ type: 'PREV_STEP' });
+  }, [dispatch]);
+
+  const submitAndNextFormStep = useCallback(
+    (formValues: FormStepData) => {
+      dispatch({
+        type: 'SET_FORM_STEP_DATA',
+        formId: `form${formStep}`,
+        formValues,
+      });
+      dispatch({ type: 'NEXT_STEP' });
+    },
+    [dispatch, formStep],
+  );
+
+  return {
+    isActive: state.activeStep === formStep,
+    activeStep: state.activeStep,
+    setActiveStep: (step: number) => dispatch({ type: 'SET_STEP', step }),
+    previousFormStep,
+    submitAndNextFormStep,
+    formData: state.formData,
+  };
+}
+
+type Action =
+  | { type: 'SET_STEP'; step: number }
+  | { type: 'NEXT_STEP' }
+  | { type: 'PREV_STEP' }
+  | { type: 'SET_FORM_STEP_DATA'; formId: string; formValues: unknown };
+
+type State<T> = {
+  activeStep: number;
+  formData: T;
+};
+
+function formStepReducer<T>(state: State<T>, action: Action) {
+  switch (action.type) {
+    case 'NEXT_STEP': {
+      return {
+        ...state,
+        activeStep: state.activeStep + 1,
+      };
+    }
+    case 'PREV_STEP': {
+      return {
+        ...state,
+        activeStep: Math.max(state.activeStep - 1, 1),
+      };
+    }
+    case 'SET_STEP': {
+      return {
+        ...state,
+        activeStep: action.step,
+      };
+    }
+    case 'SET_FORM_STEP_DATA': {
+      return {
+        ...state,
+        formData: {
+          ...state.formData,
+          [action.formId]: action.formValues,
+        },
+      };
+    }
+  }
+}
+
+export function FormStepProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(formStepReducer, {
+    activeStep: 1,
+    formData: {},
+  });
+
+  const context = useMemo(() => {
+    return [state, dispatch] as const;
+  }, [state, dispatch]);
+
+  return (
+    <FormStepContext.Provider value={context}>
+      {children}
+    </FormStepContext.Provider>
+  );
+}

--- a/packages/react/src/Form/MultiStep/FormStepHeader.tsx
+++ b/packages/react/src/Form/MultiStep/FormStepHeader.tsx
@@ -18,11 +18,10 @@ export const FormStepHeader = (props: FormStepHeaderProps) => {
   return (
     <button
       type="button"
-      aria-label={collapsed ? `Åpne steg ${step}` : `Steg ${step} er åpent`}
+      aria-disabled={collapsed}
       onClick={onClick}
-      disabled={collapsed && formStatus !== 'completed'}
       className={classNames(className, 'w-full py-4 pl-4 md:py-8 ', {
-        'bg-blue-dark cursor-default': !collapsed,
+        'bg-blue-dark': !collapsed,
         'border-black bg-white': collapsed && formStatus !== 'completed',
 
         'border-green bg-green text-white':

--- a/packages/react/src/Form/MultiStep/FormStepHeader.tsx
+++ b/packages/react/src/Form/MultiStep/FormStepHeader.tsx
@@ -75,7 +75,7 @@ export const FormStepHeaderContent = (props: FormStepHeaderContentProps) => {
   return (
     <h2
       className={classNames(
-        'w-fitn grid grid-cols-[auto_1fr] grid-rows-[1fr_auto] items-center text-left text-xl font-bold md:text-2xl',
+        'grid grid-cols-[auto_1fr] grid-rows-[1fr_auto] items-center text-left text-xl font-bold md:text-2xl',
         {
           'text-white': !collapsed,
         },

--- a/packages/react/src/Form/MultiStep/FormStepHeader.tsx
+++ b/packages/react/src/Form/MultiStep/FormStepHeader.tsx
@@ -1,0 +1,110 @@
+import { CheckCircle } from '@obosbbl/grunnmuren-icons';
+import { ReactNode, useMemo } from 'react';
+import { FormStatus } from './FormStep';
+import classNames from 'clsx';
+
+export interface FormStepHeaderProps {
+  className?: string;
+  collapsed: boolean;
+  step: number;
+  onClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  children: ReactNode;
+  formStatus: FormStatus;
+}
+
+export const FormStepHeader = (props: FormStepHeaderProps) => {
+  const { className, collapsed, step, onClick, children, formStatus } = props;
+
+  return (
+    <button
+      type="button"
+      aria-label={collapsed ? `Åpne steg ${step}` : `Steg ${step} er åpent`}
+      onClick={onClick}
+      disabled={collapsed && formStatus !== 'completed'}
+      className={classNames(className, 'w-full py-4 pl-4 md:py-8 ', {
+        'bg-blue-dark cursor-default': !collapsed,
+        'border-black bg-white': collapsed && formStatus !== 'completed',
+
+        'border-green bg-green text-white':
+          collapsed && formStatus === 'completed',
+      })}
+    >
+      <FormStepHeaderContent
+        collapsed={collapsed}
+        step={step}
+        formStatus={formStatus}
+      >
+        {children}
+      </FormStepHeaderContent>
+    </button>
+  );
+};
+
+export interface FormStepHeaderContentProps {
+  collapsed: boolean;
+  step: number;
+  children: ReactNode;
+  formStatus: FormStatus;
+}
+
+export const FormStepHeaderContent = (props: FormStepHeaderContentProps) => {
+  const { collapsed, step, children, formStatus } = props;
+
+  const statusText = useMemo(() => {
+    switch (formStatus) {
+      case 'blank':
+        return 'Ikke utfylt';
+      case 'completed':
+        return 'Fullført';
+    }
+  }, [formStatus]);
+
+  const statusIcon = useMemo(() => {
+    if (!collapsed) {
+      return <div>{step}</div>;
+    }
+
+    switch (formStatus) {
+      case 'blank':
+        return <div>{step}</div>;
+      case 'completed':
+        return <CheckCircle className="h-10 w-10 md:h-12 md:w-12" />;
+    }
+  }, [formStatus, step, collapsed]);
+
+  return (
+    <h2
+      className={classNames(
+        'w-fitn grid grid-cols-[auto_1fr] grid-rows-[1fr_auto] items-center text-left text-xl font-bold md:text-2xl',
+        {
+          'text-white': !collapsed,
+        },
+      )}
+    >
+      <div
+        className={classNames(
+          'row-span-2 mr-4 flex h-10 w-10 items-center justify-center self-center rounded-full border-2 font-bold md:h-12 md:w-12',
+          {
+            'border-white text-white': !collapsed,
+            'border-black': collapsed && formStatus !== 'completed',
+            'border-none': formStatus === 'completed' && collapsed,
+          },
+        )}
+        role="text"
+      >
+        {statusIcon}
+      </div>
+      {children}
+      {collapsed && (
+        <div
+          className={classNames(
+            'text-base font-normal',
+            formStatus === 'completed' ? 'text-white' : 'text-black',
+          )}
+        >
+          {statusText}
+        </div>
+      )}
+    </h2>
+  );
+};

--- a/packages/react/src/Form/MultiStep/index.ts
+++ b/packages/react/src/Form/MultiStep/index.ts
@@ -1,0 +1,3 @@
+export * from './FormStep';
+export * from './FormStepContext';
+export * from './FormStepHeader';

--- a/packages/react/src/Form/index.ts
+++ b/packages/react/src/Form/index.ts
@@ -4,3 +4,4 @@ export * from './FormErrorMessage';
 export * from './FormHelperText';
 export * from './FormLabel';
 export * from './FormSuccess';
+export * from './MultiStep';

--- a/packages/react/src/Form/stories/Form.stories.tsx
+++ b/packages/react/src/Form/stories/Form.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Form as GmForm,
   FormError as GmFormError,
@@ -5,7 +6,12 @@ import {
   FormErrorMessage,
   FormHelperText,
   FormSuccess,
+  useFormStepContext,
+  FormStep,
+  TextField,
+  Button,
 } from '../..';
+import { FormStatus, FormStepProvider } from '../MultiStep';
 
 const metadata = {
   title: 'Forms',
@@ -42,4 +48,59 @@ export const Form = () => {
 
 export const FormError = () => {
   return <GmFormError />;
+};
+
+export const MultiStep = () => {
+  const FormStep1 = () => {
+    const { submitAndNextFormStep } = useFormStepContext<FormData1>(1);
+    const [formStatus, setFormStatus] = useState<FormStatus>('blank');
+
+    return (
+      <FormStep
+        step={1}
+        heading="Form step 1"
+        formStatus={formStatus}
+        onSubmit={(data) => {
+          data.preventDefault();
+          setFormStatus('completed');
+          submitAndNextFormStep({ name: 'test' });
+        }}
+      >
+        <div className="grid gap-4">
+          <TextField label="name" />
+          <Button type="submit">Submit</Button>
+        </div>
+      </FormStep>
+    );
+  };
+
+  const FormStep2 = () => {
+    return (
+      <FormStep
+        step={2}
+        heading="Form step 2"
+        formStatus="blank"
+        onSubmit={(e) => e.preventDefault()}
+      >
+        <div className="grid gap-4">
+          <TextField label="name" />
+          <Button type="submit">Submit</Button>
+        </div>
+      </FormStep>
+    );
+  };
+
+  return (
+    <FormStepProvider>
+      <div className="grid gap-2">
+        <FormStep1 />
+
+        <FormStep2 />
+      </div>
+    </FormStepProvider>
+  );
+};
+
+type FormData1 = {
+  name: string;
 };


### PR DESCRIPTION


Endringer
- Fjernet aria-hidden på *
- header er alltid button, men disabled hvis formStatus !== completed og den er Collapsed
- FormStep Counter er inne i header, samme er description (ikke utfylt, completed osv)
- Fokus på neste steg etter at man har trykka på neste (fokus skal på button, og ikke på første input)



I teorien så har jeg nå lagt til prelease mode i changeset i `next`-branchen. Denne merges inn til next-branchen og så lages det en beta-release som vi kan teste med. Har ikke fått testa dette, så blir spennende når det blir merga inn