### PR TITLE
add loading spinner to Button

### DIFF
--- a/packages/react/src/utils/useClientLayoutEffect.ts
+++ b/packages/react/src/utils/useClientLayoutEffect.ts
@@ -1,0 +1,11 @@
+import { useLayoutEffect } from 'react';
+
+const canUseDOM = (): boolean => {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.document !== 'undefined' &&
+    typeof window.document.createElement !== 'undefined'
+  );
+};
+
+export const useClientLayoutEffect = canUseDOM() ? useLayoutEffect : () => {};


### PR DESCRIPTION
Denne PRen legger den bruker nå samme teknikk som NAV for å beholde bredden på knappen https://github.com/navikt/aksel/blob/main/%40navikt/core/react/src/button/Button.tsx, i stedet for den litt mer komplekse måten vi løste det på før https://github.com/code-obos/grunnmuren/blob/6cddc29ae9d37c486be954e35920710c0dde4bb6/packages/react/src/Button/Button.tsx#L96