### PR TITLE
Add Select component

### DIFF
--- a/.changeset/gentle-seas-boil.md
+++ b/.changeset/gentle-seas-boil.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+add Select component

--- a/.changeset/moody-rice-tie.md
+++ b/.changeset/moody-rice-tie.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-tailwind': minor
+---
+
+add Tailwind animation plugin

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,6 +28,10 @@
     "./textfield": {
       "types": "./dist/textfield/index.d.ts",
       "default": "./dist/textfield/index.mjs"
+    },
+    "./select": {
+      "types": "./dist/select/index.d.ts",
+      "default": "./dist/select/index.mjs"
     }
   },
   "files": [
@@ -50,7 +54,8 @@
       "./src/checkbox/index.ts",
       "./src/label/index.ts",
       "./src/radiogroup/index.ts",
-      "./src/textfield/index.ts"
+      "./src/textfield/index.ts",
+      "./src/select/index.ts"
     ],
     "declaration": true,
     "rollup": {

--- a/packages/react/src/select/Select.stories.tsx
+++ b/packages/react/src/select/Select.stories.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from '../button/Button';
+import { Select, SelectItem, SelectProps } from './Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Select',
+  component: Select,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+const Template = <T extends object>(args: SelectProps<T>) => {
+  const select = (
+    <Select {...args}>
+      <SelectItem id="agder">Agder</SelectItem>
+      <SelectItem id="innlandet">Innlandet</SelectItem>
+      <SelectItem id="more-og-romsdal">Møre og Romsdal</SelectItem>
+      <SelectItem id="oslo">Oslo</SelectItem>
+      <SelectItem id="rogaland">Rogaland</SelectItem>
+      <SelectItem id="trondelag">Trøndelag</SelectItem>
+      <SelectItem id="vestfold-og-telemark">Vestfold og Telemark</SelectItem>
+      <SelectItem id="viken">Viken</SelectItem>
+    </Select>
+  );
+  return args.isRequired ? (
+    <form
+      className="flex flex-col items-start gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert('Lagret!');
+      }}
+    >
+      {select}
+      <Button type="submit">Send inn</Button>
+    </form>
+  ) : (
+    select
+  );
+};
+
+const ControlledTemplate = <T extends object>(args: SelectProps<T>) => {
+  const [value, setValue] = useState<string | number>('oslo');
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Template {...args} selectedKey={value} onSelectionChange={setValue} />
+      <pre className="font-sans">{value}</pre>
+    </div>
+  );
+};
+
+const defaultProps = {
+  label: 'Velg område',
+  isRequired: false,
+  isInvalid: false,
+  name: undefined,
+  defaultSelectedKey: undefined,
+  selectedKey: undefined,
+  placeholder: 'Velg område',
+};
+
+export const Default: Story = {
+  render: Template,
+  args: { ...defaultProps },
+};
+
+export const Required: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isRequired: true,
+  },
+};
+
+export const WithDescription: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    description: 'OBOS bygger nye boliger over store deler av landet.',
+  },
+};
+
+export const WithoutLabel: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    label: undefined,
+    placeholder: 'Velg område',
+    'aria-label': 'Velg område',
+  },
+};
+
+export const IsInvalid: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isInvalid: true,
+  },
+};
+
+export const WithErrorMessage: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    errorMessage: 'Feltet er påkrevd',
+  },
+};
+
+export const Controlled = {
+  render: ControlledTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -1,0 +1,106 @@
+import { cx } from 'cva';
+import {
+  Button,
+  ListBox,
+  Popover,
+  Select as RACSelect,
+  type SelectProps as RACSelectProps,
+  SelectValue,
+  ListBoxItem,
+  ListBoxItemProps,
+} from 'react-aria-components';
+import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
+
+import { Label } from '../label/Label';
+import { Description } from '../label/Description';
+import { ErrorMessage } from '../label/ErrorMessage';
+
+type SelectProps<T extends object> = {
+  children: React.ReactNode;
+  /** Additional CSS className for the element. */
+  className?: string;
+  /** Help text for the form control. */
+  description?: React.ReactNode;
+  /** Error message for the form control. Automatically sets `isInvalid` to true */
+  errorMessage?: React.ReactNode;
+  /** Label for the form control. */
+  label?: React.ReactNode;
+  /** Placeholder text. Only visible when the input value is empty. */
+  placeholder?: string;
+  /** Additional style properties for the element. */
+  style?: React.CSSProperties;
+} & Omit<
+  RACSelectProps<T>,
+  'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
+>;
+
+function Select<T extends object>(props: SelectProps<T>) {
+  const {
+    className,
+    children,
+    description,
+    errorMessage,
+    label,
+    isInvalid: _isInvalid,
+    ...restProps
+  } = props;
+
+  const isInvalid = _isInvalid || errorMessage != null;
+
+  return (
+    <RACSelect
+      {...restProps}
+      className={cx(className, 'group flex flex-col gap-2')}
+      isInvalid={isInvalid}
+    >
+      {label && <Label>{label}</Label>}
+      {description && <Description>{description}</Description>}
+
+      <Button
+        className={cx(
+          'flex items-center gap-2',
+          'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6',
+          // focus
+          'ring-black focus:outline-none focus-visible:ring-2',
+          // invalid
+          'group-data-[invalid]:border-red',
+        )}
+      >
+        <SelectValue className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />
+        <ChevronDown className="text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none" />
+      </Button>
+
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+
+      <Popover className="min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out">
+        <ListBox className="text-sm outline-none">{children}</ListBox>
+      </Popover>
+    </RACSelect>
+  );
+}
+
+const SelectItem = (props: ListBoxItemProps) => {
+  return (
+    <ListBoxItem
+      {...props}
+      className={cx(
+        props.className,
+        'flex cursor-default px-6 py-2 leading-6 outline-none focus:bg-sky-lightest',
+      )}
+    >
+      {({ isSelected }) => (
+        <>
+          {isSelected && <Check className="-ml-6 text-base" />}
+          {props.children}
+        </>
+      )}
+    </ListBoxItem>
+  );
+};
+
+export {
+  Select,
+  SelectItem,
+  type SelectProps,
+  type ListBoxItemProps as SelectItemProps,
+};

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -58,7 +58,7 @@ function Select<T extends object>(props: SelectProps<T>) {
 
       <Button
         className={cx(
-          'flex items-center gap-2',
+          'flex cursor-default items-center gap-2',
           'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6',
           // focus
           'ring-black focus:outline-none focus-visible:ring-2',

--- a/packages/react/src/select/index.ts
+++ b/packages/react/src/select/index.ts
@@ -1,0 +1,6 @@
+export {
+  Select,
+  SelectItem,
+  type SelectProps,
+  type SelectItemProps,
+} from './Select';

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -49,7 +49,6 @@ function TextArea(props: TextAreaProps) {
     description,
     errorMessage,
     label,
-    isRequired,
     isInvalid: _isInvalid,
     rows,
     ...restProps
@@ -62,7 +61,6 @@ function TextArea(props: TextAreaProps) {
       {...restProps}
       className={cx(className, classes.base)}
       isInvalid={isInvalid}
-      isRequired={isRequired}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -78,7 +78,6 @@ function TextField(props: TextFieldProps) {
     errorMessage,
     label,
     leftAddon,
-    isRequired,
     isInvalid: _isInvalid,
     textAlign,
     rightAddon,
@@ -93,7 +92,6 @@ function TextField(props: TextFieldProps) {
       {...restProps}
       className={cx(className, classes.base)}
       isInvalid={isInvalid}
-      isRequired={isRequired}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",
-    "@tailwindcss/typography": "^0.5.10"
+    "@tailwindcss/typography": "^0.5.10",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "tailwindcss": "3.3.6"

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -47,6 +47,7 @@ module.exports = (options = {}) => {
     plugins: [
       ...v1CompatibilityPlugins,
       require('@tailwindcss/typography'),
+      require('tailwindcss-animate'),
       plugin(function ({ addBase, addComponents }) {
         addBase({
           html: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.10
         version: 0.5.10(tailwindcss@3.3.6)
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.3.6)
     devDependencies:
       tailwindcss:
         specifier: 3.3.6
@@ -11404,6 +11407,14 @@ packages:
     dependencies:
       '@pkgr/utils': 2.4.2
       tslib: 2.6.2
+    dev: false
+
+  /tailwindcss-animate@1.0.7(tailwindcss@3.3.6):
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+    dependencies:
+      tailwindcss: 3.3.6
     dev: false
 
   /tailwindcss@3.3.6:


### PR DESCRIPTION
Denne PRen inkluderer en første versjon av en Select komponent. Denne er helt i startfasen, da den ikke er helt ferdig skisset opp i Figma, så det kommer nok endringer her etter hvert.

Legger også til [tailwind-animate](https://github.com/jamiebuilds/tailwindcss-animate) pluginet. R[AC støtter animation states](https://react-spectrum.adobe.com/react-aria/styling.html#css-animations) som vi kan targete med Tailwind. Lagt til fade in/ut på nedtrekkslisten til Selecten. 