### PR TITLE
fix: add support for moduleResolution Bundler

### DIFF
--- a/.changeset/happy-socks-pay.md
+++ b/.changeset/happy-socks-pay.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+add support for moduleResolution `Bundler` in TS

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,14 +3,14 @@
   "version": "1.14.6",
   "description": "OBOS Grunnmuren design system React components",
   "license": "MIT",
+  "type": "module",
   "repository": {
     "url": "https://github.com/code-obos/grunnmuren",
     "directory": "packages/react"
   },
   "exports": {
-    ".": {
-      "import": "./dist/grunnmuren.mjs"
-    }
+    "types": "./dist/index.d.ts",
+    "default": "./dist/grunnmuren.mjs"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Denne PRen fikser på package.json exports slik at Grunnmuren kan brukes i TS prosjekter som har[ moduleresolution](https://www.typescriptlang.org/tsconfig#moduleResolution) satt til `Bundler`.

Nye Next-prosjekter i TS setter `Bundler` by default, så greit at dette er på plass.

Før:
<img width="332" alt="Screenshot 2023-09-30 at 14 16 51" src="https://github.com/code-obos/grunnmuren/assets/81577/3f6e9d4c-a490-411d-b534-705104fa051f">

Etter:
<img width="349" alt="Screenshot 2023-09-30 at 14 16 06" src="https://github.com/code-obos/grunnmuren/assets/81577/0865e2b5-877c-4102-bebc-df69f3674594">

For Node16 får vi en [`Internal resolution error` ](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/InternalResolutionError.md) når jeg jeg sjekker package.json med [arethetypeswrong.io](https://github.com/arethetypeswrong/arethetypeswrong.github.io). I dokumentasjonen ser det ut til at det kan oppstå når man har bundlet og generert typene med forskjellige verktøy (noe vi gjør for denne pakken), men at bare kan være et potensielt problem for folk som ikke har `skipLibCheck: true` i `tsconfig.json`. Dette potensielle problemet har vi allerede fikset i v2, hvor vi bundler på en annen måte.

TLDR:
Før: Kun støtte for node10 i TS
Etter: Støtte for node10, bundler. Delvis støtte for Node16



