### PR TITLE
Combobox and field refactoring

### DIFF
--- a/.changeset/pretty-geckos-rush.md
+++ b/.changeset/pretty-geckos-rush.md
@@ -1,0 +1,9 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+- improve TextField focus/invalid styles
+- improve TextArea focus/invalid styles
+- improve Select focus/invalid styles
+- refactor: share styles between form components
+- add Comobox component

--- a/.changeset/slimy-meals-sin.md
+++ b/.changeset/slimy-meals-sin.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-tailwind': patch
+---
+
+Set tailwindcss 3.4.0 as the minimum peer dep

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/checkbox/index.d.ts",
       "default": "./dist/checkbox/index.mjs"
     },
+    "./combobox": {
+      "types": "./dist/combobox/index.d.ts",
+      "default": "./dist/combobox/index.mjs"
+    },
     "./label": {
       "types": "./dist/label/index.d.ts",
       "default": "./dist/label/index.mjs"
@@ -52,6 +56,7 @@
     "entries": [
       "./src/button/Button.tsx",
       "./src/checkbox/index.ts",
+      "./src/combobox/index.ts",
       "./src/label/index.ts",
       "./src/radiogroup/index.ts",
       "./src/textfield/index.ts",

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -1,0 +1,44 @@
+import { cx, cva } from 'cva';
+
+const formField = cx('group flex flex-col gap-2');
+
+const input = cva({
+  base: [
+    'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
+    // invalid styles
+    'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
+  ],
+  variants: {
+    // Focus rings. Can either be :focus or :focus-visible based on the needs of the particular component.
+    focusModifier: {
+      focus: 'focus:ring-2 group-data-[invalid]:focus:ring',
+      visible:
+        'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
+    },
+    isGrouped: {
+      false: '',
+      //
+      true: 'flex-1 !ring-0 first:pl-0 last:pr-0',
+    },
+  },
+  defaultVariants: {
+    focusModifier: 'focus',
+    isGrouped: false,
+  },
+});
+
+const inputGroup = cx(
+  'inline-flex items-center overflow-hidden rounded-md px-3 ring-1 ring-black focus-within:ring-2 group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
+);
+
+const dropdown = {
+  popover: cx(
+    'min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
+  ),
+  listbox: cx('text-sm outline-none'),
+  chevronIcon: cx(
+    'text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none',
+  ),
+};
+
+export { formField, input, inputGroup, dropdown };

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../button/Button';

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../button/Button';
@@ -42,8 +42,14 @@ const Template = <T extends object>(args: ComboboxProps<T>) => {
   const select = (
     <Combobox {...args}>
       {items.map((item) => (
-        <ComboboxItem key={item.name} textValue={item.name}>
+        <ComboboxItem
+          key={item.name}
+          textValue={item.name}
+          id={item.name}
+          className="flex gap-2"
+        >
           {item.name}
+          <small className="text-gray">{item.area}</small>
         </ComboboxItem>
       ))}
     </Combobox>
@@ -65,13 +71,50 @@ const Template = <T extends object>(args: ComboboxProps<T>) => {
 };
 
 const ControlledTemplate = <T extends object>(args: ComboboxProps<T>) => {
-  const [value, setValue] = useState<string | number>('oslo');
+  const [value, setValue] = useState<string | number>(items[0].name);
 
   return (
     <div className="flex flex-col gap-2">
       <Template {...args} selectedKey={value} onSelectionChange={setValue} />
       <pre className="font-sans">{value}</pre>
     </div>
+  );
+};
+
+const AsyncTemplate = <T extends object>(args: ComboboxProps<T>) => {
+  const [items, setItems] = useState([]);
+  const [filterText, setFilterText] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    async function fetchData() {
+      if (filterText.length >= 2) {
+        setIsLoading(true);
+        const result = await fetch(
+          `https://swapi.dev/api/people?search=${filterText}`,
+        );
+        const data = await result.json();
+        setItems(data.results);
+        setIsLoading(false);
+      }
+    }
+    fetchData();
+  }, [filterText]);
+  console.log(items);
+
+  return (
+    <Combobox
+      label="SW character lookup"
+      items={items}
+      onInputChange={setFilterText}
+      inputValue={filterText}
+      isLoading={isLoading}
+      {...args}
+    >
+      {items.map((item) => (
+        <ComboboxItem key={item.url}>{item.name}</ComboboxItem>
+      ))}
+    </Combobox>
   );
 };
 
@@ -134,6 +177,14 @@ export const WithErrorMessage: Story = {
 
 export const Controlled = {
   render: ControlledTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const Async = {
+  render: AsyncTemplate,
 
   args: {
     ...defaultProps,

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from '../button/Button';
+import { Combobox, ComboboxItem, ComboboxProps } from './Combobox';
+
+const meta: Meta<typeof Combobox> = {
+  title: 'Combobox',
+  component: Combobox,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Combobox>;
+
+const Template = <T extends object>(args: ComboboxProps<T>) => {
+  const select = (
+    <Combobox {...args}>
+      <ComboboxItem id="agder">Agder</ComboboxItem>
+      <ComboboxItem id="innlandet">Innlandet</ComboboxItem>
+      <ComboboxItem id="more-og-romsdal">Møre og Romsdal</ComboboxItem>
+      <ComboboxItem id="oslo">Oslo</ComboboxItem>
+      <ComboboxItem id="rogaland">Rogaland</ComboboxItem>
+      <ComboboxItem id="trondelag">Trøndelag</ComboboxItem>
+      <ComboboxItem id="vestfold-og-telemark">
+        Vestfold og Telemark
+      </ComboboxItem>
+      <ComboboxItem id="viken">Viken</ComboboxItem>
+    </Combobox>
+  );
+  return args.isRequired ? (
+    <form
+      className="flex flex-col items-start gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert('Lagret!');
+      }}
+    >
+      {select}
+      <Button type="submit">Send inn</Button>
+    </form>
+  ) : (
+    select
+  );
+};
+
+const ControlledTemplate = <T extends object>(args: ComboboxProps<T>) => {
+  const [value, setValue] = useState<string | number>('oslo');
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Template {...args} selectedKey={value} onSelectionChange={setValue} />
+      <pre className="font-sans">{value}</pre>
+    </div>
+  );
+};
+
+const defaultProps = {
+  label: 'Velg område',
+  isRequired: false,
+  isInvalid: false,
+  name: undefined,
+  defaultSelectedKey: undefined,
+  selectedKey: undefined,
+  placeholder: 'Velg område',
+};
+
+export const Default: Story = {
+  render: Template,
+  args: { ...defaultProps },
+};
+
+export const Required: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isRequired: true,
+  },
+};
+
+export const WithDescription: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    description: 'OBOS bygger nye boliger over store deler av landet.',
+  },
+};
+
+export const WithoutLabel: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    label: undefined,
+    placeholder: 'Velg område',
+    'aria-label': 'Velg område',
+  },
+};
+
+export const IsInvalid: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    isInvalid: true,
+  },
+};
+
+export const WithErrorMessage: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    errorMessage: 'Feltet er påkrevd',
+  },
+};
+
+export const Controlled = {
+  render: ControlledTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -13,19 +13,39 @@ export default meta;
 
 type Story = StoryObj<typeof Combobox>;
 
+const items = [
+  { name: 'Ager', area: 'Norde Aker' },
+  { name: 'Bogerud Torg', area: 'Østensjø' },
+  { name: 'Bølgelengden', area: 'Nordstrand' },
+  { name: 'Ensjøveien 8', area: 'Gamle Oslo' },
+  { name: 'Fjorten', area: 'Nordre Aker' },
+  { name: 'Furuset Village', area: 'Alna' },
+  { name: 'Hoffsveien Hage', area: 'Ullern' },
+  { name: 'Lumanders hage', area: 'Gamle Oslo' },
+  { name: 'Løren botaniske', area: 'Grünerløkka' },
+  { name: 'Mortensrud Felt 16', area: 'Søndre Nordstrand' },
+  { name: 'Oen', area: 'Grorud' },
+  { name: 'Rosenholmveien', area: 'Søndre Nordstrand' },
+  { name: 'Røakollen', area: 'Vestre Aker' },
+  { name: 'Sandakerveien 121', area: 'Nordre Aker' },
+  { name: 'Stenbråtveien', area: 'Søndre Nordstrand' },
+  { name: 'Stilla', area: 'Nordre Aker' },
+  { name: 'Teglverksløkka', area: 'Bjerke' },
+  { name: 'Ulvenkroken', area: 'Bjerke' },
+  { name: 'Ulvenplassen', area: 'Bjerke' },
+  { name: 'Vitigrend', area: 'Vestre Aker' },
+  { name: 'Vollebekk', area: 'Bjerke' },
+  { name: 'Våronnveien 17', area: 'Østensjø' },
+];
+
 const Template = <T extends object>(args: ComboboxProps<T>) => {
   const select = (
     <Combobox {...args}>
-      <ComboboxItem id="agder">Agder</ComboboxItem>
-      <ComboboxItem id="innlandet">Innlandet</ComboboxItem>
-      <ComboboxItem id="more-og-romsdal">Møre og Romsdal</ComboboxItem>
-      <ComboboxItem id="oslo">Oslo</ComboboxItem>
-      <ComboboxItem id="rogaland">Rogaland</ComboboxItem>
-      <ComboboxItem id="trondelag">Trøndelag</ComboboxItem>
-      <ComboboxItem id="vestfold-og-telemark">
-        Vestfold og Telemark
-      </ComboboxItem>
-      <ComboboxItem id="viken">Viken</ComboboxItem>
+      {items.map((item) => (
+        <ComboboxItem key={item.name} textValue={item.name}>
+          {item.name}
+        </ComboboxItem>
+      ))}
     </Combobox>
   );
   return args.isRequired ? (
@@ -56,13 +76,13 @@ const ControlledTemplate = <T extends object>(args: ComboboxProps<T>) => {
 };
 
 const defaultProps = {
-  label: 'Velg område',
+  label: 'Velg boligprosjekt',
   isRequired: false,
   isInvalid: false,
   name: undefined,
   defaultSelectedKey: undefined,
   selectedKey: undefined,
-  placeholder: 'Velg område',
+  placeholder: 'Velg boligprosjekt',
 };
 
 export const Default: Story = {
@@ -91,8 +111,8 @@ export const WithoutLabel: Story = {
   args: {
     ...defaultProps,
     label: undefined,
-    placeholder: 'Velg område',
-    'aria-label': 'Velg område',
+    placeholder: 'Velg boligprosjekt',
+    'aria-label': 'Velg boligprosjekt',
   },
 };
 

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -82,10 +82,11 @@ const ControlledTemplate = <T extends object>(args: ComboboxProps<T>) => {
 };
 
 const AsyncTemplate = <T extends object>(args: ComboboxProps<T>) => {
-  const [items, setItems] = useState([]);
+  const [items, setItems] = useState<Array<{ url: string; name: string }>>([]);
   const [filterText, setFilterText] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
+  // TODO: Add debouncing
   useEffect(() => {
     async function fetchData() {
       if (filterText.length >= 2) {
@@ -100,12 +101,13 @@ const AsyncTemplate = <T extends object>(args: ComboboxProps<T>) => {
     }
     fetchData();
   }, [filterText]);
-  console.log(items);
 
   return (
     <Combobox
-      label="SW character lookup"
-      items={items}
+      // items={items}
+      // provide our own filtering as the result is already filtered. Should behave same as
+      // providing items={items}, but TS is complaining for some reason. Doing this for now.
+      defaultFilter={() => true}
       onInputChange={setFilterText}
       inputValue={filterText}
       isLoading={isLoading}
@@ -126,6 +128,7 @@ const defaultProps = {
   defaultSelectedKey: undefined,
   selectedKey: undefined,
   placeholder: 'Velg boligprosjekt',
+  isLoading: false,
 };
 
 export const Default: Story = {
@@ -188,5 +191,7 @@ export const Async = {
 
   args: {
     ...defaultProps,
+    label: 'SW characters lookup',
+    placeholder: 'Search for names',
   },
 };

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -12,7 +12,8 @@ import {
 } from 'react-aria-components';
 import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
 
-import { classes } from '../select/Select';
+import { classes as inputClasses } from '../textfield/TextField';
+import { classes as selectClasses } from '../select/Select';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -52,25 +53,17 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
   return (
     <RACCombobox
       {...restProps}
-      className={cx(className, 'group flex flex-col gap-2')}
+      className={cx(className, inputClasses.field)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
 
-      <Group
-        className={cx(
-          'flex cursor-default items-center gap-2',
-          'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6',
-          // focus
-          'ring-black focus:outline-none focus-visible:ring-2',
-          // invalid
-          'group-data-[invalid]:border-red',
-        )}
-      >
-        <Input className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />
+      <Group className="inline-flex items-center">
+        <Input className={inputClasses.input} />
+        {/* <Input className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" /> */}
         <Button>
-          <ChevronDown className={classes.chevron} />
+          <ChevronDown className={selectClasses.chevron} />
         </Button>
       </Group>
 
@@ -78,12 +71,12 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
 
       <Popover
         className={cx(
-          classes.popover,
+          selectClasses.popover,
           'min-w-[calc(var(--trigger-width)+1.5rem)]',
         )}
         offset={20}
       >
-        <ListBox className={classes.listbox}>{children}</ListBox>
+        <ListBox className={selectClasses.listbox}>{children}</ListBox>
       </Popover>
     </RACCombobox>
   );

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -60,7 +60,7 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
       {description && <Description>{description}</Description>}
 
       <Group className={cx('inline-flex items-center gap-2')}>
-        <Input className={inputClasses.input} />
+        <Input className={cx(inputClasses.input, 'flex-1')} />
         <Button>
           <ChevronDown className={selectClasses.chevron} />
         </Button>

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -60,7 +60,7 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
       {description && <Description>{description}</Description>}
 
       <Group className={cx('inline-flex items-center gap-2')}>
-        <Input className={cx(inputClasses.input, 'flex-1')} />
+        <Input className={cx(inputClasses.input(), 'flex-1')} />
         <Button>
           <ChevronDown className={selectClasses.chevron} />
         </Button>

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -10,7 +10,11 @@ import {
   ListBoxItem,
   ListBoxItemProps,
 } from 'react-aria-components';
-import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
+import {
+  ChevronDown,
+  Check,
+  LoadingSpinner,
+} from '@obosbbl/grunnmuren-icons-react';
 
 import { classes as inputClasses } from '../textfield/TextField';
 import { classes as selectClasses } from '../select/Select';
@@ -26,6 +30,11 @@ type ComboboxProps<T extends object> = {
   description?: React.ReactNode;
   /** Error message for the form control. Automatically sets `isInvalid` to true */
   errorMessage?: React.ReactNode;
+  /**
+   * Display the dropdown button in a loading state
+   * @default false
+   */
+  isLoading?: boolean;
   /** Label for the form control. */
   label?: React.ReactNode;
   /** Placeholder text. Only visible when the input value is empty. */
@@ -43,6 +52,7 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
     children,
     description,
     errorMessage,
+    isLoading,
     label,
     isInvalid: _isInvalid,
     ...restProps
@@ -62,7 +72,11 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
       <Group className={inputClasses.inputGroup}>
         <Input className={inputClasses.input({ isGrouped: true })} />
         <Button>
-          <ChevronDown className={selectClasses.chevron} />
+          {isLoading ? (
+            <LoadingSpinner className="animate-spin" />
+          ) : (
+            <ChevronDown className={selectClasses.chevron} />
+          )}
         </Button>
       </Group>
 

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -81,7 +81,7 @@ const ComboboxItem = (props: ListBoxItemProps) => {
       {...props}
       className={cx(
         props.className,
-        'flex cursor-default px-6 py-2 leading-6 outline-none focus:bg-sky-lightest',
+        'flex cursor-default px-6 py-2 leading-6 outline-none data-[focused]:bg-sky-lightest',
       )}
     >
       {({ isSelected }) => (

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-aria-components';
 import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
 
+import { styles } from '../select/Select';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -75,8 +76,15 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
 
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
-      <Popover className="min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out">
-        <ListBox className="text-sm outline-none">{children}</ListBox>
+      <Popover
+        className={cx(
+          styles.popover,
+          'min-w-[calc(var(--trigger-width)+1.5rem)]',
+        )}
+        offset={20}
+        // crossOffset={-12}
+      >
+        <ListBox className={styles.listbox}>{children}</ListBox>
       </Popover>
     </RACCombobox>
   );

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -59,8 +59,8 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
 
-      <Group className={cx('inline-flex items-center gap-2')}>
-        <Input className={cx(inputClasses.input(), 'flex-1')} />
+      <Group className={inputClasses.inputGroup}>
+        <Input className={inputClasses.input({ isGrouped: true })} />
         <Button>
           <ChevronDown className={selectClasses.chevron} />
         </Button>

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -16,8 +16,7 @@ import {
   LoadingSpinner,
 } from '@obosbbl/grunnmuren-icons-react';
 
-import { classes as inputClasses } from '../textfield/TextField';
-import { classes as selectClasses } from '../select/Select';
+import { formField, inputGroup, input, dropdown } from '../classes';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -31,7 +30,7 @@ type ComboboxProps<T extends object> = {
   /** Error message for the form control. Automatically sets `isInvalid` to true */
   errorMessage?: React.ReactNode;
   /**
-   * Display the dropdown button in a loading state
+   * Display the dropdown button trigger in a loading state
    * @default false
    */
   isLoading?: boolean;
@@ -63,19 +62,19 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
   return (
     <RACCombobox
       {...restProps}
-      className={cx(className, inputClasses.field)}
+      className={cx(className, formField)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
 
-      <Group className={inputClasses.inputGroup}>
-        <Input className={inputClasses.input({ isGrouped: true })} />
+      <Group className={inputGroup}>
+        <Input className={input({ isGrouped: true })} />
         <Button>
           {isLoading ? (
             <LoadingSpinner className="animate-spin" />
           ) : (
-            <ChevronDown className={selectClasses.chevron} />
+            <ChevronDown className={dropdown.chevronIcon} />
           )}
         </Button>
       </Group>
@@ -88,18 +87,27 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
         // and the offset.
         // The input gutter should probably be moved to a theme variable instead of using the hardcoded value as here.
         className={cx(
-          selectClasses.popover,
+          dropdown.popover,
           'min-w-[calc(var(--trigger-width)+26px)]',
         )}
         crossOffset={-13}
       >
-        <ListBox className={selectClasses.listbox}>{children}</ListBox>
+        <ListBox className={dropdown.listbox}>{children}</ListBox>
       </Popover>
     </RACCombobox>
   );
 }
 
 const ComboboxItem = (props: ListBoxItemProps) => {
+  let textValue = props.textValue;
+
+  // When the ListBoxItem child isn't a string we have to set textValue for keyboard completion to work.
+  // Since we use a render function (to handle the selected state) the child is never a string.
+  // This condition adds back that behaviour
+  if (textValue == null && typeof props.children === 'string') {
+    textValue = props.children;
+  }
+
   return (
     <ListBoxItem
       {...props}
@@ -107,6 +115,7 @@ const ComboboxItem = (props: ListBoxItemProps) => {
         props.className,
         'flex cursor-default px-6 py-2 leading-6 outline-none data-[focused]:bg-sky-lightest',
       )}
+      textValue={textValue}
     >
       {({ isSelected }) => (
         <>

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -59,9 +59,8 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
 
-      <Group className="inline-flex items-center">
+      <Group className={cx('inline-flex items-center gap-2')}>
         <Input className={inputClasses.input} />
-        {/* <Input className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" /> */}
         <Button>
           <ChevronDown className={selectClasses.chevron} />
         </Button>
@@ -69,13 +68,7 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
 
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
-      <Popover
-        className={cx(
-          selectClasses.popover,
-          'min-w-[calc(var(--trigger-width)+1.5rem)]',
-        )}
-        offset={20}
-      >
+      <Popover className={selectClasses.popover}>
         <ListBox className={selectClasses.listbox}>{children}</ListBox>
       </Popover>
     </RACCombobox>

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -68,7 +68,17 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
 
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
-      <Popover className={selectClasses.popover}>
+      <Popover
+        // FIXME: The trigger width doesn't include the padding of the group, so for now we have to apply this workaround.
+        // Also... the combobox border gets a pixel wider when focused, so we account for that as well when calculating the width
+        // and the offset.
+        // The input gutter should probably be moved to a theme variable instead of using the hardcoded value as here.
+        className={cx(
+          selectClasses.popover,
+          'min-w-[calc(var(--trigger-width)+26px)]',
+        )}
+        crossOffset={-13}
+      >
         <ListBox className={selectClasses.listbox}>{children}</ListBox>
       </Popover>
     </RACCombobox>

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -1,0 +1,109 @@
+import { cx } from 'cva';
+import {
+  ListBox,
+  Group,
+  Popover,
+  ComboBox as RACCombobox,
+  Button,
+  Input,
+  type ComboBoxProps as RACComboboxProps,
+  ListBoxItem,
+  ListBoxItemProps,
+} from 'react-aria-components';
+import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
+
+import { Label } from '../label/Label';
+import { Description } from '../label/Description';
+import { ErrorMessage } from '../label/ErrorMessage';
+
+type ComboboxProps<T extends object> = {
+  children: React.ReactNode;
+  /** Additional CSS className for the element. */
+  className?: string;
+  /** Help text for the form control. */
+  description?: React.ReactNode;
+  /** Error message for the form control. Automatically sets `isInvalid` to true */
+  errorMessage?: React.ReactNode;
+  /** Label for the form control. */
+  label?: React.ReactNode;
+  /** Placeholder text. Only visible when the input value is empty. */
+  placeholder?: string;
+  /** Additional style properties for the element. */
+  style?: React.CSSProperties;
+} & Omit<
+  RACComboboxProps<T>,
+  'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
+>;
+
+function Combobox<T extends object>(props: ComboboxProps<T>) {
+  const {
+    className,
+    children,
+    description,
+    errorMessage,
+    label,
+    isInvalid: _isInvalid,
+    ...restProps
+  } = props;
+
+  const isInvalid = _isInvalid || errorMessage != null;
+
+  return (
+    <RACCombobox
+      {...restProps}
+      className={cx(className, 'group flex flex-col gap-2')}
+      isInvalid={isInvalid}
+    >
+      {label && <Label>{label}</Label>}
+      {description && <Description>{description}</Description>}
+
+      <Group
+        className={cx(
+          'flex cursor-default items-center gap-2',
+          'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6',
+          // focus
+          'ring-black focus:outline-none focus-visible:ring-2',
+          // invalid
+          'group-data-[invalid]:border-red',
+        )}
+      >
+        <Input className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />
+        <Button>
+          <ChevronDown className="text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none" />
+        </Button>
+      </Group>
+
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+
+      <Popover className="min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out">
+        <ListBox className="text-sm outline-none">{children}</ListBox>
+      </Popover>
+    </RACCombobox>
+  );
+}
+
+const ComboboxItem = (props: ListBoxItemProps) => {
+  return (
+    <ListBoxItem
+      {...props}
+      className={cx(
+        props.className,
+        'flex cursor-default px-6 py-2 leading-6 outline-none focus:bg-sky-lightest',
+      )}
+    >
+      {({ isSelected }) => (
+        <>
+          {isSelected && <Check className="-ml-6 text-base" />}
+          {props.children}
+        </>
+      )}
+    </ListBoxItem>
+  );
+};
+
+export {
+  Combobox,
+  ComboboxItem,
+  type ComboboxProps,
+  type ListBoxItemProps as ComboboxItemProps,
+};

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-aria-components';
 import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
 
-import { styles } from '../select/Select';
+import { classes } from '../select/Select';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -78,13 +78,12 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
 
       <Popover
         className={cx(
-          styles.popover,
+          classes.popover,
           'min-w-[calc(var(--trigger-width)+1.5rem)]',
         )}
         offset={20}
-        // crossOffset={-12}
       >
-        <ListBox className={styles.listbox}>{children}</ListBox>
+        <ListBox className={classes.listbox}>{children}</ListBox>
       </Popover>
     </RACCombobox>
   );

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -70,7 +70,7 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
       >
         <Input className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />
         <Button>
-          <ChevronDown className="text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none" />
+          <ChevronDown className={classes.chevron} />
         </Button>
       </Group>
 

--- a/packages/react/src/combobox/index.ts
+++ b/packages/react/src/combobox/index.ts
@@ -1,0 +1,6 @@
+export {
+  Combobox,
+  ComboboxItem,
+  type ComboboxProps,
+  type ComboboxItemProps,
+} from './Combobox';

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-aria-components';
 import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
 
+import { classes as inputClasses } from '../textfield/TextField';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -21,6 +22,9 @@ const classes = {
     // 'overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
   ),
   listbox: cx('text-sm outline-none'),
+  chevron: cx(
+    'text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none',
+  ),
 };
 
 type SelectProps<T extends object> = {
@@ -66,22 +70,26 @@ function Select<T extends object>(props: SelectProps<T>) {
 
       <Button
         className={cx(
+          // 'flex cursor-default items-center gap-2',
+          // 'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6',
+          // // focus
+          // 'ring-black focus:outline-none focus-visible:ring-2',
+          // // invalid
+          // 'group-data-[invalid]:border-red',
+          inputClasses.input,
+          // TODO: focus or focus-visible?
+          // How to reuse placeholder text?
           'flex cursor-default items-center gap-2',
-          'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6',
-          // focus
-          'ring-black focus:outline-none focus-visible:ring-2',
-          // invalid
-          'group-data-[invalid]:border-red',
         )}
       >
         <SelectValue className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />
-        <ChevronDown className="text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none" />
+        <ChevronDown className={classes.chevron} />
       </Button>
 
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
-      <Popover className={styles.popover}>
-        <ListBox className={styles.listbox}>{children}</ListBox>
+      <Popover className={classes.popover}>
+        <ListBox className={classes.listbox}>{children}</ListBox>
       </Popover>
     </RACSelect>
   );

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -15,6 +15,14 @@ import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
 
+const styles = {
+  popover: cx(
+    'min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
+    // 'overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
+  ),
+  listbox: cx('text-sm outline-none'),
+};
+
 type SelectProps<T extends object> = {
   children: React.ReactNode;
   /** Additional CSS className for the element. */
@@ -72,8 +80,8 @@ function Select<T extends object>(props: SelectProps<T>) {
 
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
-      <Popover className="min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out">
-        <ListBox className="text-sm outline-none">{children}</ListBox>
+      <Popover className={styles.popover}>
+        <ListBox className={styles.listbox}>{children}</ListBox>
       </Popover>
     </RACSelect>
   );
@@ -103,4 +111,5 @@ export {
   SelectItem,
   type SelectProps,
   type ListBoxItemProps as SelectItemProps,
+  styles,
 };

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -101,7 +101,7 @@ const SelectItem = (props: ListBoxItemProps) => {
       {...props}
       className={cx(
         props.className,
-        'flex cursor-default px-6 py-2 leading-6 outline-none focus:bg-sky-lightest',
+        'flex cursor-default px-6 py-2 leading-6 outline-none data-[focused]:bg-sky-lightest',
       )}
     >
       {({ isSelected }) => (

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -62,7 +62,7 @@ function Select<T extends object>(props: SelectProps<T>) {
   return (
     <RACSelect
       {...restProps}
-      className={cx(className, 'group flex flex-col gap-2')}
+      className={cx(className, inputClasses.field)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -19,7 +19,6 @@ import { ErrorMessage } from '../label/ErrorMessage';
 const classes = {
   popover: cx(
     'min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
-    // 'overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
   ),
   listbox: cx('text-sm outline-none'),
   chevron: cx(
@@ -70,14 +69,7 @@ function Select<T extends object>(props: SelectProps<T>) {
 
       <Button
         className={cx(
-          // 'flex cursor-default items-center gap-2',
-          // 'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6',
-          // // focus
-          // 'ring-black focus:outline-none focus-visible:ring-2',
-          // // invalid
-          // 'group-data-[invalid]:border-red',
-          inputClasses.input({ focusVisible: true }),
-          // TODO: focus or focus-visible?
+          inputClasses.input({ focusModifier: 'visible' }),
           // How to reuse placeholder text?
           'inline-flex cursor-default items-center gap-2',
         )}

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -79,7 +79,7 @@ function Select<T extends object>(props: SelectProps<T>) {
           inputClasses.input,
           // TODO: focus or focus-visible?
           // How to reuse placeholder text?
-          'flex cursor-default items-center gap-2',
+          'inline-flex cursor-default items-center gap-2',
         )}
       >
         <SelectValue className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -15,7 +15,7 @@ import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
 
-const styles = {
+const classes = {
   popover: cx(
     'min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
     // 'overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
@@ -111,5 +111,5 @@ export {
   SelectItem,
   type SelectProps,
   type ListBoxItemProps as SelectItemProps,
-  styles,
+  classes,
 };

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -11,20 +11,10 @@ import {
 } from 'react-aria-components';
 import { ChevronDown, Check } from '@obosbbl/grunnmuren-icons-react';
 
-import { classes as inputClasses } from '../textfield/TextField';
+import { formField, input, dropdown } from '../classes';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
-
-const classes = {
-  popover: cx(
-    'min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
-  ),
-  listbox: cx('text-sm outline-none'),
-  chevron: cx(
-    'text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none',
-  ),
-};
 
 type SelectProps<T extends object> = {
   children: React.ReactNode;
@@ -61,7 +51,7 @@ function Select<T extends object>(props: SelectProps<T>) {
   return (
     <RACSelect
       {...restProps}
-      className={cx(className, inputClasses.field)}
+      className={cx(className, formField)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}
@@ -69,25 +59,34 @@ function Select<T extends object>(props: SelectProps<T>) {
 
       <Button
         className={cx(
-          inputClasses.input({ focusModifier: 'visible' }),
+          input({ focusModifier: 'visible' }),
           // How to reuse placeholder text?
           'inline-flex cursor-default items-center gap-2',
         )}
       >
         <SelectValue className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />
-        <ChevronDown className={classes.chevron} />
+        <ChevronDown className={dropdown.chevronIcon} />
       </Button>
 
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
-      <Popover className={classes.popover}>
-        <ListBox className={classes.listbox}>{children}</ListBox>
+      <Popover className={dropdown.popover}>
+        <ListBox className={dropdown.listbox}>{children}</ListBox>
       </Popover>
     </RACSelect>
   );
 }
 
 const SelectItem = (props: ListBoxItemProps) => {
+  let textValue = props.textValue;
+
+  // When the ListBoxItem child isn't a string we have to set textValue for keyboard completion to work.
+  // Since we use a render function (to handle the selected state) the child is never a string.
+  // This condition adds back that behaviour
+  if (textValue == null && typeof props.children === 'string') {
+    textValue = props.children;
+  }
+
   return (
     <ListBoxItem
       {...props}
@@ -95,6 +94,7 @@ const SelectItem = (props: ListBoxItemProps) => {
         props.className,
         'flex cursor-default px-6 py-2 leading-6 outline-none data-[focused]:bg-sky-lightest',
       )}
+      textValue={textValue}
     >
       {({ isSelected }) => (
         <>
@@ -111,5 +111,4 @@ export {
   SelectItem,
   type SelectProps,
   type ListBoxItemProps as SelectItemProps,
-  classes,
 };

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -76,7 +76,7 @@ function Select<T extends object>(props: SelectProps<T>) {
           // 'ring-black focus:outline-none focus-visible:ring-2',
           // // invalid
           // 'group-data-[invalid]:border-red',
-          inputClasses.input,
+          inputClasses.input({ focusVisible: true }),
           // TODO: focus or focus-visible?
           // How to reuse placeholder text?
           'inline-flex cursor-default items-center gap-2',

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -33,17 +33,6 @@ type TextAreaProps = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-// const classes = {
-//   base: cx('group flex flex-col gap-2'),
-//   textarea: cx([
-//     'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070]',
-//     // focus
-//     'focus:outline-none focus:ring-2 focus:ring-black',
-//     // invalid
-//     'data-[invalid]:border-red',
-//   ]),
-// };
-
 function TextArea(props: TextAreaProps) {
   const {
     className,

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -49,7 +49,7 @@ function TextArea(props: TextAreaProps) {
   return (
     <RACTextField
       {...restProps}
-      className={cx(className, classes.base)}
+      className={cx(className, classes.field)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -5,7 +5,7 @@ import {
   type TextFieldProps as RACTextFieldProps,
 } from 'react-aria-components';
 
-import { classes } from '../textfield/TextField';
+import { formField, input } from '../classes';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -49,12 +49,12 @@ function TextArea(props: TextAreaProps) {
   return (
     <RACTextField
       {...restProps}
-      className={cx(className, classes.field)}
+      className={cx(className, formField)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
-      <RACTextArea className={classes.input()} rows={rows} />
+      <RACTextArea className={input()} rows={rows} />
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </RACTextField>
   );

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -54,7 +54,7 @@ function TextArea(props: TextAreaProps) {
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
-      <RACTextArea className={classes.input} rows={rows} />
+      <RACTextArea className={classes.input()} rows={rows} />
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </RACTextField>
   );

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -5,6 +5,7 @@ import {
   type TextFieldProps as RACTextFieldProps,
 } from 'react-aria-components';
 
+import { classes } from '../textfield/TextField';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -32,16 +33,16 @@ type TextAreaProps = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-const classes = {
-  base: cx('group flex flex-col gap-2'),
-  textarea: cx([
-    'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070]',
-    // focus
-    'focus:outline-none focus:ring-2 focus:ring-black',
-    // invalid
-    'data-[invalid]:border-red',
-  ]),
-};
+// const classes = {
+//   base: cx('group flex flex-col gap-2'),
+//   textarea: cx([
+//     'rounded-md border border-black px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070]',
+//     // focus
+//     'focus:outline-none focus:ring-2 focus:ring-black',
+//     // invalid
+//     'data-[invalid]:border-red',
+//   ]),
+// };
 
 function TextArea(props: TextAreaProps) {
   const {
@@ -64,7 +65,7 @@ function TextArea(props: TextAreaProps) {
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
-      <RACTextArea className={classes.textarea} rows={rows} />
+      <RACTextArea className={classes.input} rows={rows} />
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </RACTextField>
   );

--- a/packages/react/src/textfield/TextField.stories.tsx
+++ b/packages/react/src/textfield/TextField.stories.tsx
@@ -45,6 +45,9 @@ const ControlledTemplate = (args: TextFieldProps) => {
 const LeftAddonTemplate = (args: TextFieldProps) => {
   return (
     <TextField {...args} leftAddon={<Mail className="pointer-events-none" />} />
+    // <TextField {...args}>
+    //   <Mail className="pointer-events-none" />
+    // </TextField>
   );
 };
 

--- a/packages/react/src/textfield/TextField.stories.tsx
+++ b/packages/react/src/textfield/TextField.stories.tsx
@@ -45,9 +45,6 @@ const ControlledTemplate = (args: TextFieldProps) => {
 const LeftAddonTemplate = (args: TextFieldProps) => {
   return (
     <TextField {...args} leftAddon={<Mail className="pointer-events-none" />} />
-    // <TextField {...args}>
-    //   <Mail className="pointer-events-none" />
-    // </TextField>
   );
 };
 

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -77,17 +77,19 @@ const classes = {
   input: cva({
     base: [
       'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
-      // 'focus:ring-2',
-      'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus:ring',
+      // invalid styles
+      'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
     ],
     variants: {
-      focusVisible: {
-        true: 'data-[focus-visible]:ring-2',
-        false: 'focus:ring-2',
+      // Focus rings
+      focusModifier: {
+        visible:
+          'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
+        focus: 'focus:ring-2 group-data-[invalid]:focus:ring',
       },
     },
     defaultVariants: {
-      focusVisible: false,
+      focusModifier: 'focus',
     },
   }),
   inputGroup: cx('inline-flex items-center'),

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -79,6 +79,7 @@ const classes = {
     'focus:ring-2',
     'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus:ring',
   ),
+  inputGroup: cx(),
   divider: cx('block h-6 w-px flex-none bg-black'),
 };
 

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -73,7 +73,7 @@ type TextFieldProps = {
 // };
 
 const classes = {
-  base: cx('group flex flex-col gap-2'),
+  field: cx('group flex flex-col gap-2'),
   input: cx(
     'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
     'focus:ring-2',
@@ -113,7 +113,7 @@ function TextField(props: TextFieldProps) {
   return (
     <RACTextField
       {...restProps}
-      className={cx(className, classes.base)}
+      className={cx(className, classes.field)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -74,18 +74,29 @@ type TextFieldProps = {
 
 const classes = {
   field: cx('group flex flex-col gap-2'),
-  input: cx(
-    'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
-    'focus:ring-2',
-    'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus:ring',
-  ),
-  inputGroup: cx(),
+  input: cva({
+    base: [
+      'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
+      // 'focus:ring-2',
+      'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus:ring',
+    ],
+    variants: {
+      focusVisible: {
+        true: 'data-[focus-visible]:ring-2',
+        false: 'focus:ring-2',
+      },
+    },
+    defaultVariants: {
+      focusVisible: false,
+    },
+  }),
+  inputGroup: cx('inline-flex items-center'),
   divider: cx('block h-6 w-px flex-none bg-black'),
 };
 
 const variants = {
   input: cva({
-    base: classes.input,
+    base: classes.input(),
     variants: {
       textAlign: {
         right: 'text-right',
@@ -121,7 +132,7 @@ function TextField(props: TextFieldProps) {
       {description && <Description>{description}</Description>}
 
       {leftAddon || rightAddon ? (
-        <Group className="inline-flex items-center">
+        <Group className={classes.inputGroup}>
           {leftAddon}
           {withAddonDivider && leftAddon && <Divider className="ml-3" />}
           <Input className={variants.input({ textAlign })} />

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -3,6 +3,7 @@ import {
   Input,
   TextField as RACTextField,
   type TextFieldProps as RACTextFieldProps,
+  Group,
 } from 'react-aria-components';
 
 import { Label } from '../label/Label';
@@ -78,6 +79,19 @@ const classes = {
     'focus:ring-2',
     'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus:ring',
   ),
+  divider: cx('block h-6 w-px flex-none bg-black'),
+};
+
+const variants = {
+  input: cva({
+    base: classes.input,
+    variants: {
+      textAlign: {
+        right: 'text-right',
+        left: '',
+      },
+    },
+  }),
 };
 
 function TextField(props: TextFieldProps) {
@@ -86,11 +100,11 @@ function TextField(props: TextFieldProps) {
     description,
     errorMessage,
     label,
-    // leftAddon,
+    leftAddon,
     isInvalid: _isInvalid,
     textAlign,
-    // rightAddon,
-    // withAddonDivider,
+    rightAddon,
+    withAddonDivider,
     ...restProps
   } = props;
 
@@ -104,6 +118,19 @@ function TextField(props: TextFieldProps) {
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
+
+      {leftAddon || rightAddon ? (
+        <Group className="inline-flex items-center">
+          {leftAddon}
+          {withAddonDivider && leftAddon && <Divider className="ml-3" />}
+          <Input className={variants.input({ textAlign })} />
+          {withAddonDivider && rightAddon && <Divider className="mr-3" />}
+          {rightAddon}
+        </Group>
+      ) : (
+        <Input className={variants.input({ textAlign })} />
+      )}
+
       {/* <div
         className={classes.inputWrapper({
           leftAddon: !!leftAddon,
@@ -113,7 +140,7 @@ function TextField(props: TextFieldProps) {
       {/* {leftAddon}
         {withAddonDivider && leftAddon && <Divider className="ml-3" />} */}
       {/* <Input className={classes.input({ textAlign })} /> */}
-      <Input className={classes.input} />
+      {/* <Input className={classes.input} /> */}
       {/* {withAddonDivider && rightAddon && <Divider className="mr-3" />}
         {rightAddon}
       </div> */}

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -137,7 +137,7 @@ function TextField(props: TextFieldProps) {
         <Group className={classes.inputGroup}>
           {leftAddon}
           {withAddonDivider && leftAddon && <Divider className="ml-3" />}
-          <Input className={variants.input({ textAlign })} />
+          <Input className={cx(variants.input({ textAlign }), 'flex-1')} />
           {withAddonDivider && rightAddon && <Divider className="mr-3" />}
           {rightAddon}
         </Group>

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -1,4 +1,4 @@
-import { cx, cva } from 'cva';
+import { cx, cva, compose } from 'cva';
 import {
   Input,
   TextField as RACTextField,
@@ -87,18 +87,25 @@ const classes = {
           'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
         focus: 'focus:ring-2 group-data-[invalid]:focus:ring',
       },
+      isGrouped: {
+        false: '',
+        true: 'flex-1 !ring-0',
+      },
     },
     defaultVariants: {
       focusModifier: 'focus',
+      isGrouped: false,
     },
   }),
-  inputGroup: cx('inline-flex items-center'),
+  inputGroup: cx(
+    'inline-flex items-center overflow-hidden rounded-md ring-1 ring-black focus-within:ring-2 group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
+  ),
   divider: cx('block h-6 w-px flex-none bg-black'),
 };
 
 const variants = {
   input: cva({
-    base: classes.input(),
+    base: '',
     variants: {
       textAlign: {
         right: 'text-right',
@@ -107,6 +114,8 @@ const variants = {
     },
   }),
 };
+
+const test = compose(classes.input, variants.input);
 
 function TextField(props: TextFieldProps) {
   const {
@@ -137,12 +146,12 @@ function TextField(props: TextFieldProps) {
         <Group className={classes.inputGroup}>
           {leftAddon}
           {withAddonDivider && leftAddon && <Divider className="ml-3" />}
-          <Input className={cx(variants.input({ textAlign }), 'flex-1')} />
+          <Input className={test({ textAlign, isGrouped: true })} />
           {withAddonDivider && rightAddon && <Divider className="mr-3" />}
           {rightAddon}
         </Group>
       ) : (
-        <Input className={variants.input({ textAlign })} />
+        <Input className={test({ textAlign })} />
       )}
 
       {/* <div

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -38,37 +38,46 @@ type TextFieldProps = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
+// const classes = {
+//   base: cx('group flex flex-col gap-2'),
+//   inputWrapper: cva({
+//     base: [
+//       'relative inline-flex flex-row items-center rounded-md border border-black py-2.5 text-sm font-normal leading-6',
+//       // prevent icons in addons from being flexed and affected by the text size of the input
+//       '[&>svg]:flex-none [&>svg]:text-base',
+//       // focus
+//       'focus-within:ring-2 focus-within:ring-blue-dark',
+//       // invalid
+//       'group-data-[invalid]:border-red group-data-[invalid]:outline group-data-[invalid]:outline-1 group-data-[invalid]:outline-red',
+//     ],
+//     variants: {
+//       leftAddon: {
+//         true: 'pl-3',
+//       },
+//       rightAddon: {
+//         true: 'pr-3',
+//       },
+//     },
+//   }),
+//   input: cva({
+//     base: 'relative w-full px-3 font-normal leading-6 placeholder-[#727070] !outline-none',
+//     variants: {
+//       textAlign: {
+//         right: 'text-right',
+//         left: '',
+//       },
+//     },
+//   }),
+//   divider: cx('block h-6 w-px flex-none bg-black'),
+// };
+
 const classes = {
   base: cx('group flex flex-col gap-2'),
-  inputWrapper: cva({
-    base: [
-      'relative inline-flex flex-row items-center rounded-md border border-black py-2.5 text-sm font-normal leading-6',
-      // prevent icons in addons from being flexed and affected by the text size of the input
-      '[&>svg]:flex-none [&>svg]:text-base',
-      // focus
-      'focus-within:ring-2 focus-within:ring-blue-dark',
-      // invalid
-      'group-data-[invalid]:border-red group-data-[invalid]:outline group-data-[invalid]:outline-1 group-data-[invalid]:outline-red',
-    ],
-    variants: {
-      leftAddon: {
-        true: 'pl-3',
-      },
-      rightAddon: {
-        true: 'pr-3',
-      },
-    },
-  }),
-  input: cva({
-    base: 'relative w-full px-3 font-normal leading-6 placeholder-[#727070] !outline-none',
-    variants: {
-      textAlign: {
-        right: 'text-right',
-        left: '',
-      },
-    },
-  }),
-  divider: cx('block h-6 w-px flex-none bg-black'),
+  input: cx(
+    'rounded-md px-3 py-2.5 text-sm font-normal leading-6 outline-none ring-1 ring-black',
+    'focus-within:ring-2',
+    'group-data-[invalid]:ring-red ',
+  ),
 };
 
 function TextField(props: TextFieldProps) {
@@ -77,11 +86,11 @@ function TextField(props: TextFieldProps) {
     description,
     errorMessage,
     label,
-    leftAddon,
+    // leftAddon,
     isInvalid: _isInvalid,
     textAlign,
-    rightAddon,
-    withAddonDivider,
+    // rightAddon,
+    // withAddonDivider,
     ...restProps
   } = props;
 
@@ -95,18 +104,19 @@ function TextField(props: TextFieldProps) {
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
-      <div
+      {/* <div
         className={classes.inputWrapper({
           leftAddon: !!leftAddon,
           rightAddon: !!rightAddon,
         })}
-      >
-        {leftAddon}
-        {withAddonDivider && leftAddon && <Divider className="ml-3" />}
-        <Input className={classes.input({ textAlign })} />
-        {withAddonDivider && rightAddon && <Divider className="mr-3" />}
+      > */}
+      {/* {leftAddon}
+        {withAddonDivider && leftAddon && <Divider className="ml-3" />} */}
+      {/* <Input className={classes.input({ textAlign })} /> */}
+      <Input className={classes.input} />
+      {/* {withAddonDivider && rightAddon && <Divider className="mr-3" />}
         {rightAddon}
-      </div>
+      </div> */}
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </RACTextField>
   );

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -6,6 +6,7 @@ import {
   Group,
 } from 'react-aria-components';
 
+import { formField, input, inputGroup } from '../classes';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessage } from '../label/ErrorMessage';
@@ -39,40 +40,9 @@ type TextFieldProps = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-const classes = {
-  field: cx('group flex flex-col gap-2'),
-  input: cva({
-    base: [
-      'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
-      // invalid styles
-      'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
-    ],
-    variants: {
-      // Focus rings. Can either be :focus or :focus-visible based on the needs of the particular component.
-      focusModifier: {
-        focus: 'focus:ring-2 group-data-[invalid]:focus:ring',
-        visible:
-          'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
-      },
-      isGrouped: {
-        false: '',
-        //
-        true: 'flex-1 !ring-0 first:pl-0 last:pr-0',
-      },
-    },
-    defaultVariants: {
-      focusModifier: 'focus',
-      isGrouped: false,
-    },
-  }),
-  inputGroup: cx(
-    'inline-flex items-center overflow-hidden rounded-md px-3 ring-1 ring-black focus-within:ring-2 group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
-  ),
-  divider: cx('block h-6 w-px flex-none bg-black'),
-};
-
-const variants = {
-  input: cva({
+const inputWithAlignment = compose(
+  input,
+  cva({
     base: '',
     variants: {
       textAlign: {
@@ -81,9 +51,7 @@ const variants = {
       },
     },
   }),
-};
-
-const test = compose(classes.input, variants.input);
+);
 
 function TextField(props: TextFieldProps) {
   const {
@@ -104,22 +72,24 @@ function TextField(props: TextFieldProps) {
   return (
     <RACTextField
       {...restProps}
-      className={cx(className, classes.field)}
+      className={cx(className, formField)}
       isInvalid={isInvalid}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
 
       {leftAddon || rightAddon ? (
-        <Group className={classes.inputGroup}>
+        <Group className={inputGroup}>
           {leftAddon}
           {withAddonDivider && leftAddon && <Divider className="ml-3" />}
-          <Input className={test({ textAlign, isGrouped: true })} />
+          <Input
+            className={inputWithAlignment({ textAlign, isGrouped: true })}
+          />
           {withAddonDivider && rightAddon && <Divider className="mr-3" />}
           {rightAddon}
         </Group>
       ) : (
-        <Input className={test({ textAlign })} />
+        <Input className={inputWithAlignment({ textAlign })} />
       )}
 
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
@@ -128,7 +98,9 @@ function TextField(props: TextFieldProps) {
 }
 
 function Divider({ className }: { className: string }) {
-  return <span className={cx(className, classes.divider)} />;
+  return (
+    <span className={cx(className, 'block h-6 w-px flex-none bg-black')} />
+  );
 }
 
-export { TextField, type TextFieldProps, classes };
+export { TextField, type TextFieldProps };

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -74,9 +74,9 @@ type TextFieldProps = {
 const classes = {
   base: cx('group flex flex-col gap-2'),
   input: cx(
-    'rounded-md px-3 py-2.5 text-sm font-normal leading-6 outline-none ring-1 ring-black',
-    'focus-within:ring-2',
-    'group-data-[invalid]:ring-red ',
+    'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
+    'focus:ring-2',
+    'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus:ring',
   ),
 };
 
@@ -126,4 +126,4 @@ function Divider({ className }: { className: string }) {
   return <span className={cx(className, classes.divider)} />;
 }
 
-export { TextField, type TextFieldProps };
+export { TextField, type TextFieldProps, classes };

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -39,39 +39,6 @@ type TextFieldProps = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-// const classes = {
-//   base: cx('group flex flex-col gap-2'),
-//   inputWrapper: cva({
-//     base: [
-//       'relative inline-flex flex-row items-center rounded-md border border-black py-2.5 text-sm font-normal leading-6',
-//       // prevent icons in addons from being flexed and affected by the text size of the input
-//       '[&>svg]:flex-none [&>svg]:text-base',
-//       // focus
-//       'focus-within:ring-2 focus-within:ring-blue-dark',
-//       // invalid
-//       'group-data-[invalid]:border-red group-data-[invalid]:outline group-data-[invalid]:outline-1 group-data-[invalid]:outline-red',
-//     ],
-//     variants: {
-//       leftAddon: {
-//         true: 'pl-3',
-//       },
-//       rightAddon: {
-//         true: 'pr-3',
-//       },
-//     },
-//   }),
-//   input: cva({
-//     base: 'relative w-full px-3 font-normal leading-6 placeholder-[#727070] !outline-none',
-//     variants: {
-//       textAlign: {
-//         right: 'text-right',
-//         left: '',
-//       },
-//     },
-//   }),
-//   divider: cx('block h-6 w-px flex-none bg-black'),
-// };
-
 const classes = {
   field: cx('group flex flex-col gap-2'),
   input: cva({
@@ -81,15 +48,16 @@ const classes = {
       'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
     ],
     variants: {
-      // Focus rings
+      // Focus rings. Can either be :focus or :focus-visible based on the needs of the particular component.
       focusModifier: {
+        focus: 'focus:ring-2 group-data-[invalid]:focus:ring',
         visible:
           'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
-        focus: 'focus:ring-2 group-data-[invalid]:focus:ring',
       },
       isGrouped: {
         false: '',
-        true: 'flex-1 !ring-0',
+        //
+        true: 'flex-1 !ring-0 first:pl-0 last:pr-0',
       },
     },
     defaultVariants: {
@@ -98,7 +66,7 @@ const classes = {
     },
   }),
   inputGroup: cx(
-    'inline-flex items-center overflow-hidden rounded-md ring-1 ring-black focus-within:ring-2 group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
+    'inline-flex items-center overflow-hidden rounded-md px-3 ring-1 ring-black focus-within:ring-2 group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
   ),
   divider: cx('block h-6 w-px flex-none bg-black'),
 };
@@ -154,19 +122,6 @@ function TextField(props: TextFieldProps) {
         <Input className={test({ textAlign })} />
       )}
 
-      {/* <div
-        className={classes.inputWrapper({
-          leftAddon: !!leftAddon,
-          rightAddon: !!rightAddon,
-        })}
-      > */}
-      {/* {leftAddon}
-        {withAddonDivider && leftAddon && <Divider className="ml-3" />} */}
-      {/* <Input className={classes.input({ textAlign })} /> */}
-      {/* <Input className={classes.input} /> */}
-      {/* {withAddonDivider && rightAddon && <Divider className="mr-3" />}
-        {rightAddon}
-      </div> */}
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </RACTextField>
   );

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -22,6 +22,6 @@
     "tailwindcss": "3.4.0"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.3.5"
+    "tailwindcss": "^3.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6703,7 +6703,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}


### PR DESCRIPTION
Dette startet som en PR på combobox, som endte opp med å touche de fleste formkomponentene.

Combobox består jo egentlig av en input og en select dropdown, men da jeg implementerte comoboxen var det umulig å gjenbruke stilene fra disse. Det endte dermed opp som en refaktorering med deling av stiler mellom TextField, TextArea, Combobox og Select.

Har samtidig fikset litt focus/invalid-stilene til alle de nevnte komponentene, da den bare halvferdig tidligere pga uferdig design.

Burde kanskje vært en egen PR, men har også oppgradert til nyeste Tailwind (under arbeidet med denne PRen brukte jeg noe av den nye funksjonaliteten fra 3.4, men gikk bort fra det igjen...

Merk at dette bare er en initial implementasjon av Combobox, det kommer nok mer etter hvert.

Ser også for meg at på sikt så tilbyr vi en debounce funksjon i dette biblioteket, siden alle som kommer til å bruke combobox som en async autocomplete vil ha det behovet.