### PR TITLE
add forwadRef support

### DIFF
--- a/.changeset/olive-flowers-film.md
+++ b/.changeset/olive-flowers-film.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+add forwardRef support for better compat with react-hook-form

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@obosbbl/grunnmuren-icons-react": "workspace:^2.0.0-canary.1",
+    "@react-aria/utils": "^3.23.0",
     "cva": "1.0.0-beta.1",
     "react-aria-components": "^1.0.0"
   },

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -1,6 +1,7 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, forwardRef, type Ref } from 'react';
 import { cva, type VariantProps } from 'cva';
 import { LoadingSpinner } from '@obosbbl/grunnmuren-icons-react';
+import { mergeRefs } from '@react-aria/utils';
 
 import { useClientLayoutEffect } from '../utils/useClientLayoutEffect';
 
@@ -114,7 +115,10 @@ type ButtonProps = VariantProps<typeof buttonVariants> & {
   style?: React.CSSProperties;
 } & ButtonOrLinkProps;
 
-function Button(props: ButtonProps) {
+function Button(
+  props: ButtonProps,
+  forwardedRef: Ref<HTMLButtonElement | HTMLAnchorElement>,
+) {
   const {
     children,
     className,
@@ -126,14 +130,15 @@ function Button(props: ButtonProps) {
     ...restProps
   } = props;
 
-  // TODO: Merge refs when we use RAC
-  const buttonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
   const [widthOverride, setWidthOverride] = useState<number>();
+
+  const ownRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const ref = mergeRefs(ownRef, forwardedRef);
 
   useClientLayoutEffect(() => {
     if (isLoading) {
       const requestID = window.requestAnimationFrame(() => {
-        setWidthOverride(buttonRef?.current?.getBoundingClientRect()?.width);
+        setWidthOverride(ownRef.current?.getBoundingClientRect()?.width);
       });
       return () => {
         setWidthOverride(undefined);
@@ -154,7 +159,7 @@ function Button(props: ButtonProps) {
     <Component
       aria-busy={isLoading ? true : undefined}
       className={buttonVariants({ className, color, isIconOnly, variant })}
-      ref={buttonRef as never}
+      ref={ref as never}
       style={{
         ...style,
         width: widthOverride,
@@ -171,4 +176,5 @@ function Button(props: ButtonProps) {
   );
 }
 
-export { Button, type ButtonProps };
+const _Button = forwardRef(Button);
+export { _Button as Button, type ButtonProps };

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { useId } from 'react';
 import { cx } from 'cva';
 import {
@@ -57,7 +58,7 @@ type CheckboxProps = {
   'isDisabled' | 'style' | 'children' | 'isIndeterminate' | 'isReadOnly'
 >;
 
-function Checkbox(props: CheckboxProps) {
+function Checkbox(props: CheckboxProps, ref: Ref<HTMLLabelElement>) {
   const {
     children,
     className,
@@ -86,6 +87,7 @@ function Checkbox(props: CheckboxProps) {
           {...restProps}
           className={cx(className, defaultClasses)}
           isInvalid={isInvalid}
+          ref={ref}
         >
           {/* increases the clickable area of the checkbox for accessibility */}
           <div className="absolute -left-2.5 top-0 z-10 h-11 w-11" />
@@ -108,4 +110,5 @@ function Checkbox(props: CheckboxProps) {
   );
 }
 
-export { Checkbox, type CheckboxProps };
+const _Checkbox = forwardRef(Checkbox);
+export { _Checkbox as Checkbox, type CheckboxProps };

--- a/packages/react/src/checkbox/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
 import {
   CheckboxGroup as RACCheckboxGroup,
@@ -30,7 +31,7 @@ type CheckboxGroupProps = {
   | 'orientation'
 >;
 
-function CheckboxGroup(props: CheckboxGroupProps) {
+function CheckboxGroup(props: CheckboxGroupProps, ref: Ref<HTMLDivElement>) {
   const {
     children,
     className,
@@ -50,6 +51,7 @@ function CheckboxGroup(props: CheckboxGroupProps) {
       className={cx(className, 'flex flex-col gap-2')}
       isInvalid={isInvalid}
       isRequired={isRequired}
+      ref={ref}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
@@ -59,4 +61,5 @@ function CheckboxGroup(props: CheckboxGroupProps) {
   );
 }
 
-export { CheckboxGroup, type CheckboxGroupProps };
+const _CheckboxGroup = forwardRef(CheckboxGroup);
+export { _CheckboxGroup as CheckboxGroup, type CheckboxGroupProps };

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
 import {
   ListBox,
@@ -45,7 +46,10 @@ type ComboboxProps<T extends object> = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-function Combobox<T extends object>(props: ComboboxProps<T>) {
+function Combobox<T extends object>(
+  props: ComboboxProps<T>,
+  ref: Ref<HTMLInputElement>,
+) {
   const {
     className,
     children,
@@ -69,7 +73,7 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
       {description && <Description>{description}</Description>}
 
       <Group className={inputGroup}>
-        <Input className={input({ isGrouped: true })} />
+        <Input className={input({ isGrouped: true })} ref={ref} />
         <Button>
           {isLoading ? (
             <LoadingSpinner className="animate-spin" />
@@ -127,8 +131,9 @@ const ComboboxItem = (props: ListBoxItemProps) => {
   );
 };
 
+const _Combobox = forwardRef(Combobox);
 export {
-  Combobox,
+  _Combobox as Combobox,
   ComboboxItem,
   type ComboboxProps,
   type ListBoxItemProps as ComboboxItemProps,

--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
 import {
   Radio as RACRadio,
@@ -36,10 +37,14 @@ type RadioProps = {
   style?: React.CSSProperties;
 } & Omit<RACRAdioProps, 'isDisabled' | 'children' | 'style'>;
 
-function Radio(props: RadioProps) {
+function Radio(props: RadioProps, ref: Ref<HTMLLabelElement>) {
   const { children, className, description, ...restProps } = props;
   return (
-    <RACRadio {...restProps} className={cx(className, defaultClasses)}>
+    <RACRadio
+      {...restProps}
+      className={cx(className, defaultClasses)}
+      ref={ref}
+    >
       {/* increases the clickable area of the radio button for accessibility */}
       <div className="absolute -left-2.5 top-0 z-10 h-11 w-11 " />
 
@@ -53,4 +58,5 @@ function Radio(props: RadioProps) {
   );
 }
 
-export { Radio, type RadioProps };
+const _Radio = forwardRef(Radio);
+export { _Radio as Radio, type RadioProps };

--- a/packages/react/src/radiogroup/RadioGroup.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
 import {
   RadioGroup as RACRadioGroup,
@@ -30,7 +31,7 @@ type RadioGroupProps = {
   | 'orientation'
 >;
 
-function RadioGroup(props: RadioGroupProps) {
+function RadioGroup(props: RadioGroupProps, ref: Ref<HTMLDivElement>) {
   const {
     children,
     className,
@@ -50,6 +51,7 @@ function RadioGroup(props: RadioGroupProps) {
       className={cx(className, 'flex flex-col gap-2')}
       isInvalid={isInvalid}
       isRequired={isRequired}
+      ref={ref}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
@@ -59,4 +61,5 @@ function RadioGroup(props: RadioGroupProps) {
   );
 }
 
-export { RadioGroup, type RadioGroupProps };
+const _RadioGroup = forwardRef(RadioGroup);
+export { _RadioGroup as RadioGroup, type RadioGroupProps };

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
 import {
   Button,
@@ -35,7 +36,10 @@ type SelectProps<T extends object> = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-function Select<T extends object>(props: SelectProps<T>) {
+function Select<T extends object>(
+  props: SelectProps<T>,
+  ref: Ref<HTMLButtonElement>,
+) {
   const {
     className,
     children,
@@ -63,6 +67,8 @@ function Select<T extends object>(props: SelectProps<T>) {
           // How to reuse placeholder text?
           'inline-flex cursor-default items-center gap-2',
         )}
+        // See https://github.com/adobe/react-spectrum/discussions/4792#discussioncomment-6492305
+        ref={ref}
       >
         <SelectValue className="flex-1 truncate text-left data-[placeholder]:text-[#727070]" />
         <ChevronDown className={dropdown.chevronIcon} />
@@ -106,8 +112,9 @@ const SelectItem = (props: ListBoxItemProps) => {
   );
 };
 
+const _Select = forwardRef(Select);
 export {
-  Select,
+  _Select as Select,
   SelectItem,
   type SelectProps,
   type ListBoxItemProps as SelectItemProps,

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
 import {
   TextArea as RACTextArea,
@@ -33,7 +34,7 @@ type TextAreaProps = {
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-function TextArea(props: TextAreaProps) {
+function TextArea(props: TextAreaProps, ref: Ref<HTMLTextAreaElement>) {
   const {
     className,
     description,
@@ -54,10 +55,11 @@ function TextArea(props: TextAreaProps) {
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
-      <RACTextArea className={input()} rows={rows} />
+      <RACTextArea className={input()} rows={rows} ref={ref} />
       <ErrorMessageOrFieldError errorMessage={errorMessage} />
     </RACTextField>
   );
 }
 
-export { TextArea, type TextAreaProps };
+const _TextArea = forwardRef(TextArea);
+export { _TextArea as TextArea, type TextAreaProps };

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import { cx, cva, compose } from 'cva';
 import {
   Input,
@@ -53,7 +54,7 @@ const inputWithAlignment = compose(
   }),
 );
 
-function TextField(props: TextFieldProps) {
+function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
   const {
     className,
     description,
@@ -84,6 +85,7 @@ function TextField(props: TextFieldProps) {
           {withAddonDivider && leftAddon && <Divider className="ml-3" />}
           <Input
             className={inputWithAlignment({ textAlign, isGrouped: true })}
+            ref={ref}
           />
           {withAddonDivider && rightAddon && <Divider className="mr-3" />}
           {rightAddon}
@@ -103,4 +105,5 @@ function Divider({ className }: { className: string }) {
   );
 }
 
-export { TextField, type TextFieldProps };
+const _TextField = forwardRef(TextField);
+export { _TextField as TextField, type TextFieldProps };

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -91,7 +91,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
           {rightAddon}
         </Group>
       ) : (
-        <Input className={inputWithAlignment({ textAlign })} />
+        <Input className={inputWithAlignment({ textAlign })} ref={ref} />
       )}
 
       <ErrorMessageOrFieldError errorMessage={errorMessage} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@obosbbl/grunnmuren-icons-react':
         specifier: workspace:^2.0.0-canary.1
         version: link:../icons-react
+      '@react-aria/utils':
+        specifier: ^3.23.0
+        version: 3.23.0(react@18.2.0)
       cva:
         specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1(typescript@5.3.3)


### PR DESCRIPTION
Denne PRen legger til støtte for ref forwarding. Dette burde gjøre det enklere å bruke skjemakomponentene sammen med for eksempel react-hook-form.