### PR TITLE
fix: package was broken because of wrong file extension

### DIFF
--- a/.changeset/big-lions-rule.md
+++ b/.changeset/big-lions-rule.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+fix broken package because of wrong file extension

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,14 +3,13 @@
   "version": "1.14.8",
   "description": "OBOS Grunnmuren design system React components",
   "license": "MIT",
-  "type": "module",
   "repository": {
     "url": "https://github.com/code-obos/grunnmuren",
     "directory": "packages/react"
   },
   "exports": {
     "types": "./dist/index.d.ts",
-    "default": "./dist/grunnmuren.mjs"
+    "import": "./dist/grunnmuren.mjs"
   },
   "files": [
     "dist"


### PR DESCRIPTION
I https://github.com/code-obos/grunnmuren/pull/586 forsøkte jeg å legge til støtte for TS' `"moduleResolution": "Bundler"`. Dette er default oppsettet for blant annet Next.js prosjekter i TS nå, så det gir mening at vi støtter dette i grunnmuren.

Det jeg ikke la merke til i den PRen er at siden jeg slang inn `type: module` i package.json, så endret plutselig vite på filendingen når den spyttet ut den bundlede filen. Da gikk den fra `.mjs` til `.js`.

```sh
# with "type: module"

> vite build

vite v4.4.9 building for production...
✓ 81 modules transformed.
dist/grunnmuren.js

# without "type: module"

> vite build

vite v4.4.9 building for production...
✓ 81 modules transformed.
dist/grunnmuren.mjs 
```

Dette knakk dermed pakken, for som man ser av exports feltet i package.json så peker den på `./dist/grunnmuren.mjs`, ikke `./dist/grunnmuren.js`.


Jeg går dermed tilbake til slik det var, ved å bruke en mjs extension. Jeg har ikke lyst til å endre dette i en minor, for det vil sannsynligvis knekke folk sine content scan konfigurasjoner i Tailwind-oppsettet deres.

TLDR:
Før første (broken PR) for å støtte `moduleResolution: Bundler`
<img width="332" alt="Screenshot 2023-09-30 at 14 16 51" src="https://github.com/code-obos/grunnmuren/assets/81577/411caace-f958-4281-96bf-12c069d43893">

Etter denne PRen:
<img width="337" alt="Screenshot 2023-10-04 at 12 49 34" src="https://github.com/code-obos/grunnmuren/assets/81577/d7d18420-28d9-4766-b3a9-358242c3f165">


