### PR TITLE
Add Checkbox and CheckboxGroup to v2

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,9 @@
+import { addons } from '@storybook/manager-api';
+
+// Allows us to place CheckboxGroup under Checkbox as a folder instead of a new root
+// https://storybook.js.org/docs/react/configure/sidebar-and-urls#roots
+addons.setConfig({
+  sidebar: {
+    showRoots: false,
+  },
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,6 +13,10 @@
       "types": "./dist/button/Button.d.ts",
       "default": "./dist/button/Button.mjs"
     },
+    "./checkbox": {
+      "types": "./dist/checkbox/index.d.ts",
+      "default": "./dist/checkbox/index.mjs"
+    },
     "./label": {
       "types": "./dist/label/index.d.ts",
       "default": "./dist/label/index.mjs"
@@ -43,6 +47,7 @@
   "unbuild": {
     "entries": [
       "./src/button/Button.tsx",
+      "./src/checkbox/index.ts",
       "./src/label/index.ts",
       "./src/radiogroup/index.ts",
       "./src/textfield/index.ts"

--- a/packages/react/src/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/checkbox/Checkbox.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Checkbox } from './Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Checkbox',
+  component: Checkbox,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Example: Story = {
+  args: {
+    children: 'Jeg godtar medlemsvilkårene',
+    isRequired: true,
+  },
+};

--- a/packages/react/src/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/checkbox/Checkbox.stories.tsx
@@ -14,6 +14,7 @@ type Story = StoryObj<typeof Checkbox>;
 export const Example: Story = {
   args: {
     children: 'Jeg godtar medlemsvilkårene',
-    isRequired: true,
+    isRequired: false,
+    isInvalid: false,
   },
 };

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -5,30 +5,29 @@ import {
 } from 'react-aria-components';
 import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
 
-const defaultClasses = cx(['flex cursor-pointer items-center gap-2 leading-7']);
+const defaultClasses = cx([
+  'group flex cursor-pointer items-center gap-4 leading-7',
+]);
 
-function Checkmark({
-  isSelected,
-  isFocusVisible,
-  isHovered,
-  isInvalid,
-}: {
-  isSelected: boolean;
-  isFocusVisible: boolean;
-  isHovered: boolean;
-  isInvalid: boolean;
-}) {
+// Pulling this out into it's own component. Will probably export it in the future
+// so it can be used in other views, outside of an input of type checkbox, like in table rows.
+function CheckmarkBox() {
   return (
     <div
-      className={cx(
-        'grid h-6 w-6 place-content-center rounded-sm border-2 border-black p-0.5 text-white',
-        isSelected ? 'bg-green' : '[&>svg]:hidden',
-        isFocusVisible && 'ring-2 ring-black ring-offset-[10px]',
-        isHovered && ' bg-green shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
-        isInvalid && 'border-red',
-      )}
+      className={cx([
+        'relative z-0 grid h-6 w-6 place-content-center rounded-sm border-2 border-black p-1 text-white',
+        // selected
+        'group-data-[selected]:border-green group-data-[selected]:bg-green',
+        // focus
+        'group-data-[focus-visible]:ring-2 group-data-[focus-visible]:ring-black group-data-[focus-visible]:ring-offset-[9px]',
+        // hovered
+        'before:z-0 before:h-3 before:w-3 before:rounded-sm group-data-[selected=true]:before:hidden group-data-[hovered]:before:bg-green',
+        // invalid - The border is 1 px thicker when invalid. We don't actually want to change the border width, as that causes the element's size to change
+        // so we use an inner shadow of 1 px instead to pad the actual border
+        'group-data-[invalid]:border-red group-data-[invalid]:group-data-[selected]:shadow-none group-data-[invalid]:shadow-[inset_0_0_0_1px] group-data-[invalid]:shadow-red group-data-[hovered]:group-data-[invalid]:before:bg-red',
+      ])}
     >
-      <CheckIcon className="h-full w-full" />
+      <CheckIcon className="h-full w-full opacity-0 group-data-[selected]:opacity-100" />
     </div>
   );
 }
@@ -49,17 +48,8 @@ function Checkbox(props: CheckboxProps) {
       className={cx(className, defaultClasses)}
       autoFocus
     >
-      {({ isSelected, isFocusVisible, isHovered, isInvalid }) => (
-        <>
-          <Checkmark
-            isSelected={isSelected}
-            isFocusVisible={isFocusVisible}
-            isHovered={isHovered}
-            isInvalid={isInvalid}
-          />
-          {children}
-        </>
-      )}
+      <CheckmarkBox />
+      {children}
     </RACCheckbox>
   );
 }

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -1,0 +1,63 @@
+import { cx } from 'cva';
+import {
+  Checkbox as RACCheckbox,
+  CheckboxProps as RACCheckboxProps,
+} from 'react-aria-components';
+import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
+
+const defaultClasses = cx(['flex cursor-pointer items-center gap-2']);
+
+function Checkmark({
+  isSelected,
+  isFocusVisible,
+  isHovered,
+}: {
+  isSelected: boolean;
+  isFocusVisible: boolean;
+  isHovered: boolean;
+}) {
+  return (
+    <div
+      className={cx(
+        'grid h-5 w-5 place-content-center rounded-sm border border-black p-0.5 text-white transition-all duration-200',
+        isSelected ? 'bg-green' : '[&>svg]:hidden',
+        isFocusVisible && 'ring-2 ring-black ring-offset-2',
+        isHovered && 'border-green bg-green-lightest',
+      )}
+    >
+      <CheckIcon className="h-full w-full" />
+    </div>
+  );
+}
+
+type CheckboxProps = {
+  children: React.ReactNode;
+  className?: string;
+} & Omit<
+  RACCheckboxProps,
+  'isDisabled' | 'style' | 'children' | 'isIndeterminate' | 'isReadOnly'
+>;
+
+function Checkbox(props: CheckboxProps) {
+  const { children, className, ...restProps } = props;
+  return (
+    <RACCheckbox
+      {...restProps}
+      className={cx(className, defaultClasses)}
+      autoFocus
+    >
+      {({ isSelected, isFocusVisible, isHovered }) => (
+        <>
+          <Checkmark
+            isSelected={isSelected}
+            isFocusVisible={isFocusVisible}
+            isHovered={isHovered}
+          />
+          {children}
+        </>
+      )}
+    </RACCheckbox>
+  );
+}
+
+export { Checkbox, type CheckboxProps };

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import {
 import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
 
 const defaultClasses = cx([
-  'group relative flex cursor-pointer items-center gap-4 leading-7',
+  'group relative flex w-fit cursor-pointer items-center gap-4 py-2 leading-7',
 ]);
 
 // Pulling this out into it's own component. Will probably export it in the future
@@ -15,7 +15,7 @@ function CheckmarkBox() {
   return (
     <div
       className={cx([
-        'relative z-0 grid h-6 w-6 flex-none place-content-center rounded-sm border-2 border-black p-1 text-white',
+        'relative grid h-6 w-6 flex-none place-content-center rounded-sm border-2 border-black p-1 text-white',
         // selected
         'group-data-[selected]:border-green group-data-[selected]:bg-green',
         // focus

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import {
 import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
 
 const defaultClasses = cx([
-  'group flex cursor-pointer items-center gap-4 leading-7',
+  'group relative flex cursor-pointer items-center gap-4 leading-7',
 ]);
 
 // Pulling this out into it's own component. Will probably export it in the future
@@ -15,7 +15,7 @@ function CheckmarkBox() {
   return (
     <div
       className={cx([
-        'relative z-0 grid h-6 w-6 place-content-center rounded-sm border-2 border-black p-1 text-white',
+        'relative z-0 grid h-6 w-6 flex-none place-content-center rounded-sm border-2 border-black p-1 text-white',
         // selected
         'group-data-[selected]:border-green group-data-[selected]:bg-green',
         // focus
@@ -43,11 +43,9 @@ type CheckboxProps = {
 function Checkbox(props: CheckboxProps) {
   const { children, className, ...restProps } = props;
   return (
-    <RACCheckbox
-      {...restProps}
-      className={cx(className, defaultClasses)}
-      autoFocus
-    >
+    <RACCheckbox {...restProps} className={cx(className, defaultClasses)}>
+      {/* increases the clickable area of the checkbox for accessibility */}
+      <div className="absolute -left-2.5 top-1/2 z-10 h-11 w-11 -translate-y-1/2" />
       <CheckmarkBox />
       {children}
     </RACCheckbox>

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -5,24 +5,27 @@ import {
 } from 'react-aria-components';
 import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
 
-const defaultClasses = cx(['flex cursor-pointer items-center gap-2']);
+const defaultClasses = cx(['flex cursor-pointer items-center gap-2 leading-7']);
 
 function Checkmark({
   isSelected,
   isFocusVisible,
   isHovered,
+  isInvalid,
 }: {
   isSelected: boolean;
   isFocusVisible: boolean;
   isHovered: boolean;
+  isInvalid: boolean;
 }) {
   return (
     <div
       className={cx(
-        'grid h-5 w-5 place-content-center rounded-sm border border-black p-0.5 text-white transition-all duration-200',
+        'grid h-6 w-6 place-content-center rounded-sm border-2 border-black p-0.5 text-white',
         isSelected ? 'bg-green' : '[&>svg]:hidden',
-        isFocusVisible && 'ring-2 ring-black ring-offset-2',
-        isHovered && 'border-green bg-green-lightest',
+        isFocusVisible && 'ring-2 ring-black ring-offset-[10px]',
+        isHovered && ' bg-green shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
+        isInvalid && 'border-red',
       )}
     >
       <CheckIcon className="h-full w-full" />
@@ -46,12 +49,13 @@ function Checkbox(props: CheckboxProps) {
       className={cx(className, defaultClasses)}
       autoFocus
     >
-      {({ isSelected, isFocusVisible, isHovered }) => (
+      {({ isSelected, isFocusVisible, isHovered, isInvalid }) => (
         <>
           <Checkmark
             isSelected={isSelected}
             isFocusVisible={isFocusVisible}
             isHovered={isHovered}
+            isInvalid={isInvalid}
           />
           {children}
         </>

--- a/packages/react/src/checkbox/CheckboxGroup.stories.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CheckboxGroup } from './CheckboxGroup';
+import { Checkbox } from './Checkbox';
+
+const meta: Meta<typeof CheckboxGroup> = {
+  title: 'CheckboxGroup',
+  component: CheckboxGroup,
+  render: (args) => (
+    <CheckboxGroup {...args}>
+      <Checkbox value="bolig">Bolig</Checkbox>
+      <Checkbox value="bank">Bank</Checkbox>
+      <Checkbox value="fordeler">Medlemsfordeler</Checkbox>
+    </CheckboxGroup>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CheckboxGroup>;
+
+export const Example: Story = {
+  args: {
+    description: 'Velg minst en',
+    label: 'Jeg er interessert i',
+    isRequired: true,
+    isInvalid: false,
+  },
+};
+
+export const AsInvalid: Story = {
+  args: {
+    ...Example.args,
+    errorMessage: 'Velg et alternativ for å fortsette',
+  },
+};

--- a/packages/react/src/checkbox/CheckboxGroup.stories.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.stories.tsx
@@ -4,7 +4,7 @@ import { CheckboxGroup } from './CheckboxGroup';
 import { Checkbox } from './Checkbox';
 
 const meta: Meta<typeof CheckboxGroup> = {
-  title: 'CheckboxGroup',
+  title: 'Checkbox/CheckboxGroup',
   component: CheckboxGroup,
   render: (args) => (
     <CheckboxGroup {...args}>

--- a/packages/react/src/checkbox/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.tsx
@@ -1,0 +1,62 @@
+import { cx } from 'cva';
+import {
+  CheckboxGroup as RACCheckboxGroup,
+  type CheckboxGroupProps as RACCheckboxGroupProps,
+} from 'react-aria-components';
+
+import { Label } from '../label/Label';
+import { Description } from '../label/Description';
+import { ErrorMessage } from '../label/ErrorMessage';
+
+type CheckboxGroupProps = {
+  children: React.ReactNode;
+  /** Additional CSS className for the element. */
+  className?: string;
+  /** Help text for the form control. */
+  description?: React.ReactNode;
+  /** Error message for the form control. Automatically sets `isInvalid` to true */
+  errorMessage?: React.ReactNode;
+  /** Label for the form control. */
+  label?: React.ReactNode;
+  /** Additional style properties for the element. */
+  style?: React.CSSProperties;
+} & Omit<
+  RACCheckboxGroupProps,
+  | 'className'
+  | 'isReadOnly'
+  | 'isDisabled'
+  | 'children'
+  | 'style'
+  | 'orientation'
+>;
+
+function CheckboxGroup(props: CheckboxGroupProps) {
+  const {
+    children,
+    className,
+    description,
+    errorMessage,
+    label,
+    isRequired,
+    isInvalid: _isInvalid,
+    ...restProps
+  } = props;
+
+  const isInvalid = _isInvalid || errorMessage != null;
+
+  return (
+    <RACCheckboxGroup
+      {...restProps}
+      className={cx(className, 'flex flex-col gap-2')}
+    >
+      <Label isInvalid={isInvalid} isRequired={isRequired}>
+        {label}
+      </Label>
+      {description && <Description>{description}</Description>}
+      {children}
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+    </RACCheckboxGroup>
+  );
+}
+
+export { CheckboxGroup, type CheckboxGroupProps };

--- a/packages/react/src/checkbox/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.tsx
@@ -48,10 +48,10 @@ function CheckboxGroup(props: CheckboxGroupProps) {
     <RACCheckboxGroup
       {...restProps}
       className={cx(className, 'flex flex-col gap-2')}
+      isInvalid={isInvalid}
+      isRequired={isRequired}
     >
-      <Label isInvalid={isInvalid} isRequired={isRequired}>
-        {label}
-      </Label>
+      <Label>{label}</Label>
       {description && <Description>{description}</Description>}
       {children}
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}

--- a/packages/react/src/checkbox/index.ts
+++ b/packages/react/src/checkbox/index.ts
@@ -1,0 +1,2 @@
+export { Checkbox, type CheckboxProps } from './Checkbox';
+export { CheckboxGroup, type CheckboxGroupProps } from './CheckboxGroup';


### PR DESCRIPTION
Denne PRen legger til støtte for Checkbox og CheckboxGroup i v2 av Grunnmuren. 

Figma skisser finnes her https://www.figma.com/file/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=154%3A1412&mode=dev

Se preview på Netlify for å teste hover, invalid, selected og focus states.

### Checkbox
<img width="276" alt="Screenshot 2023-11-08 at 09 12 43" src="https://github.com/code-obos/grunnmuren/assets/81577/7c89c81b-e297-498d-821e-80cdbcfe1987">


En av de største endringen her er at vi legger et absolutt posisjonert element over selve checkboxen, dette er for å øke klikkflaten på den til 44 x 44 px, for å tilfredsstille UU-krav.
<img width="314" alt="Screenshot 2023-11-08 at 09 08 11" src="https://github.com/code-obos/grunnmuren/assets/81577/901fdad8-94f7-4fde-85ae-30de8e81c8b7">


### CheckboxGroup
Ny komponent i v2 som lar oss gruppere flere checkboxer sammen, med delt label, description og error message


<img width="227" alt="Screenshot 2023-11-08 at 09 18 49" src="https://github.com/code-obos/grunnmuren/assets/81577/309ca8bf-b83f-49b7-a9ae-06d2d29db6ed">

### TODO

Ting som kommer i en senere PR:

- [ ] Støtte for description på en enkelt checkbox.
- [ ] Støtte for error message på en enkelt checkbox.
- [ ] Finne ut av hva vi gjør med varianten i bildet nedenfor (fra Figma). Labelet til en checkbox er jo egentlig en del av checkboxen, så her får man egentlig to labels. Er det da riktig å bruke checkboxgroup for dette? Gir det mening for bare en checkbox?

<img width="138" alt="Screenshot 2023-11-08 at 09 21 14" src="https://github.com/code-obos/grunnmuren/assets/81577/4fe5e928-6e57-4ce9-939f-146ff979c152">
