### PR TITLE
formStep: export more states from formStepContext

### DIFF
--- a/.changeset/quiet-pigs-look.md
+++ b/.changeset/quiet-pigs-look.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+FormStep: export setFormData, nextFormStep from formStepContext and add new useFormContext to get formData and activeStep without using a step

--- a/packages/react/src/Form/MultiStep/FormStepContext.tsx
+++ b/packages/react/src/Form/MultiStep/FormStepContext.tsx
@@ -22,6 +22,15 @@ const FormStepContext = createContext<
   () => {},
 ]);
 
+export function useFormContext() {
+  const [state] = useContext(FormStepContext);
+
+  return {
+    activeStep: state.activeStep,
+    formData: state.formData,
+  };
+}
+
 export function useFormStepContext<FormStepData extends FieldValues>(
   formStep: number,
 ) {
@@ -31,16 +40,27 @@ export function useFormStepContext<FormStepData extends FieldValues>(
     dispatch({ type: 'PREV_STEP' });
   }, [dispatch]);
 
-  const submitAndNextFormStep = useCallback(
+  const setFormData = useCallback(
     (formValues: FormStepData) => {
       dispatch({
         type: 'SET_FORM_STEP_DATA',
         formId: `form${formStep}`,
         formValues,
       });
-      dispatch({ type: 'NEXT_STEP' });
     },
     [dispatch, formStep],
+  );
+
+  const nextFormStep = useCallback(() => {
+    dispatch({ type: 'NEXT_STEP' });
+  }, [dispatch]);
+
+  const submitAndNextFormStep = useCallback(
+    (formValues: FormStepData) => {
+      setFormData(formValues);
+      nextFormStep();
+    },
+    [nextFormStep, setFormData],
   );
 
   return {
@@ -48,7 +68,9 @@ export function useFormStepContext<FormStepData extends FieldValues>(
     activeStep: state.activeStep,
     setActiveStep: (step: number) => dispatch({ type: 'SET_STEP', step }),
     previousFormStep,
+    nextFormStep,
     submitAndNextFormStep,
+    setFormData,
     formData: state.formData,
   };
 }


### PR DESCRIPTION
Kanskje litt overkill?

useFormContext som returnerer
- formData
- activeStep

useFormStepContext returnerer i tillegg
- nextFormStep (bare går videre til neste)
- setFormData (setter formdata for steget)