### PR TITLE
Add version to form-demo to fix changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": ["form-demo"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/form-demo/package.json
+++ b/form-demo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "form-demo",
   "private": true,
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "build": "next build",

--- a/form-demo/package.json
+++ b/form-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "form-demo",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
changeset klikker totalt når en pakke eller app ikke har version. Legger også til ignore på form-demo i changesets sin config så den ikke driver og oppdaterer den. 

