### PR TITLE
add I18nProvider to configure the locale

### DIFF
--- a/.changeset/kind-ladybugs-doubt.md
+++ b/.changeset/kind-ladybugs-doubt.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+add I18nProvider

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,1 +1,0 @@
-import './storybook.css';

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Preview } from '@storybook/react';
+import { I18nProvider } from '../packages/react/src/index';
+
+import './storybook.css';
+
+const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <I18nProvider locale="nb">
+        <Story />
+      </I18nProvider>
+    ),
+  ],
+};
+
+export default preview;

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -14,6 +14,42 @@ npm install @obosbbl/grunnmuren-react@canary
 pnpm add @obosbbl/grunnmuren-react@canary
 ```
 
+## Localization configuration
+
+Grunnmuren uses [React Aria Components](https://react-spectrum.adobe.com/react-aria/) under the hood. RAC has built in translation strings for non visible content (for accessibility reasons). It also automatically detects the language based on the browser or system language.
+
+To ensure that the language of the page content matches the accessibility strings you should wrap your application in a `I18nProvider`. This will override RAC's automatic locale selection.
+
+In [Next.js](https://nextjs.org/) you can do this in the root [root layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required).
+
+Valid locales for Norwegian are `nb-NO` or `nb`, Swedish is `sv-SE` or `sv`.
+
+```js
+// app/layout.tsx
+import { I18nProvider } from '@obosbbl/grunnmuren-react';
+
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+
+  // Either 'nb' or 'sv'
+  const locale = 'nb';
+
+  return (
+    <I18nProvider locale={locale}>
+      <html lang={locale}>
+        <body>{children}</body>
+      </html>
+    </I18nProvider>
+  )
+}
+```
+
+See the [RAC internationalization docs](https://react-spectrum.adobe.com/react-aria/internationalization.html) for more information.
+
 ## Usage
 
 Before you start using the components you need to configure the [Tailwind preset](../tailwind/). Remember to add this package to the content scan.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-export { Form } from 'react-aria-components';
+export { Form, I18nProvider } from 'react-aria-components';
 
 export * from './button';
 export * from './checkbox';


### PR DESCRIPTION
Denne PRen legger til støtte for I18nProvideren til React Aria Components.

Denne skal wrappe applikasjonen slik at RAC benytter riktige translation strings for diverese innebygde hjelpetekster. Den pårvirker også ting som tallformateringen i [NumberField](https://react-spectrum.adobe.com/react-aria/NumberField.html#numberfield) (som jeg tenker er en komponent vi legger til støtte for snart).

Her er et eksempel på Storybooken før og etter endringen:


Før, uten I18nProvider i Storybook:
<img width="227" alt="Screenshot 2024-01-12 at 20 33 24" src="https://github.com/code-obos/grunnmuren/assets/81577/62e40232-d023-42ca-9d70-22b4127c3df2">

Etter, med I18nProvider i Storybook, med locale satt til `nb`:
<img width="228" alt="Screenshot 2024-01-12 at 20 33 40" src="https://github.com/code-obos/grunnmuren/assets/81577/63a9d540-433e-4f0f-addd-07416fdc1ca5">

Kommer en oppfølgings-PR hvor jeg legger til dokumentasjon for [build utilen som fjerner unødvendige locales](https://react-spectrum.adobe.com/react-aria/internationalization.html#optimizing-bundle-size).
