### PR TITLE
remove no longer needed prettier plugin loading workaround

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,6 +1,5 @@
 module.exports = {
   singleQuote: true,
   trailingComma: 'all',
-  // Workaround symlinked plugins (pnpm) not being autodetected https://github.com/prettier/prettier/issues/8056
-  plugins: [require.resolve('prettier-plugin-tailwindcss')],
+  plugins: ['prettier-plugin-tailwindcss'],
 };


### PR DESCRIPTION
as it was fixed in Prettier v3. See https://github.com/prettier/prettier/issues/8056


This would also allow us to convert the config file to JSON or ESM if we want to.