### PR TITLE
Refactor away custom breakpoint in preparation for v2

### DIFF
--- a/packages/react/src/Campaign/Campaign.tsx
+++ b/packages/react/src/Campaign/Campaign.tsx
@@ -87,8 +87,10 @@ export const CampaignImage = forwardRef<HTMLImageElement, CampaignImageProps>(
 
     const className = cx(
       classNameProp,
-      'max-md:rounded-b-3xl w-full',
-      bodyIsRightAligned ? 'md:rounded-r-3xl' : 'md:rounded-l-3xl md:order-1',
+      'rounded-b-3xl w-full',
+      bodyIsRightAligned
+        ? 'md:rounded-r-3xl md:rounded-l-none'
+        : 'md:rounded-l-3xl md:rounded-r-none md:order-1',
     );
 
     // If the component has children, clone it and apply our classes.

--- a/packages/react/src/Hero/HeroContent.tsx
+++ b/packages/react/src/Hero/HeroContent.tsx
@@ -22,24 +22,23 @@ export const HeroContent = forwardRef<HTMLDivElement, HeroContentProps>(
       <div
         className={cx(
           className,
-          'relative grid grid-flow-row grid-cols-[minmax(auto,_37rem)] content-center gap-6 rounded-3xl px-6 py-10 text-center max-md:mx-4 md:p-12',
+          'relative mx-4 grid grid-flow-row grid-cols-[minmax(auto,_37rem)] content-center gap-6 rounded-3xl px-6 py-10 text-center md:p-12',
           {
             // On mobile we use negative margin on the content to pull the content up into the image
-            'max-md:-mt-18': hasImage,
+            '-mt-18': hasImage,
             'text-white': bgColor !== 'white',
             'bg-green-dark': bgColor === 'green',
             'bg-blue-dark': bgColor === 'blue',
             'bg-white': bgColor === 'white',
             // vertical split
             // vertically center the content, remove the border radius on the edge, add some negative margin to pull the image beneath the hero content, left align the content
-            'md:z-10 md:-order-1 md:-mr-5 md:mt-0 md:justify-center md:rounded-l-none md:text-left':
+            'md:z-10 md:-order-1 md:-mr-5 md:ml-0 md:mt-0 md:justify-center md:rounded-l-none md:text-left':
               contentPosition === 'vertical-split',
             // below center/content header
             'justify-center md:mx-auto md:w-4/5':
               contentPosition === 'below-center',
-            'md:-mt-18': hasImage && contentPosition === 'below-center',
             // Below left style
-            'md:-mt-32 md:ml-[8%] md:max-w-[58%] md:text-left':
+            'md:-mt-32 md:ml-[8%] md:mr-0 md:max-w-[58%] md:text-left':
               contentPosition === 'below-left',
             // styles for when the contain is fully contained within the image
             'md:mx-32 md:my-9 md:w-2/5': usesGridArea,

--- a/packages/react/src/Navbar/stories/Navbar.stories.tsx
+++ b/packages/react/src/Navbar/stories/Navbar.stories.tsx
@@ -40,7 +40,7 @@ export const Default = () => {
         logo={
           <a href="#" aria-label="Til startsiden for OBOS">
             <img
-              className="max-md:w-[100px]"
+              className="w-[100px] md:w-[149px]"
               src="/obos_liggende_hus_hvit.svg"
               width="173"
               height="41"

--- a/packages/react/src/Snackbar/Snackbar.tsx
+++ b/packages/react/src/Snackbar/Snackbar.tsx
@@ -19,7 +19,7 @@ export const Snackbar = (props: SnackbarProps) => {
 
   return (
     <div className="container max-w-[59rem]">
-      <div className="bg-orange-light px-8 py-4 max-md:p-4">
+      <div className="bg-orange-light p-4 md:px-8">
         <div className="snackbar grid items-center">
           <InfoCircle className="text-orange snackbar-icon mr-4 self-start md:mr-8 md:text-2xl" />
 

--- a/packages/react/src/Snackbar/Snackbar.tsx
+++ b/packages/react/src/Snackbar/Snackbar.tsx
@@ -35,7 +35,7 @@ export const Snackbar = (props: SnackbarProps) => {
             {heading}
           </h3>
 
-          <div className="snackbar-actions flex justify-end gap-4 max-md:mt-3 md:ml-4">
+          <div className="snackbar-actions mt-3 flex justify-end gap-4 md:ml-4 md:mt-0">
             <SnackbarButton
               aria-expanded={isExpanded}
               onClick={() => setIsExpanded(!isExpanded)}


### PR DESCRIPTION
Dette refaktorer et par komponenter til å gå vekk fra bruken av vår [custom breakpoint modifier `max-md`](https://github.com/code-obos/grunnmuren/blob/main/packages/tailwind/tailwind-base.cjs#L383). Den stammer fra en tid da Tailwind ikke hadde egen støtte for dette, slik [de har nå](https://tailwindcss.com/docs/responsive-design#targeting-a-breakpoint-range).

Vi jobber med å bake inn v1 støtte i v2-presetet #606, men screens konfigurasjonen vil ikke bli videreført (selv i kompabilitetsmodus). Det er fordi Tailwind sin innebygde støtte ikke fungerer dersom man har en custom screens konfigurasjon.

Denne PRen fjerner dermed bruken av vår egensnekrede `max-md`. Komponentene rendres fortsatt som før, og de vil da forhåpentligvis kunne brukes sammen med v2 presetet i compat mode.

