### PR TITLE
add changeset to prepare for release

### DIFF
--- a/.changeset/many-oranges-drum.md
+++ b/.changeset/many-oranges-drum.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+update dependency react-collapsed for better Safari <= 13 compatibility


### PR DESCRIPTION
This PR only adds a changeset to do an automated release. React-collapsed was updated in https://github.com/code-obos/grunnmuren/pull/493, and I want to do a patch release of this, as I think it fixes an issue I see for Safari in Sentry