### PR TITLE
Add TextArea component to Grunnmuren v2

### DIFF
--- a/packages/react/src/textarea/TextArea.stories.tsx
+++ b/packages/react/src/textarea/TextArea.stories.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from '../button/Button';
+import { TextArea, TextAreaProps } from './TextArea';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'TextArea',
+  component: TextArea,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextArea>;
+
+const Template = (args: TextAreaProps) => {
+  return args.isRequired ? (
+    <form
+      className="flex flex-col items-start gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert('Lagret!');
+      }}
+    >
+      <TextArea {...args} />
+      <Button type="submit">Send inn</Button>
+    </form>
+  ) : (
+    <TextArea {...args} />
+  );
+};
+
+const ControlledTemplate = (args: TextAreaProps) => {
+  const [value, setValue] = useState('');
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Template {...args} value={value} onChange={setValue} />
+      <pre className="font-sans">{value}</pre>
+    </div>
+  );
+};
+
+const defaultProps = {
+  label: 'Beskrivelse',
+  isRequired: false,
+  isInvalid: false,
+  name: undefined,
+  defaultValue: undefined,
+  value: undefined,
+  rows: undefined,
+};
+
+export const Default: Story = {
+  render: Template,
+  args: { ...defaultProps },
+};
+
+export const Required: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isRequired: true,
+  },
+};
+
+export const WithDescription: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    description: 'Maks 250 tegn',
+  },
+};
+
+export const WithPlaceholder: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    placeholder: 'Lorem ipsum',
+  },
+};
+
+export const With5Rows: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    rows: 3,
+  },
+};
+
+export const WithoutLabel: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    label: undefined,
+    placeholder: 'Beskrivelse',
+    'aria-label': 'Beskrivelse',
+  },
+};
+
+export const IsInvalid: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isInvalid: true,
+  },
+};
+
+export const WithErrorMessage: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    errorMessage: 'Feltet er påkrevd',
+  },
+};
+
+export const Controlled = {
+  render: ControlledTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -1,0 +1,75 @@
+import { cx } from 'cva';
+import {
+  TextArea as RACTextArea,
+  TextField as RACTextField,
+  type TextFieldProps as RACTextFieldProps,
+} from 'react-aria-components';
+
+import { Label } from '../label/Label';
+import { Description } from '../label/Description';
+import { ErrorMessage } from '../label/ErrorMessage';
+
+type TextAreaProps = {
+  /** Additional CSS className for the element. */
+  className?: string;
+  /** Help text for the form control. */
+  description?: React.ReactNode;
+  /** Error message for the form control. Automatically sets `isInvalid` to true */
+  errorMessage?: React.ReactNode;
+  /** Label for the form control. */
+  label?: React.ReactNode;
+  /** Placeholder text. Only visible when the input value is empty. */
+  placeholder?: string;
+  /** Additional style properties for the element. */
+  style?: React.CSSProperties;
+  /**
+   * The number of visible text lines for the control.
+   * @default 2
+   */
+  rows?: number;
+} & Omit<
+  RACTextFieldProps,
+  'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
+>;
+
+const classes = {
+  base: cx('group flex flex-col gap-2.5'),
+  textarea: cx([
+    'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070]',
+    // focus
+    'focus:outline-none focus:ring-2 focus:ring-black',
+    // invalid
+    'data-[invalid]:border-red',
+  ]),
+};
+
+function TextArea(props: TextAreaProps) {
+  const {
+    className,
+    description,
+    errorMessage,
+    label,
+    isRequired,
+    isInvalid: _isInvalid,
+    rows,
+    ...restProps
+  } = props;
+
+  const isInvalid = _isInvalid || errorMessage != null;
+
+  return (
+    <RACTextField
+      {...restProps}
+      className={cx(className, classes.base)}
+      isInvalid={isInvalid}
+      isRequired={isRequired}
+    >
+      {label && <Label>{label}</Label>}
+      {description && <Description>{description}</Description>}
+      <RACTextArea className={classes.textarea} rows={rows} />
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+    </RACTextField>
+  );
+}
+
+export { TextArea, type TextAreaProps };

--- a/packages/react/src/textarea/index.ts
+++ b/packages/react/src/textarea/index.ts
@@ -1,0 +1,1 @@
+export { TextArea, type TextAreaProps } from './TextArea';

--- a/packages/react/src/textfield/TextField.stories.tsx
+++ b/packages/react/src/textfield/TextField.stories.tsx
@@ -34,7 +34,12 @@ const Template = (args: TextFieldProps) => {
 const ControlledTemplate = (args: TextFieldProps) => {
   const [value, setValue] = useState('');
 
-  return <Template {...args} value={value} onChange={setValue} />;
+  return (
+    <div className="flex flex-col gap-2">
+      <Template {...args} value={value} onChange={setValue} />
+      <p>{value}</p>
+    </div>
+  );
 };
 
 const LeftAddonTemplate = (args: TextFieldProps) => {
@@ -176,6 +181,5 @@ export const Controlled = {
 
   args: {
     ...defaultProps,
-    variant: 'bordered',
   },
 };


### PR DESCRIPTION
[AB#88383](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/88383)

Denne PRen legger til en TextArea komponent.

Det som gjenstår er riktig styling ved fokus og invalid (dette gjelder TextField også). Tar det i en egen PR når det er på plass i Figma.

