### PR TITLE
v2: prevent underline for button links

### DIFF
--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -20,9 +20,9 @@ const buttonVariants = cva({
      * @default primary
      */
     variant: {
-      primary: '',
+      primary: 'no-underline',
       // by using an inset box-shadow to emulate a border instead of an actual border, the button size will be equal regardless of the variant
-      secondary: 'shadow-[inset_0_0_0_2px]',
+      secondary: 'no-underline shadow-[inset_0_0_0_2px]',
       tertiary: 'underline hover:no-underline',
     },
     /**


### PR DESCRIPTION
Fixes link (anchor) buttons being rendered with underlines.

Before:
<img width="199" alt="Screenshot 2023-11-13 at 18 42 35" src="https://github.com/code-obos/grunnmuren/assets/81577/30695d54-51ca-4851-ba2d-7113684d6588">

After:

<img width="206" alt="Screenshot 2023-11-13 at 18 45 18" src="https://github.com/code-obos/grunnmuren/assets/81577/ef996a33-6113-4c84-b64a-170100636220">
