### PR TITLE
Flesh out checkboxgroup stories

### DIFF
--- a/packages/react/src/checkbox/CheckboxGroup.stories.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.stories.tsx
@@ -1,36 +1,134 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { CheckboxGroup } from './CheckboxGroup';
+import { Button } from '../button/Button';
+import { CheckboxGroup, type CheckboxGroupProps } from './CheckboxGroup';
 import { Checkbox } from './Checkbox';
 
 const meta: Meta<typeof CheckboxGroup> = {
   title: 'Checkbox/CheckboxGroup',
   component: CheckboxGroup,
-  render: (args) => (
-    <CheckboxGroup {...args}>
-      <Checkbox value="bolig">Bolig</Checkbox>
-      <Checkbox value="bank">Bank</Checkbox>
-      <Checkbox value="fordeler">Medlemsfordeler</Checkbox>
-    </CheckboxGroup>
-  ),
+  argTypes: {
+    onChange: { action: 'changed' },
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof CheckboxGroup>;
 
-export const Example: Story = {
+const items = (
+  <>
+    <Checkbox value="bolig">Bolig</Checkbox>
+    <Checkbox value="bank">Bank</Checkbox>
+    <Checkbox value="fordeler">Medlemsfordeler</Checkbox>
+  </>
+);
+
+const Template = (args: CheckboxGroupProps) => {
+  return args.isRequired ? (
+    <form
+      className="flex flex-col items-start gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert('Lagret!');
+      }}
+    >
+      <CheckboxGroup {...args}>{items}</CheckboxGroup>
+      <Button type="submit">Send inn</Button>
+    </form>
+  ) : (
+    <CheckboxGroup {...args}>{items}</CheckboxGroup>
+  );
+};
+
+const ControlledTemplate = (args: CheckboxGroupProps) => {
+  const [selectedItems, setSelectedItems] = useState(['bank']);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <CheckboxGroup
+        {...args}
+        value={selectedItems}
+        onChange={(value) => {
+          setSelectedItems(value);
+          args.onChange?.(value);
+        }}
+      >
+        {items}
+      </CheckboxGroup>
+      <p>Valgt: {selectedItems.join(', ')}</p>
+    </div>
+  );
+};
+
+const defaultProps = {
+  label: 'Jeg er interessert i',
+  isRequired: false,
+  isInvalid: false,
+  defaultValue: undefined,
+  name: undefined,
+  value: undefined,
+};
+
+export const Default: Story = {
+  render: Template,
   args: {
-    description: 'Velg minst en',
-    label: 'Jeg er interessert i',
-    isRequired: true,
-    isInvalid: false,
+    ...defaultProps,
   },
 };
 
-export const AsInvalid: Story = {
+export const DefaultValue: Story = {
+  render: Template,
   args: {
-    ...Example.args,
+    ...defaultProps,
+    defaultValue: ['bolig', 'bank'],
+  },
+};
+
+export const isRequired: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isRequired: true,
+  },
+};
+
+export const WithDescription: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    description: 'Du kan velge flere om du vil',
+  },
+};
+
+export const IsInvalid: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isInvalid: true,
+  },
+};
+
+export const WithErrorMessage: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
     errorMessage: 'Velg et alternativ for å fortsette',
+  },
+};
+
+export const HTMLForms: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    name: 'interested-in',
+  },
+};
+
+export const Controlled = {
+  render: ControlledTemplate,
+  args: {
+    ...defaultProps,
   },
 };

--- a/packages/react/src/checkbox/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.tsx
@@ -51,7 +51,7 @@ function CheckboxGroup(props: CheckboxGroupProps) {
       isInvalid={isInvalid}
       isRequired={isRequired}
     >
-      <Label>{label}</Label>
+      {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
       {children}
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}


### PR DESCRIPTION
Denne PRen gjør egentlig mye av det samme som i #625. Den legger til fler og mer eksplisitte stories for CheckboxGroup.

<img width="176" alt="Screenshot 2023-11-14 at 20 03 58" src="https://github.com/code-obos/grunnmuren/assets/81577/baa2e746-5e6e-4a78-9768-9a4b1176689e">

Fikser også en liten bug hvor tomt label ble rendret dersom det ikke ble sendt inn.
