### PR TITLE
add deploy status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Grunnmuren - OBOS' design system
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/62c234c7-3bb2-4592-a22f-ecb44d84f463/deploy-status)](https://app.netlify.com/sites/obos-grunnmuren/deploys)


### PR DESCRIPTION
Siden vi deployer storybooken til Netlify er det greit med en badge som viser statusen på deploy tenker jeg. READMEn trenger ganske mye mer utfylling, men tar ikke det som en del av denne tasken.

<img width="496" alt="Screenshot 2023-10-30 at 13 33 45" src="https://github.com/code-obos/grunnmuren/assets/81577/74622842-aa50-4866-ae21-0a62b2211372">



Docs for badge: https://docs.netlify.com/monitor-sites/status-badges/