### PR TITLE
add back special colors like transparent to color theme

### DIFF
--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -138,6 +138,9 @@ module.exports = (options = {}) => {
     ],
     theme: {
       colors: {
+        inherit: 'inherit',
+        current: 'currentColor',
+        transparent: 'transparent',
         black: '#333',
         white: '#fff',
         gray: {


### PR DESCRIPTION
I v1 av Tailwind-presetet _extendet_ vi fargene til Tailwind med OBOS sin fargepalett. Det fungerte greit nok, men det gjorde at man fikk opp haugevis med grønnfarger på autocomplete (som ikke er en del av fargepalett).

I V2 _overskriver_ vi derfor heller Tailwind sine farger med OBOS sine. Men da forsvant samtidig noen utility farger som transparent, currentColor og inherit.

Denne PRen legger de inn så man man fortsatt kan bruke disse, for eksempel som bakgrunn:
<img width="461" alt="Screenshot 2023-11-14 at 19 02 36" src="https://github.com/code-obos/grunnmuren/assets/81577/50a8d729-9fc3-4a9d-98ef-828973c2528a">
