### PR TITLE
Compatibility support for v1 in v2 Tailwind preset

### DIFF
--- a/packages/tailwind/README.md
+++ b/packages/tailwind/README.md
@@ -48,6 +48,19 @@ Add the Tailwind directives to your CSS
 @tailwind utilities;
 ```
 
+Configure PostCSS to use Tailwind
+
+```js
+// postcss.config.js
+
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+```
+
 ## Migrating from v1?
 
 To ease the transition from v1 to v2 of Grunnmuren, it is possible to configure the preset to be (partially) compatible with v1. This allows you to use v2 of the Tailwind preset with v1 of the React components, and upgrade your application over time instead of a full migration.

--- a/packages/tailwind/README.md
+++ b/packages/tailwind/README.md
@@ -1,26 +1,66 @@
 # @obosbbl/grunnmuren-tailwind
 
-Grunnmuren Tailwind preset.
+[![npm version](https://badge.fury.io/js/@obosbbl%2Fgrunnmuren-tailwind.svg)](https://www.npmjs.com/package/@obosbbl/grunnmuren-tailwind)
+
+Grunnmuren Tailwind preset. See the [Tailwind documentation](https://tailwindcss.com/docs/presets) for more information about how presets work.
 
 ## Install
 
 ```sh
-npm install -D @obosbbl/grunnmuren-tailwind tailwindcss
+# npm
+npm install -D @obosbbl/grunnmuren-tailwind tailwindcss postcss autoprefixer
+
+# pnpm
+pnpm add -D @obosbbl/grunnmuren-tailwind tailwindcss postcss autoprefixer
+
+# yarn
+yarn add -D @obosbbl/grunnmuren-tailwind tailwindcss postcss autoprefixer
+
 ```
 
 ## Usage
 
+Configure Tailwind to use the preset
+
 ```js
 // tailwind.config.js
 
-// Regular usage
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   presets: [require('@obosbbl/grunnmuren-tailwind')],
   content: [
-    // If using this together with Grunnmuren's React components
-    './node_modules/@obosbbl/grunnmuren-react/dist/**/*.js',
     // Add your own content sources as needed, eg:
-    './src/components/**/*.{ts,tsx}',
+    './src/app/**/*.{js,ts,jsx,tsx,}',
+
+    // If you're using Grunnmuren's React components
+    './node_modules/@obosbbl/grunnmuren-react/dist/**/*.js',
+  ],
+};
+```
+
+Add the Tailwind directives to your CSS
+
+```css
+/* globals.css */
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+## Migrating from v1?
+
+To ease the transition from v1 to v2 of Grunnmuren, it is possible to configure the preset to be (partially) compatible with v1. This allows you to use v2 of the Tailwind preset with v1 of the React components, and upgrade your application over time instead of a full migration.
+
+To do that you need to configure the preset with `legacyV1Compatibility` option.
+
+```js
+// tailwind.config.js
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  presets: [
+    require('@obosbbl/grunnmuren-tailwind')({ legacyV1Compatibility: true }),
   ],
 };
 ```

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -13,7 +13,9 @@
   "files": [
     "tailwind-base.cjs"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@tailwindcss/typography": "^0.5.10"
+  },
   "devDependencies": {
     "tailwindcss": "3.3.4"
   },

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -14,12 +14,13 @@
     "tailwind-base.cjs"
   ],
   "dependencies": {
+    "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/typography": "^0.5.10"
   },
   "devDependencies": {
-    "tailwindcss": "3.3.4"
+    "tailwindcss": "3.3.5"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.4"
+    "tailwindcss": "^3.3.5"
   }
 }

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -184,7 +184,74 @@ module.exports = (options) => {
       fontFamily: {
         sans: [fontFamily, 'sans-serif'],
       },
+      extend: {
+        typography: (theme) => ({
+          DEFAULT: {
+            css: {
+              '--tw-prose-headings': 'inherit',
+              '--tw-prose-lead': 'inherit',
+              '--tw-prose-links': 'inherit',
+              '--tw-prose-quotes': theme('colors.blue.dark'),
+              '--tw-prose-quote-borders': theme('colors.green.DEFAULT'),
+              '--tw-prose-counters': theme('colors.black'),
+              // TODO: Increase bullet size. See design sketches
+              '--tw-prose-bullets': theme('colors.green.DEFAULT'),
+              color: theme('colors.black'),
+              maxWidth: theme('maxWidth.prose'),
+              a: {
+                fontWeight: 400,
+              },
+              h1: {
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.3xl'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.5xl'),
+                },
+              },
+              h2: {
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.2xl'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.4xl'),
+                },
+              },
+              h3: {
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.xl'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.2xl'),
+                },
+              },
+              h4: {
+                fontWeight: theme('fontWeight.bold'),
+                fontSize: theme('fontSize.lg'),
+                '@media (min-width: theme("screens.md"))': {
+                  fontSize: theme('fontSize.xl'),
+                },
+              },
+              li: {
+                marginTop: '1.5em',
+                marginBottom: '1.5em',
+              },
+              blockquote: {
+                fontWeight: theme('fontWeight.bold'),
+                fontStyle: 'normal',
+              },
+              'blockquote p:first-of-type::before': {
+                content: '"«"',
+              },
+              'blockquote p:last-of-type::after': {
+                content: '"»"',
+              },
+              '[class~="lead"]': {
+                fontWeight: theme('fontWeight.medium'),
+              },
+            },
+          },
+        }),
+      }
     },
+
   };
 };
 

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -23,15 +23,14 @@ const obosFonts = [
   },
 ];
 
-const defaultOpts = {
-  v1Compatiblity: false,
-};
+/**
+ * @param {boolean} options.legacyV1Compatibility
+ */
+module.exports = (options = {}) => {
+  const v1CompatibilityPlugins = [];
 
-module.exports = (options) => {
-  console.log('options', options);
-  const compatiblityPlugins = [];
-  if (options.v1Compatiblity) {
-    compatiblityPlugins.push(button, checkbox, radio, snackbar);
+  if (options.legacyV1Compatibility) {
+    v1CompatibilityPlugins.push(button, checkbox, radio, snackbar);
   }
 
   const fontFamily = 'OBOSFont';
@@ -40,7 +39,9 @@ module.exports = (options) => {
 
   return {
     plugins: [
-      ...compatiblityPlugins,
+      ...v1CompatibilityPlugins,
+      // TODO: Remove the aspect ratio plugin when Safari 14 usage is low enough
+      require('@tailwindcss/aspect-ratio'),
       require('@tailwindcss/typography'),
       plugin(function ({ addBase, addComponents }) {
         addBase({
@@ -85,7 +86,7 @@ module.exports = (options) => {
         const h3 = '@apply font-bold text-xl md:text-2xl';
         const h4 = '@apply font-bold text-lg md:text-xl';
 
-        if (options.v1Compatiblity) {
+        if (options.legacyV1Compatibility) {
           addBase({
             h1: {
               [h1]: {},
@@ -185,6 +186,21 @@ module.exports = (options) => {
         sans: [fontFamily, 'sans-serif'],
       },
       extend: {
+        maxWidth: {
+          // Override Tailwinds default prose width of 60 chars to 48. Roughly 590 pixels
+          prose: '696px',
+        },
+        width: {
+          prose: '696px',
+        },
+        spacing: {
+          18: '4.5rem',
+        },
+        borderColor: options.legacyV1Compatibility
+          ? ({ theme }) => ({
+              DEFAULT: theme('colors.gray.light', 'currentColor'),
+            })
+          : undefined,
         typography: (theme) => ({
           DEFAULT: {
             css: {
@@ -194,7 +210,6 @@ module.exports = (options) => {
               '--tw-prose-quotes': theme('colors.blue.dark'),
               '--tw-prose-quote-borders': theme('colors.green.DEFAULT'),
               '--tw-prose-counters': theme('colors.black'),
-              // TODO: Increase bullet size. See design sketches
               '--tw-prose-bullets': theme('colors.green.DEFAULT'),
               color: theme('colors.black'),
               maxWidth: theme('maxWidth.prose'),
@@ -249,13 +264,12 @@ module.exports = (options) => {
             },
           },
         }),
-      }
+      },
     },
-
   };
 };
 
-// V1 compatiblity
+// These custom components are only used for v1 compat
 const button = plugin(function ({ addComponents, theme }) {
   const hoverLoadingBgColor = 'rgba(0, 0, 0, 0.1)';
 

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -191,7 +191,7 @@ module.exports = (options = {}) => {
       },
       extend: {
         maxWidth: {
-          // Override Tailwinds default prose width of 60 chars to 48. Roughly 590 pixels
+          // Override Tailwinds default prose width of 60 chars.
           prose: '696px',
         },
         width: {

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -30,7 +30,13 @@ module.exports = (options = {}) => {
   const v1CompatibilityPlugins = [];
 
   if (options.legacyV1Compatibility) {
-    v1CompatibilityPlugins.push(button, checkbox, radio, snackbar);
+    v1CompatibilityPlugins.push(
+      button,
+      checkbox,
+      radio,
+      snackbar,
+      require('@tailwindcss/aspect-ratio'),
+    );
   }
 
   const fontFamily = 'OBOSFont';
@@ -40,8 +46,6 @@ module.exports = (options = {}) => {
   return {
     plugins: [
       ...v1CompatibilityPlugins,
-      // TODO: Remove the aspect ratio plugin when Safari 14 usage is low enough
-      require('@tailwindcss/aspect-ratio'),
       require('@tailwindcss/typography'),
       plugin(function ({ addBase, addComponents }) {
         addBase({

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -23,13 +23,26 @@ const obosFonts = [
   },
 ];
 
-module.exports = () => {
+const defaultOpts = {
+  v1Compatiblity: false,
+};
+
+module.exports = (options) => {
+  console.log('options', options);
+  const compatiblityPlugins = [];
+  if (options.v1Compatiblity) {
+    compatiblityPlugins.push(button, checkbox, radio, snackbar);
+  }
+
   const fontFamily = 'OBOSFont';
   const fonts = obosFonts;
+  const containerSize = '92rem';
 
   return {
     plugins: [
-      plugin(function ({ addBase }) {
+      ...compatiblityPlugins,
+      require('@tailwindcss/typography'),
+      plugin(function ({ addBase, addComponents }) {
         addBase({
           html: {
             '@apply text-black antialiased font-normal': {},
@@ -40,7 +53,68 @@ module.exports = () => {
           strong: {
             fontWeight: 500,
           },
+          a: {
+            'text-decoration': 'underline',
+          },
           '::selection': { '@apply bg-mint text-black': {} },
+        });
+
+        addComponents({
+          '.container': {
+            width: '100%',
+            paddingLeft: '1rem',
+            paddingRight: '1rem',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            maxWidth: containerSize,
+          },
+          '.container-prose': {
+            width: '100%',
+            paddingLeft: '1rem',
+            paddingRight: '1rem',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            maxWidth: '45.5rem',
+          },
+        });
+      }),
+
+      plugin(function ({ addBase, addComponents }) {
+        const h1 = '@apply font-bold text-3xl md:text-5xl';
+        const h2 = '@apply font-bold text-2xl md:text-4xl';
+        const h3 = '@apply font-bold text-xl md:text-2xl';
+        const h4 = '@apply font-bold text-lg md:text-xl';
+
+        if (options.v1Compatiblity) {
+          addBase({
+            h1: {
+              [h1]: {},
+            },
+            h2: {
+              [h2]: {},
+            },
+            h3: {
+              [h3]: {},
+            },
+            h4: {
+              [h4]: {},
+            },
+          });
+        }
+
+        addComponents({
+          '.h1': {
+            [h1]: {},
+          },
+          '.h2': {
+            [h2]: {},
+          },
+          '.h3': {
+            [h3]: {},
+          },
+          '.h4': {
+            [h4]: {},
+          },
         });
       }),
       plugin(function ({ addBase }) {
@@ -113,3 +187,154 @@ module.exports = () => {
     },
   };
 };
+
+// V1 compatiblity
+const button = plugin(function ({ addComponents, theme }) {
+  const hoverLoadingBgColor = 'rgba(0, 0, 0, 0.1)';
+
+  addComponents({
+    '.button': {
+      // The Tailwind utilities we use for focus styling are kinda hard to "translate", so using the @apply utility here, even though mixing styles are meh...
+      '@apply focus:outline-none focus-visible:ring-2 focus-visible:ring-black ring-offset-2':
+        {},
+      position: 'relative',
+      textDecorationLine: 'none',
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme('spacing.3'),
+      border: '2px solid',
+      padding: `${theme('spacing.2')} ${theme('spacing.6')}`,
+      borderRadius: '0.75rem',
+      transition: `all 200ms ${theme('transitionTimingFunction.DEFAULT')}`,
+      fontWeight: theme('fontWeight.medium'),
+      width: 'fit-content',
+      '&:disabled': {
+        backgroundColor: theme('colors.gray.light'),
+        borderColor: theme('colors.gray.light'),
+        color: theme('colors.black'),
+        pointerEvents: 'none',
+      },
+      '&:hover': {
+        borderRadius: '0.375rem',
+      },
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        backgroundColor: 'transparent',
+        display: 'block',
+        top: '-2px',
+        left: '-2px',
+        right: '-2px',
+        bottom: '-2px',
+        borderRadius: 'inherit',
+      },
+      // adds a shade on the button when hovered
+      // ideally this would be solved by just darkening the button background,
+      // but that doesn't really work since some of the button variations have transparent backgrounds
+      '&:hover::after': {
+        backgroundColor: hoverLoadingBgColor,
+        transition: `all 200ms ${theme('transitionTimingFunction.DEFAULT')}`,
+      },
+      // We use aria-busy to indicate loading state
+      '&[aria-busy="true"] > *': {
+        visibility: 'hidden',
+      },
+      '&[aria-busy="true"]::after': {
+        backgroundColor: hoverLoadingBgColor,
+      },
+    },
+  });
+});
+
+const radio = plugin(function ({ addComponents, theme }) {
+  addComponents({
+    '.radio': {
+      // hide the native radio input
+      appearance: 'none',
+      // not removed via appeareance
+      margin: 0,
+      height: '1.25rem',
+      width: '1.25rem',
+      borderRadius: '50%',
+      border: `2px solid ${theme('colors.gray.dark')}`,
+      cursor: 'pointer',
+      // use grid to handle the checked:before styles
+      display: 'inline-grid',
+      placeContent: 'center',
+      // Prevent flex container from altering the size of the radio button
+      flex: '0 0 auto',
+      // magic number that tries to keep the input horizontally centered in relation to the first line of the label text
+      transform: 'translateY(0.095em)',
+      '&:checked': {
+        borderColor: theme('colors.green.DEFAULT'),
+      },
+      '&:focus-visible': {
+        outline: '1px solid currentColor',
+        outlineOffset: '4px',
+      },
+      '&::before': {
+        content: '""',
+        display: 'block',
+        borderRadius: '50%',
+        transform: 'scale(0)',
+        width: '0.65em',
+        height: '0.65em',
+        transition: '120ms transform ease-in-out',
+        boxShadow: `inset 1em 1em ${theme('colors.green.DEFAULT')}`,
+        /* Windows High Contrast Mode */
+        backgroundColor: 'CanvasText',
+      },
+      '&:checked::before': {
+        transform: 'scale(1)',
+      },
+    },
+  });
+});
+
+const checkbox = plugin(function ({ addComponents, theme }) {
+  addComponents({
+    '.checkbox': {
+      '&::before': {
+        content: '""',
+        width: '0.65em',
+        height: '0.65em',
+        transform: 'scale(0)',
+        transition: '120ms transform ease-in-out',
+        backgroundColor: theme('colors.white'),
+        'box-shadow': 'inset 1em 1em currentColor',
+        'clip-path':
+          'polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%)',
+      },
+      '&:checked::before': {
+        transform: 'scale(1)',
+      },
+    },
+  });
+});
+
+const snackbar = plugin(function ({ addComponents, theme }) {
+  addComponents({
+    '.snackbar': {
+      'grid-template-columns': 'min-content auto',
+      'grid-template-areas': '"icon header" ". content" "actions actions"',
+    },
+    [`@media(min-width: ${theme('screens.md')})`]: {
+      '.snackbar': {
+        'grid-template-columns': 'min-content auto auto',
+        'grid-template-areas': '"icon header actions" ". content content"',
+      },
+    },
+    '.snackbar-icon': {
+      'grid-area': 'icon',
+    },
+    '.snackbar-header': {
+      'grid-area': 'header',
+    },
+    '.snackbar-content': {
+      'grid-area': 'content',
+    },
+    '.snackbar-actions': {
+      'grid-area': 'actions',
+    },
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,13 +150,16 @@ importers:
 
   packages/tailwind:
     dependencies:
+      '@tailwindcss/aspect-ratio':
+        specifier: ^0.4.2
+        version: 0.4.2(tailwindcss@3.3.5)
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.10(tailwindcss@3.3.4)
+        version: 0.5.10(tailwindcss@3.3.5)
     devDependencies:
       tailwindcss:
-        specifier: 3.3.4
-        version: 3.3.4
+        specifier: 3.3.5
+        version: 3.3.5
 
 packages:
 
@@ -5172,7 +5175,15 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@tailwindcss/typography@0.5.10(tailwindcss@3.3.4):
+  /@tailwindcss/aspect-ratio@0.4.2(tailwindcss@3.3.5):
+    resolution: {integrity: sha512-8QPrypskfBa7QIMuKHg2TA7BqES6vhBrDLOv8Unb6FcFyd3TjKbc6lcmb9UPQHxfl24sXoJ41ux/H7qQQvfaSQ==}
+    peerDependencies:
+      tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
+    dependencies:
+      tailwindcss: 3.3.5
+    dev: false
+
+  /@tailwindcss/typography@0.5.10(tailwindcss@3.3.5):
     resolution: {integrity: sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
@@ -5181,7 +5192,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.3.4
+      tailwindcss: 3.3.5
     dev: false
 
   /@trysound/sax@0.2.0:
@@ -11566,6 +11577,37 @@ packages:
 
   /tailwindcss@3.3.4:
     resolution: {integrity: sha512-JXZNOkggUAc9T5E7nCrimoXHcSf9h3NWFe5sh36CGD/3M5TRLuQeFnQoDsit2uVTqgoOZHLx5rTykLUu16vsMQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.5.3
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.1
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.20.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.31
+      postcss-import: 15.1.0(postcss@8.4.31)
+      postcss-js: 4.0.1(postcss@8.4.31)
+      postcss-load-config: 4.0.1(postcss@8.4.31)
+      postcss-nested: 6.0.1(postcss@8.4.31)
+      postcss-selector-parser: 6.0.13
+      resolve: 1.22.8
+      sucrase: 3.34.0
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
+  /tailwindcss@3.3.5:
+    resolution: {integrity: sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,10 @@ importers:
         version: 1.0.0-rc.0(react-dom@18.2.0)(react@18.2.0)
 
   packages/tailwind:
+    dependencies:
+      '@tailwindcss/typography':
+        specifier: ^0.5.10
+        version: 0.5.10(tailwindcss@3.3.4)
     devDependencies:
       tailwindcss:
         specifier: 3.3.4
@@ -5168,6 +5172,18 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@tailwindcss/typography@0.5.10(tailwindcss@3.3.4):
+    resolution: {integrity: sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.3.4
+    dev: false
+
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -9216,8 +9232,16 @@ packages:
       p-locate: 5.0.0
     dev: false
 
+  /lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+    dev: false
+
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+    dev: false
+
+  /lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
     dev: false
 
   /lodash.merge@4.6.2:
@@ -10175,6 +10199,14 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
+
+  /postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+    dev: false
 
   /postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}


### PR DESCRIPTION
Denne PRen legger til støtte for å kjøre versjon 2 av presetet i en slags v1 kompabilitetsmodus. Dette enables ved å kjøre presetet med følgende options:

```js
// tailwind.config.js

/** @type {import('tailwindcss').Config} */
module.exports = {
  presets: [
    require('@obosbbl/grunnmuren-tailwind')({ legacyV1Compatibility: true }),
  ],
};
```

Det betyr ikke full bakoverkompabilitet, men den er god nok til at versjon 2 av presetet kan kjøres sammen med versjon 1 av React komponentene. Dette lar deg ta i bruk v2 uten at du nødvendigvis må gjøre en full migrering fra v1 til v2, men heller kan gjøre det over tid.

~~gjør vi med aspect-ratio pluginet? Skal vi bare legge det til i kompabilitetsmodus, eller skal det være enabled by default? Her må vi se på browserstatistikk og hvilke browsere vi supporterer. Jeg oppretter en egen oppgave på det.~~

Diskutert litt med @ingara. Legger aspect-ratio pluginet bak compat flagget.