### PR TITLE
v2 error message and description design changes

### DIFF
--- a/packages/react/src/label/Description.tsx
+++ b/packages/react/src/label/Description.tsx
@@ -12,7 +12,7 @@ function Description(props: DescriptionProps) {
   return (
     <Text
       {...restProps}
-      className={cx(className, 'text-sm text-gray-dark')}
+      className={cx(className, 'text-sm font-light leading-6')}
       slot="description"
     />
   );

--- a/packages/react/src/label/ErrorMessage.tsx
+++ b/packages/react/src/label/ErrorMessage.tsx
@@ -1,6 +1,5 @@
 import { cx } from 'cva';
 import { Text } from 'react-aria-components';
-import { Warning } from '@obosbbl/grunnmuren-icons-react';
 
 type ErrorMessageProps = {
   className?: string;
@@ -14,11 +13,10 @@ function ErrorMessage(props: ErrorMessageProps) {
       {...restProps}
       className={cx(
         className,
-        'flex items-center gap-2 rounded bg-red-light px-2 py-1 text-sm text-red',
+        'w-fit rounded-sm bg-red-light px-2 py-1 text-sm leading-6 text-red',
       )}
       slot="errorMessage"
     >
-      <Warning className="flex-shrink-0 text-red" />
       {children}
     </Text>
   );

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -94,9 +94,9 @@ module.exports = () => {
           dark: '#00524C',
         },
         red: {
-          DEFAULT: '#cd465e',
+          DEFAULT: '#C0385D',
           // error red
-          light: '#faedef',
+          light: '#FAEDEF',
         },
         orange: {
           DEFAULT: '#e8a74a',


### PR DESCRIPTION
Adjust error message and description after [design changes in Figma](https://www.figma.com/file/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=407%3A5976&mode=dev)

<img width="255" alt="Screenshot 2023-11-06 at 18 44 43" src="https://github.com/code-obos/grunnmuren/assets/81577/5ccf5e41-08e6-4941-9e74-ddb519e9c3bd">

The reds are updated for improved contrast and accessibility. In addition the icon has been removed from the error message.