### PR TITLE
Bugfix/button icon spacing

### DIFF
--- a/.changeset/swift-masks-design.md
+++ b/.changeset/swift-masks-design.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixed inconsistent spacing in buttons with icon and text.

--- a/packages/react/src/button/Button.stories.tsx
+++ b/packages/react/src/button/Button.stories.tsx
@@ -60,14 +60,30 @@ export const Tertiary: Story = {
 
 export const WithIconAndText = () => {
   return (
-    <div className="flex gap-8 p-8">
-      <Button>
-        <Edit /> Rediger
-      </Button>
-      <Button>
-        Rediger <Edit />
-      </Button>
-    </div>
+    <>
+      <div className="flex gap-8 p-8">
+        <Button>
+          <Edit /> Rediger
+        </Button>
+        <Button>
+          <Edit /> Rediger mer
+        </Button>
+        <Button>
+          <Edit /> Rediger med enda mer tekst
+        </Button>
+      </div>
+      <div className="flex gap-8 p-8">
+        <Button>
+          Rediger <Edit />
+        </Button>
+        <Button>
+          Rediger mer <Edit />
+        </Button>
+        <Button>
+          Rediger med enda mer tekst <Edit />
+        </Button>
+      </div>
+    </>
   );
 };
 

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -40,9 +40,7 @@ const buttonVariants = cva({
      */
     isIconOnly: {
       true: 'p-2 [&>svg]:h-7 [&>svg]:w-7',
-      false:
-        // The of-type classes takes care to add spacing when the button is used with icons
-        'gap-2.5 px-4 py-2',
+      false: 'gap-2.5 px-4 py-2',
     },
   },
   compoundVariants: [

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -42,7 +42,7 @@ const buttonVariants = cva({
       true: 'p-2 [&>svg]:h-7 [&>svg]:w-7',
       false:
         // The of-type classes takes care to add spacing when the button is used with icons
-        'px-4 py-2 [&>svg]:first-of-type:mr-2.5 [&>svg]:last-of-type:ml-2.5',
+        'gap-2.5 px-4 py-2',
     },
   },
   compoundVariants: [


### PR DESCRIPTION
Fikset inkonsekvent spacing i knapper med ikoner og lagt til litt flere eksempler i stories som demonstrerer dette:

![Screenshot 2024-02-09 at 08 43 29](https://github.com/code-obos/grunnmuren/assets/6680533/163188d6-29bc-46f7-9623-ffd0cc8a1882)
