### PR TITLE
Add hover state and stories to RadioGroup

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
   addons: [
     '@storybook/addon-docs',
     '@storybook/addon-controls',
+    '@storybook/addon-actions',
     {
       name: '@storybook/addon-styling',
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@changesets/cli": "2.26.2",
     "@obosbbl/grunnmuren-tailwind": "workspace:*",
+    "@storybook/addon-actions": "7.5.1",
     "@storybook/addon-controls": "7.5.1",
     "@storybook/addon-docs": "7.5.1",
     "@storybook/addon-styling": "1.3.7",

--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -10,8 +10,8 @@ const defaultClasses = cx([
   'before:h-6 before:w-6 before:flex-none before:rounded-full before:border-2 before:border-black',
   // selected
   'data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
-  // hover: TODO: add hover states when they're added in figma.
-  // 'data-[hovered]:before:border-green data-[hovered]:before:bg-green-lightest data-[selected]:data-[hovered]:before:bg-green',
+  // hover states
+  'data-[hovered]:before:border-green',
   // focus
   'data-[focus-visible]:before:ring data-[focus-visible]:before:ring-black data-[focus-visible]:before:ring-offset-[9px]',
   // invalid - The border is 1 px thicker when invalid. We don't actually want to change the border width, as that causes the element's size to change

--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -10,13 +10,13 @@ const defaultClasses = cx([
   'before:h-6 before:w-6 before:flex-none before:rounded-full before:border-2 before:border-black',
   // selected
   'data-[selected]:before:border-black data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
-  // hover states
-  'before:bg-green-lightest data-[hovered]:before:border-green data-[hovered]:before:bg-green-lightest',
+  // hover
+  'data-[hovered]:before:border-green data-[hovered]:before:bg-green-lightest data-[hovered]:data-[invalid]:before:bg-red-light',
   // focus
   'data-[focus-visible]:before:ring data-[focus-visible]:before:ring-black data-[focus-visible]:before:ring-offset-[9px]',
   // invalid - The border is 1 px thicker when invalid. We don't actually want to change the border width, as that causes the element's size to change
   // so we use an inner outline to artifically pad the border
-  'data-[invalid]:before:outline-solid data-[invalid]:before:!border-red data-[invalid]:data-[selected]:before:bg-red data-[invalid]:before:outline data-[invalid]:before:outline-[3px] data-[invalid]:before:outline-offset-[-3px] data-[invalid]:before:outline-red',
+  'data-[invalid]:before:outline-solid data-[invalid]:before:border-red data-[invalid]:data-[selected]:before:!bg-red data-[invalid]:before:outline data-[invalid]:before:outline-[3px] data-[invalid]:before:outline-offset-[-3px] data-[invalid]:before:outline-red',
 ]);
 
 type RadioProps = {

--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -9,14 +9,14 @@ const defaultClasses = cx([
   // the radio button itself
   'before:h-6 before:w-6 before:flex-none before:rounded-full before:border-2 before:border-black',
   // selected
-  'data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
+  'data-[selected]:before:border-black data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
   // hover states
-  'data-[hovered]:before:border-green',
+  'before:bg-green-lightest data-[hovered]:before:border-green data-[hovered]:before:bg-green-lightest',
   // focus
   'data-[focus-visible]:before:ring data-[focus-visible]:before:ring-black data-[focus-visible]:before:ring-offset-[9px]',
   // invalid - The border is 1 px thicker when invalid. We don't actually want to change the border width, as that causes the element's size to change
   // so we use an inner outline to artifically pad the border
-  'data-[invalid]:before:outline-solid data-[invalid]:before:border-red data-[invalid]:data-[selected]:before:bg-red data-[invalid]:before:outline data-[invalid]:before:outline-[3px] data-[invalid]:before:outline-offset-[-3px] data-[invalid]:before:outline-red',
+  'data-[invalid]:before:outline-solid data-[invalid]:before:!border-red data-[invalid]:data-[selected]:before:bg-red data-[invalid]:before:outline data-[invalid]:before:outline-[3px] data-[invalid]:before:outline-offset-[-3px] data-[invalid]:before:outline-red',
 ]);
 
 type RadioProps = {

--- a/packages/react/src/radiogroup/RadioGroup.stories.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../button/Button';
@@ -45,13 +45,16 @@ const Template = (args: RadioGroupProps) => {
 const ControlledTemplate = (args: RadioGroupProps) => {
   const [selectedItem, setSelectedItem] = useState<string>('ordinary');
 
-  useEffect(() => {
-    console.log('isSelected:', selectedItem);
-  }, [selectedItem]);
-
   return (
     <div className="flex flex-col gap-2">
-      <RadioGroup {...args} value={selectedItem} onChange={setSelectedItem}>
+      <RadioGroup
+        {...args}
+        value={selectedItem}
+        onChange={(value) => {
+          setSelectedItem(value);
+          args.onChange?.(value);
+        }}
+      >
         {items}
       </RadioGroup>
       <p>Valgt: {selectedItem}</p>

--- a/packages/react/src/radiogroup/RadioGroup.stories.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.stories.tsx
@@ -51,7 +51,7 @@ const ControlledTemplate = (args: RadioGroupProps) => {
 
   return (
     <div className="flex flex-col gap-2">
-      <RadioGroup value={selectedItem} {...args} onChange={setSelectedItem}>
+      <RadioGroup {...args} value={selectedItem} onChange={setSelectedItem}>
         {items}
       </RadioGroup>
       <p>Valgt: {selectedItem}</p>

--- a/packages/react/src/radiogroup/RadioGroup.stories.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.stories.tsx
@@ -1,37 +1,133 @@
+import { useState, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { RadioGroup } from './RadioGroup';
+import { Button } from '../button/Button';
+import { RadioGroup, type RadioGroupProps } from './RadioGroup';
 import { Radio } from './Radio';
 
 const meta: Meta<typeof RadioGroup> = {
   title: 'RadioGroup',
   component: RadioGroup,
-  render: (args) => (
-    <RadioGroup {...args}>
-      <Radio value="ordinary">Ordinær pris</Radio>
-      <Radio value="bostart">OBOS Bostart</Radio>
-      <Radio value="deleie">OBOS Deleie</Radio>
-    </RadioGroup>
-  ),
+  argTypes: {
+    onChange: { action: 'changed' },
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof RadioGroup>;
 
-export const Example: Story = {
+const items = (
+  <>
+    <Radio value="ordinary">Ordinær pris</Radio>
+    <Radio value="bostart">OBOS Bostart</Radio>
+    <Radio value="deleie">OBOS Deleie</Radio>
+  </>
+);
+
+const Template = (args: RadioGroupProps) => {
+  return args.isRequired ? (
+    <form
+      className="flex flex-col items-start gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert('Lagret!');
+      }}
+    >
+      <RadioGroup {...args}>{items}</RadioGroup>
+      <Button type="submit">Send inn</Button>
+    </form>
+  ) : (
+    <RadioGroup {...args}>{items}</RadioGroup>
+  );
+};
+
+const ControlledTemplate = (args: RadioGroupProps) => {
+  const [selectedItem, setSelectedItem] = useState<string>('ordinary');
+
+  useEffect(() => {
+    console.log('isSelected:', selectedItem);
+  }, [selectedItem]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <RadioGroup
+        label="Select city"
+        value={selectedItem}
+        {...args}
+        onChange={setSelectedItem}
+      >
+        {items}
+      </RadioGroup>
+      <p className="text-default-500">Valgt: {selectedItem}</p>
+    </div>
+  );
+};
+
+const defaultProps = {
+  label: 'Velg hvordan du vil kjøpe boligen',
+  isRequired: false,
+  isInvalid: false,
+  defaultValue: undefined,
+};
+
+export const Default: Story = {
+  render: Template,
   args: {
-    description:
-      'Kontakt oss for mer utfyllende informasjon om de forskjellige alternativene',
-    label: 'Velg hvordan du vil kjøpe boligen',
-    isRequired: true,
-    isInvalid: false,
+    ...defaultProps,
   },
 };
 
-export const AsInvalid: Story = {
+export const DefaultChecked: Story = {
+  render: Template,
   args: {
-    ...Example.args,
-    errorMessage: 'Velg et alternativ for å fortsette',
+    ...defaultProps,
+    defaultValue: 'deleie',
+  },
+};
+
+export const isRequired: Story = {
+  render: Template,
+
+  args: {
+    ...defaultProps,
+    isRequired: true,
+  },
+};
+
+export const WithDescription: Story = {
+  render: Template,
+
+  args: {
+    ...defaultProps,
+    description:
+      'Kontakt oss for mer utfyllende informasjon om de forskjellige alternativene',
+  },
+};
+
+export const IsInvalid: Story = {
+  render: Template,
+
+  args: {
+    ...defaultProps,
+    isInvalid: true,
+  },
+};
+
+export const WithErrorMessage: Story = {
+  render: Template,
+
+  args: {
+    ...defaultProps,
+    isInvalid: true,
+    errorMessage: 'Det valgte alternativet er ikke gyldig',
+  },
+};
+
+export const Controlled = {
+  render: ControlledTemplate,
+
+  args: {
+    ...defaultProps,
   },
 };

--- a/packages/react/src/radiogroup/RadioGroup.stories.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.stories.tsx
@@ -51,15 +51,10 @@ const ControlledTemplate = (args: RadioGroupProps) => {
 
   return (
     <div className="flex flex-col gap-2">
-      <RadioGroup
-        label="Select city"
-        value={selectedItem}
-        {...args}
-        onChange={setSelectedItem}
-      >
+      <RadioGroup value={selectedItem} {...args} onChange={setSelectedItem}>
         {items}
       </RadioGroup>
-      <p className="text-default-500">Valgt: {selectedItem}</p>
+      <p>Valgt: {selectedItem}</p>
     </div>
   );
 };
@@ -69,6 +64,8 @@ const defaultProps = {
   isRequired: false,
   isInvalid: false,
   defaultValue: undefined,
+  name: undefined,
+  value: undefined,
 };
 
 export const Default: Story = {
@@ -121,6 +118,15 @@ export const WithErrorMessage: Story = {
     ...defaultProps,
     isInvalid: true,
     errorMessage: 'Det valgte alternativet er ikke gyldig',
+  },
+};
+
+export const HTMLForms: Story = {
+  render: Template,
+
+  args: {
+    ...defaultProps,
+    name: 'kjopsform',
   },
 };
 

--- a/packages/react/src/radiogroup/RadioGroup.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.tsx
@@ -51,7 +51,7 @@ function RadioGroup(props: RadioGroupProps) {
       isInvalid={isInvalid}
       isRequired={isRequired}
     >
-      <Label>{label}</Label>
+      {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
       {children}
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@obosbbl/grunnmuren-tailwind':
         specifier: workspace:*
         version: link:packages/tailwind
+      '@storybook/addon-actions':
+        specifier: 7.5.1
+        version: 7.5.1(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/addon-controls':
         specifier: 7.5.1
         version: 7.5.1(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
@@ -4317,6 +4320,40 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: false
 
+  /@storybook/addon-actions@7.5.1(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-GieD3ru6EslKvwol1cE4lvszQCLB/AkQdnLofnqy1nnYso+hRxmPAw9/O+pWfpUBFdjXsQ7GX09+wEUpOJzepw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/client-logger': 7.5.1
+      '@storybook/components': 7.5.1(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-events': 7.5.1
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 7.5.1(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/preview-api': 7.5.1
+      '@storybook/theming': 7.5.1(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/types': 7.5.1
+      dequal: 2.0.3
+      lodash: 4.17.21
+      polished: 4.2.2
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-inspector: 6.0.2(react@18.2.0)
+      telejson: 7.2.0
+      ts-dedent: 2.2.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    dev: false
+
   /@storybook/addon-controls@7.5.1(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Xag1e7TZo04LjUenfobkShpKMxTtwa4xM4bXQA8LjaAGZQ7jipbQ4PE73a17K59S2vqq89VAhkuMJWiyaOFqpw==}
     peerDependencies:
@@ -5233,13 +5270,13 @@ packages:
     resolution: {integrity: sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==}
     dependencies:
       '@types/connect': 3.4.37
-      '@types/node': 20.8.8
+      '@types/node': 20.8.9
     dev: false
 
   /@types/connect@3.4.37:
     resolution: {integrity: sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.9
     dev: false
 
   /@types/cross-spawn@6.0.4:
@@ -5297,7 +5334,7 @@ packages:
   /@types/express-serve-static-core@4.17.39:
     resolution: {integrity: sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.9
       '@types/qs': 6.9.9
       '@types/range-parser': 1.2.6
       '@types/send': 0.17.3
@@ -5466,7 +5503,7 @@ packages:
     resolution: {integrity: sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==}
     dependencies:
       '@types/mime': 1.3.4
-      '@types/node': 20.8.8
+      '@types/node': 20.8.9
     dev: false
 
   /@types/serve-static@1.15.4:
@@ -5474,7 +5511,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.3
       '@types/mime': 3.0.3
-      '@types/node': 20.8.8
+      '@types/node': 20.8.9
     dev: false
 
   /@types/unist@2.0.9:
@@ -10616,6 +10653,14 @@ packages:
       react-is: 18.1.0
     dev: false
 
+  /react-inspector@6.0.2(react@18.2.0):
+    resolution: {integrity: sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: false
@@ -12213,6 +12258,11 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
     engines: {node: '>= 0.4.0'}
+    dev: false
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
     dev: false
 
   /validate-npm-package-license@3.0.4:


### PR DESCRIPTION
TLDR:

- Hover state for radioknapp
- Storybook actions plugin
- Masse nye stories for RadioGroup.

PRen legger til hover state for radioknapper:

https://github.com/code-obos/grunnmuren/assets/81577/120ac6b8-a86e-4638-aa95-51b8edc263b2

Den legger også til betydelig flere stories for radiogruppen. Da har vi mer eksplisitte stories i stedet for at man må sitte og klikke av og på varianter via storybook kontroll-panelet:

<img width="185" alt="Screenshot 2023-11-14 at 18 48 14" src="https://github.com/code-obos/grunnmuren/assets/81577/3491a574-cd2f-4003-aeb2-236012f60409">

Den legger også til [Storybook actions pluginet](https://storybook.js.org/docs/react/essentials/actions), slik at vi kan logge event handlers i storybooken:

<img width="256" alt="Screenshot 2023-11-14 at 18 51 30" src="https://github.com/code-obos/grunnmuren/assets/81577/9f2db3f7-7f05-4433-b14e-f9050f5eeb89">
