### PR TITLE
add description support to radio buttons

### DIFF
--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -13,6 +13,7 @@ const defaultClasses = cx([
   // to vertically align the radio we need to calculate the label's height, which is equal to it's font size multiplied by the line height.
   // For the ::before psuedo element the line height of the label is always 1em.
   // When we know the height of the label we use the height of the radio to push it down to align with the label's first line
+  // TODO: 1.75 here is the unit less lineheight, altough we use 1.75rem as the line height, so there is a mismatch here. Revisit this when we've worked on typography in v2. Should this be a CSS custom property instead?
   'before:mt-[calc((1em_*_1.75_-_24px)_/_2)] before:h-[24px] before:w-[24px]',
   // selected
   'data-[selected]:before:border-black data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',

--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -4,10 +4,16 @@ import {
   RadioProps as RACRAdioProps,
 } from 'react-aria-components';
 
+import { Description } from '../label';
+
 const defaultClasses = cx([
-  'relative inline-flex max-w-fit cursor-pointer items-center gap-4 py-2 leading-7',
+  'relative inline-flex max-w-fit cursor-pointer items-start gap-4 py-2 leading-7',
   // the radio button itself
-  'before:h-6 before:w-6 before:flex-none before:rounded-full before:border-2 before:border-black',
+  'before:flex-none before:rounded-full before:border-2 before:border-black',
+  // to vertically align the radio we need to calculate the label's height, which is equal to it's font size multiplied by the line height.
+  // For the ::before psuedo element the line height of the label is always 1em.
+  // When we know the height of the label we use the height of the radio to push it down to align with the label's first line
+  'before:mt-[calc((1em_*_1.75_-_24px)_/_2)] before:h-[24px] before:w-[24px]',
   // selected
   'data-[selected]:before:border-black data-[selected]:before:bg-green data-[selected]:before:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
   // hover
@@ -21,16 +27,27 @@ const defaultClasses = cx([
 
 type RadioProps = {
   children: React.ReactNode;
+  /** Additional CSS className for the element. */
   className?: string;
+  /** Help text for the form control. */
+  description?: React.ReactNode;
+  /** Additional style properties for the element. */
+  style?: React.CSSProperties;
 } & Omit<RACRAdioProps, 'isDisabled' | 'children' | 'style'>;
 
 function Radio(props: RadioProps) {
-  const { children, className, ...restProps } = props;
+  const { children, className, description, ...restProps } = props;
   return (
     <RACRadio {...restProps} className={cx(className, defaultClasses)}>
       {/* increases the clickable area of the radio button for accessibility */}
-      <div className="absolute -left-2.5 top-1/2 z-10 h-11 w-11 -translate-y-1/2" />
-      {children}
+      <div className="absolute -left-2.5 top-0 z-10 h-11 w-11 " />
+
+      <div>
+        {children}
+        {description && (
+          <Description className="mt-2.5 block">{description}</Description>
+        )}
+      </div>
     </RACRadio>
   );
 }

--- a/packages/react/src/radiogroup/RadioGroup.stories.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.stories.tsx
@@ -17,15 +17,37 @@ export default meta;
 
 type Story = StoryObj<typeof RadioGroup>;
 
-const items = (
-  <>
-    <Radio value="ordinary">Ordinær pris</Radio>
-    <Radio value="bostart">OBOS Bostart</Radio>
-    <Radio value="deleie">OBOS Deleie</Radio>
-  </>
-);
+const RadioItems = ({ description }: { description?: boolean }) => {
+  return (
+    <>
+      <Radio value="ordinary">Ordinær pris</Radio>
+      <Radio
+        value="bostart"
+        description={
+          description
+            ? 'OBOS Bostart gjør at du kan kjøpe en helt ny bolig til en lavere pris enn ordinær markedspris.'
+            : undefined
+        }
+      >
+        OBOS Bostart
+      </Radio>
+      <Radio
+        value="deleie"
+        description={
+          description
+            ? 'Med OBOS Deleie kan du kjøpe halve boligen, eller mer, og bo i hele.'
+            : undefined
+        }
+      >
+        OBOS Deleie
+      </Radio>
+    </>
+  );
+};
 
 const Template = (args: RadioGroupProps) => {
+  const items = <RadioItems description={Boolean(args.description)} />;
+
   return args.isRequired ? (
     <form
       className="flex flex-col items-start gap-4"
@@ -44,6 +66,8 @@ const Template = (args: RadioGroupProps) => {
 
 const ControlledTemplate = (args: RadioGroupProps) => {
   const [selectedItem, setSelectedItem] = useState<string>('ordinary');
+
+  const items = <RadioItems description={Boolean(args.description)} />;
 
   return (
     <div className="flex flex-col gap-2">


### PR DESCRIPTION
Denne PRen legger inn støtte for å sette description på en enkelt radioknapp. Tidligere har vi kun støttet description på hele radiogruppa, ikke enkelte radioknapper.

<img width="637" alt="Screenshot 2023-11-20 at 12 39 56" src="https://github.com/code-obos/grunnmuren/assets/81577/9e3302ef-f4a1-41a5-9f37-eabfb1f515c1">

Har også endret til at radioknappen alignes til første linje av teksten. Se kodekommentar for hvordan vi får til dette.

<img width="166" alt="Screenshot 2023-11-20 at 12 48 13" src="https://github.com/code-obos/grunnmuren/assets/81577/06cc5da0-03f3-497e-b5fa-72f63efd36d1">
