### PR TITLE
Endret min-width for når stort bilde brukes

### DIFF
--- a/.changeset/short-eggs-shave.md
+++ b/.changeset/short-eggs-shave.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fikset URL som velges i Hero Image for ulike bredder

--- a/packages/react/src/Hero/HeroImage.tsx
+++ b/packages/react/src/Hero/HeroImage.tsx
@@ -32,7 +32,7 @@ export const HeroImage = forwardRef<HTMLPictureElement, HeroImageProps>(
         }
         ref={ref}
       >
-        <source media="(min-width: 768px)" srcSet={props.mdSrc} />
+        <source media="(min-width: 640px)" srcSet={props.mdSrc} />
         <img
           className="object-cover"
           decoding="async"


### PR DESCRIPTION
Layout og aspect-ratio på hero-bilde endres ved 640 px bredde, mens URL-en ble endret ved 768 px bredde. Fikset slik at URL-en også byttes ved 640 px bredde. 