### PR TITLE
Export all campaign components and types

### DIFF
--- a/.changeset/poor-cycles-pretend.md
+++ b/.changeset/poor-cycles-pretend.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Export all the Campaign components and types

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -58,7 +58,7 @@ const CampaignInner = <T extends React.ElementType = 'div'>(
   );
 };
 
-export const CampaignBase = forwardRef(CampaignInner);
+const CampaignBase = forwardRef(CampaignInner);
 
 export interface CampaignBodyProps
   extends React.ComponentPropsWithoutRef<'div'> {}

--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -12,7 +12,7 @@ import { cx } from '@/utils';
 // The context controls the alignment of the body vs the image
 const CampaignContext = createContext(true);
 
-interface CampaignProps<T extends React.ElementType> {
+export interface CampaignProps<T extends React.ElementType> {
   /** @default div */
   as?: T;
   body: React.ReactElement;
@@ -58,11 +58,12 @@ const CampaignInner = <T extends React.ElementType = 'div'>(
   );
 };
 
-const CampaignBase = forwardRef(CampaignInner);
+export const CampaignBase = forwardRef(CampaignInner);
 
-interface CampaignBodyProps extends React.ComponentPropsWithoutRef<'div'> {}
+export interface CampaignBodyProps
+  extends React.ComponentPropsWithoutRef<'div'> {}
 
-const CampaignBody = forwardRef<HTMLDivElement, CampaignBodyProps>(
+export const CampaignBody = forwardRef<HTMLDivElement, CampaignBodyProps>(
   (props, ref) => {
     const { className, ...rest } = props;
     return (
@@ -75,9 +76,10 @@ const CampaignBody = forwardRef<HTMLDivElement, CampaignBodyProps>(
   },
 );
 
-interface CampaignImageProps extends React.ComponentPropsWithoutRef<'img'> {}
+export interface CampaignImageProps
+  extends React.ComponentPropsWithoutRef<'img'> {}
 
-const CampaignImage = forwardRef<HTMLImageElement, CampaignImageProps>(
+export const CampaignImage = forwardRef<HTMLImageElement, CampaignImageProps>(
   (props, ref) => {
     const { className: classNameProp, children, ...rest } = props;
 


### PR DESCRIPTION
Siden det ikke er lov å bruke dot-notasjon på klient komponenter i RSC, så er en midlertidig løsning å eksponere alle komponentene sånn at vi kan bruke `<CampaignBody>,<CampaignImage>` hver for seg i stedet for `<Campaign.Body>, <Campaign.Image>`  