### PR TITLE
fix invisible ring

### DIFF
--- a/.changeset/lemon-swans-hug.md
+++ b/.changeset/lemon-swans-hug.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+fix invisible ring on input (safari v<17)

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -10,6 +10,8 @@ const input = cva({
     'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
     // invalid styles
     'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
+    // Fix invisible ring on safari: https://github.com/tailwindlabs/tailwindcss.com/issues/1135
+    'appearance-none',
   ],
   variants: {
     // Focus rings. Can either be :focus or :focus-visible based on the needs of the particular component.


### PR DESCRIPTION
Fann denna issuen: https://github.com/tailwindlabs/tailwindcss.com/issues/1135

Provat i ios 16 på browserstack, och det fungerar. 
Provat i localhost på chrome, och där ser allt likt ut som innan

Chrome
<img width="537" alt="image" src="https://github.com/code-obos/grunnmuren/assets/22050503/506ba35a-05df-4f9d-9bc2-ccd37d4d2f35">

iOS 16 (broswerstack)
![image](https://github.com/code-obos/grunnmuren/assets/22050503/665de463-4ec1-4b3a-a882-73651467d9ec)

