### PR TITLE
adjust radio group after design changes

### DIFF
--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -5,15 +5,18 @@ import {
 } from 'react-aria-components';
 
 const defaultClasses = cx([
-  'flex cursor-pointer items-center gap-2',
+  'relative inline-flex max-w-fit cursor-pointer items-center gap-4 py-2 leading-7',
   // the radio button itself
-  'before:h-5 before:w-5 before:flex-shrink-0 before:rounded-full before:border-2 before:border-gray before:transition-all before:duration-200',
+  'before:h-6 before:w-6 before:flex-none before:rounded-full before:border-2 before:border-black',
   // selected
-  'data-[selected]:before:border-green data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_3px_rgb(255,255,255)]',
-  // hover
-  'data-[hovered]:before:border-green data-[hovered]:before:bg-green-lightest data-[selected]:data-[hovered]:before:bg-green',
+  'data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
+  // hover: TODO: add hover states when they're added in figma.
+  // 'data-[hovered]:before:border-green data-[hovered]:before:bg-green-lightest data-[selected]:data-[hovered]:before:bg-green',
   // focus
-  'data-[focus-visible]:before:ring data-[focus-visible]:before:ring-black data-[focus-visible]:before:ring-offset-2',
+  'data-[focus-visible]:before:ring data-[focus-visible]:before:ring-black data-[focus-visible]:before:ring-offset-[9px]',
+  // invalid - The border is 1 px thicker when invalid. We don't actually want to change the border width, as that causes the element's size to change
+  // so we use an inner outline to artifically pad the border
+  'data-[invalid]:before:outline-solid data-[invalid]:before:border-red data-[invalid]:data-[selected]:before:bg-red data-[invalid]:before:outline data-[invalid]:before:outline-[3px] data-[invalid]:before:outline-offset-[-3px] data-[invalid]:before:outline-red',
 ]);
 
 type RadioProps = {
@@ -22,8 +25,14 @@ type RadioProps = {
 } & Omit<RACRAdioProps, 'isDisabled' | 'children' | 'style'>;
 
 function Radio(props: RadioProps) {
-  const { className, ...restProps } = props;
-  return <RACRadio {...restProps} className={cx(className, defaultClasses)} />;
+  const { children, className, ...restProps } = props;
+  return (
+    <RACRadio {...restProps} className={cx(className, defaultClasses)}>
+      {/* increases the clickable area of the radio button for accessibility */}
+      <div className="absolute -left-2.5 top-1/2 z-10 h-11 w-11 -translate-y-1/2" />
+      {children}
+    </RACRadio>
+  );
 }
 
 export { Radio, type RadioProps };

--- a/packages/react/src/radiogroup/RadioGroup.stories.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.stories.tsx
@@ -21,7 +21,8 @@ type Story = StoryObj<typeof RadioGroup>;
 
 export const Example: Story = {
   args: {
-    description: '',
+    description:
+      'Kontakt oss for mer utfyllende informasjon om de forskjellige alternativene',
     label: 'Velg hvordan du vil kjøpe boligen',
     isRequired: true,
     isInvalid: false,


### PR DESCRIPTION
Oppdaterer radio buttons etter at det er kommet [skisser på de i Figma](https://www.figma.com/file/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=397%3A5389&mode=dev)

<img width="509" alt="Screenshot 2023-11-09 at 08 30 28" src="https://github.com/code-obos/grunnmuren/assets/81577/94d21fae-bd8b-4635-a1f0-ee1d0c03c346">

Klikkflaten er større, slik som gjort i Checkbox-PRen for bedre UU.

Det som gjenstår nå er hover state, men det mangler i Figma..
