### PR TITLE
rename loading prop for Button component

### DIFF
--- a/.changeset/tall-deers-jog.md
+++ b/.changeset/tall-deers-jog.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+rename Button component's `loading` prop to `isLoading` to align better with other prop names

--- a/form-demo/app/uncontrolled/SubmitButton.tsx
+++ b/form-demo/app/uncontrolled/SubmitButton.tsx
@@ -5,5 +5,5 @@ import { Button } from '@obosbbl/grunnmuren-react';
 export default function SubmitButton(props) {
   const { pending } = useFormStatus();
 
-  return <Button loading={pending} type="submit" {...props} />;
+  return <Button isLoading={pending} type="submit" {...props} />;
 }

--- a/packages/react/src/__stories__/FormValidation.stories.tsx
+++ b/packages/react/src/__stories__/FormValidation.stories.tsx
@@ -54,7 +54,7 @@ const Form = (props: {
       validationErrors={errors}
     >
       {props.children}
-      <Button type="submit" loading={isLoading}>
+      <Button type="submit" isLoading={isLoading}>
         Send inn
       </Button>
     </RACForm>

--- a/packages/react/src/button/Button.stories.tsx
+++ b/packages/react/src/button/Button.stories.tsx
@@ -40,7 +40,7 @@ export const Primary: Story = {
   args: {
     color: 'green',
     variant: 'primary',
-    loading: false,
+    isLoading: false,
   },
 };
 

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -110,7 +110,7 @@ type ButtonProps = VariantProps<typeof buttonVariants> & {
    * Display the button in a loading state
    * @default false
    */
-  loading?: boolean;
+  isLoading?: boolean;
   style?: React.CSSProperties;
 } & ButtonOrLinkProps;
 
@@ -120,7 +120,7 @@ function Button(props: ButtonProps) {
     className,
     color,
     isIconOnly,
-    loading,
+    isLoading,
     variant,
     style,
     ...restProps
@@ -131,7 +131,7 @@ function Button(props: ButtonProps) {
   const [widthOverride, setWidthOverride] = useState<number>();
 
   useClientLayoutEffect(() => {
-    if (loading) {
+    if (isLoading) {
       const requestID = window.requestAnimationFrame(() => {
         setWidthOverride(buttonRef?.current?.getBoundingClientRect()?.width);
       });
@@ -140,7 +140,7 @@ function Button(props: ButtonProps) {
         cancelAnimationFrame(requestID);
       };
     }
-  }, [loading, children]);
+  }, [isLoading, children]);
 
   let Component: 'a' | 'button' = 'a';
   if (props.href == null) {
@@ -152,7 +152,7 @@ function Button(props: ButtonProps) {
   return (
     // @ts-expect-error TS doesn't agree here taht restProps is safe to spread, because restProps for anchors aren't type compatible with restProps for buttons, but that should be okay here
     <Component
-      aria-busy={loading ? true : undefined}
+      aria-busy={isLoading ? true : undefined}
       className={buttonVariants({ className, color, isIconOnly, variant })}
       ref={buttonRef as never}
       style={{


### PR DESCRIPTION
Denne PRen endrer navn på propen til Button for å vise en loading indikator fra `<Button loading />` til `<Button isLoading />`. Dette for å følge konvensjonen til React Aria components (og vår egen). Det heter allerede `isLoading` i Combobox..