### PR TITLE
Button: add `isIconOnly` support to render button with a single icon

### DIFF
--- a/.changeset/grumpy-pans-design.md
+++ b/.changeset/grumpy-pans-design.md
@@ -1,5 +1,5 @@
 ---
-'@obosbbl/grunnmuren-react': patch
+'@obosbbl/grunnmuren-react': minor
 ---
 
 Button: add support for `isIconOnly` to render a button with a single icon

--- a/.changeset/grumpy-pans-design.md
+++ b/.changeset/grumpy-pans-design.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Button: add support for `isIconOnly` to render a button with a single icon

--- a/packages/react/src/button/Button.stories.tsx
+++ b/packages/react/src/button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { cx } from 'cva';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Edit } from '@obosbbl/grunnmuren-icons-react';
+import { Edit, Search } from '@obosbbl/grunnmuren-icons-react';
 
 import { Button } from './Button';
 
@@ -58,7 +58,7 @@ export const Tertiary: Story = {
   },
 };
 
-export const WithIcon = () => {
+export const WithIconAndText = () => {
   return (
     <div className="flex gap-8 p-8">
       <Button>
@@ -66,6 +66,16 @@ export const WithIcon = () => {
       </Button>
       <Button>
         Rediger <Edit />
+      </Button>
+    </div>
+  );
+};
+
+export const IconOnly = () => {
+  return (
+    <div className="p-8">
+      <Button isIconOnly aria-label="Søk">
+        <Search />
       </Button>
     </div>
   );

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -10,9 +10,7 @@ import { useClientLayoutEffect } from '../utils/useClientLayoutEffect';
 
 const buttonVariants = cva({
   base: [
-    'inline-flex min-h-[44px] cursor-pointer items-center justify-center whitespace-nowrap rounded-lg px-4 py-2 font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
-    // Spaccing when using the button with icons
-    '[&>svg]:first-of-type:mr-2.5 [&>svg]:last-of-type:ml-2.5',
+    'inline-flex min-h-[44px] cursor-pointer items-center justify-center whitespace-nowrap rounded-lg font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
   ],
   variants: {
     /**
@@ -33,6 +31,16 @@ const buttonVariants = cva({
       green: 'focus-visible:ring-black',
       mint: 'focus-visible:ring-mint focus-visible:ring-offset-green-dark',
       white: 'focus-visible:ring-white focus-visible:ring-offset-blue',
+    },
+    /**
+     * When the button is without text, but with a single icon.
+     * @default false
+     */
+    isIconOnly: {
+      true: 'p-2 [&>svg]:h-7 [&>svg]:w-7',
+      false:
+        // The of-type classes takes care to add spacing when the button is used with icons
+        'px-4 py-2 [&>svg]:first-of-type:mr-2.5 [&>svg]:last-of-type:ml-2.5',
     },
   },
   compoundVariants: [
@@ -83,6 +91,7 @@ const buttonVariants = cva({
   defaultVariants: {
     variant: 'primary',
     color: 'green',
+    isIconOnly: false,
   },
 });
 
@@ -106,8 +115,16 @@ type ButtonProps = VariantProps<typeof buttonVariants> & {
 } & ButtonOrLinkProps;
 
 function Button(props: ButtonProps) {
-  const { children, className, color, loading, variant, style, ...restProps } =
-    props;
+  const {
+    children,
+    className,
+    color,
+    isIconOnly,
+    loading,
+    variant,
+    style,
+    ...restProps
+  } = props;
 
   // TODO: Merge refs when we use RAC
   const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
@@ -136,7 +153,7 @@ function Button(props: ButtonProps) {
     // @ts-expect-error TS doesn't agree here taht restProps is safe to spread, because restProps for anchors aren't type compatible with restProps for buttons, but that should be okay here
     <Component
       aria-busy={loading ? true : undefined}
-      className={buttonVariants({ className, color, variant })}
+      className={buttonVariants({ className, color, isIconOnly, variant })}
       ref={buttonRef as never}
       style={{
         ...style,


### PR DESCRIPTION
[AB#89294](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/89294)

<img width="97" alt="Screenshot 2023-11-30 at 12 25 23" src="https://github.com/code-obos/grunnmuren/assets/81577/8243445b-d051-4056-8919-4bb9310f8146">

Figma: https://www.figma.com/file/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=39%3A182&mode=dev