### PR TITLE
formstep: add css relative to FormStep 

### DIFF
--- a/.changeset/hip-melons-scream.md
+++ b/.changeset/hip-melons-scream.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+add `relative` to FormStep.tsx for better popover support

--- a/packages/react/src/Form/MultiStep/FormStep.tsx
+++ b/packages/react/src/Form/MultiStep/FormStep.tsx
@@ -28,6 +28,7 @@ export const FormStep = (props: FormStepProps) => {
     step,
     formStatus = 'blank',
     onSubmit,
+    className,
     ...rest
   } = props;
   const { isActive, setActiveStep, activeStep } = useFormStepContext(step);
@@ -50,9 +51,12 @@ export const FormStep = (props: FormStepProps) => {
   return (
     <form
       className={classNames(
-        'border-blue-dark block overflow-hidden rounded-lg border-2',
-        { 'rounded-t-2xl md:rounded-t-3xl': step === 1 },
-        { 'border-none': formStatus === 'completed' && !isActive },
+        'border-blue-dark relative block overflow-hidden rounded-lg border-2',
+        className,
+        {
+          'rounded-t-2xl md:rounded-t-3xl': step === 1,
+          'border-none': formStatus === 'completed' && !isActive,
+        },
       )}
       onSubmit={onSubmit}
       ref={formRef}


### PR DESCRIPTION
Better popover support in forms if we add relative or at least possibility to send classNames down