### PR TITLE
fix: TextField addon issues

### DIFF
--- a/.changeset/grumpy-parents-cough.md
+++ b/.changeset/grumpy-parents-cough.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+fix issue with missing spacing/gap when using TextField with addons

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -7,7 +7,7 @@ const formFieldError = cx(
 
 const input = cva({
   base: [
-    'rounded-md px-3 py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
+    'rounded-md py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
     // invalid styles
     'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
     // Fix invisible ring on safari: https://github.com/tailwindlabs/tailwindcss.com/issues/1135
@@ -21,9 +21,8 @@ const input = cva({
         'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
     },
     isGrouped: {
-      false: '',
-      //
-      true: 'flex-1 !ring-0 first:pl-0 last:pr-0',
+      false: 'px-3',
+      true: 'flex-1 !ring-0',
     },
   },
   defaultVariants: {
@@ -32,9 +31,12 @@ const input = cva({
   },
 });
 
-const inputGroup = cx(
-  'inline-flex items-center overflow-hidden rounded-md px-3 ring-1 ring-black focus-within:ring-2 group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
-);
+const inputGroup = cx([
+  'inline-flex items-center gap-3 overflow-hidden rounded-md px-3 text-sm ring-1 ring-black focus-within:ring-2',
+  'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
+  // Make sure icons are the correct size
+  '[&_svg]:text-base',
+]);
 
 const dropdown = {
   popover: cx(

--- a/packages/react/src/internals/InputAddonDivider.tsx
+++ b/packages/react/src/internals/InputAddonDivider.tsx
@@ -1,0 +1,3 @@
+export function InputAddonDivider() {
+  return <span className="block h-6 w-px flex-none bg-black" />;
+}

--- a/packages/react/src/internals/index.ts
+++ b/packages/react/src/internals/index.ts
@@ -1,1 +1,2 @@
 export * from './ListBox';
+export * from './InputAddonDivider';

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-aria-components';
 
 import { formField, input, inputGroup } from '../classes';
-import { InputAddonDivider } from '../internals/InputAddonDivider';
+import { InputAddonDivider } from '../internals';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessageOrFieldError } from '../label/ErrorMessageOrFieldError';

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-aria-components';
 
 import { formField, input, inputGroup } from '../classes';
+import { InputAddonDivider } from '../internals/InputAddonDivider';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessageOrFieldError } from '../label/ErrorMessageOrFieldError';
@@ -88,12 +89,12 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
       {leftAddon || rightAddon ? (
         <Group className={inputGroup}>
           {leftAddon}
-          {withAddonDivider && leftAddon && <Divider className="ml-3" />}
+          {withAddonDivider && leftAddon && <InputAddonDivider />}
           <Input
             className={inputWithAlignment({ textAlign, isGrouped: true })}
             ref={ref}
           />
-          {withAddonDivider && rightAddon && <Divider className="mr-3" />}
+          {withAddonDivider && rightAddon && <InputAddonDivider />}
           {rightAddon}
         </Group>
       ) : (
@@ -102,12 +103,6 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
 
       <ErrorMessageOrFieldError errorMessage={errorMessage} />
     </RACNumberField>
-  );
-}
-
-export function Divider({ className }: { className: string }) {
-  return (
-    <span className={cx(className, 'block h-6 w-px flex-none bg-black')} />
   );
 }
 

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -82,12 +82,12 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
       {leftAddon || rightAddon ? (
         <Group className={inputGroup}>
           {leftAddon}
-          {withAddonDivider && leftAddon && <Divider className="ml-3" />}
+          {withAddonDivider && leftAddon && <Divider />}
           <Input
             className={inputWithAlignment({ textAlign, isGrouped: true })}
             ref={ref}
           />
-          {withAddonDivider && rightAddon && <Divider className="mr-3" />}
+          {withAddonDivider && rightAddon && <Divider />}
           {rightAddon}
         </Group>
       ) : (
@@ -99,10 +99,8 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
   );
 }
 
-function Divider({ className }: { className: string }) {
-  return (
-    <span className={cx(className, 'block h-6 w-px flex-none bg-black')} />
-  );
+function Divider() {
+  return <span className="block h-6 w-px flex-none bg-black" />;
 }
 
 const _TextField = forwardRef(TextField);

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-aria-components';
 
 import { formField, input, inputGroup } from '../classes';
-import { InputAddonDivider } from '../internals/InputAddonDivider';
+import { InputAddonDivider } from '../internals';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessageOrFieldError } from '../label/ErrorMessageOrFieldError';

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-aria-components';
 
 import { formField, input, inputGroup } from '../classes';
+import { InputAddonDivider } from '../internals/InputAddonDivider';
 import { Label } from '../label/Label';
 import { Description } from '../label/Description';
 import { ErrorMessageOrFieldError } from '../label/ErrorMessageOrFieldError';
@@ -82,12 +83,12 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
       {leftAddon || rightAddon ? (
         <Group className={inputGroup}>
           {leftAddon}
-          {withAddonDivider && leftAddon && <Divider />}
+          {withAddonDivider && leftAddon && <InputAddonDivider />}
           <Input
             className={inputWithAlignment({ textAlign, isGrouped: true })}
             ref={ref}
           />
-          {withAddonDivider && rightAddon && <Divider />}
+          {withAddonDivider && rightAddon && <InputAddonDivider />}
           {rightAddon}
         </Group>
       ) : (
@@ -97,10 +98,6 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
       <ErrorMessageOrFieldError errorMessage={errorMessage} />
     </RACTextField>
   );
-}
-
-function Divider() {
-  return <span className="block h-6 w-px flex-none bg-black" />;
 }
 
 const _TextField = forwardRef(TextField);


### PR DESCRIPTION
Denne PRen fikser noen problemer med addons på TextField.

Det var problemer med manglende spacing mellom addon og inputfeltet, dersom addonen din var kun tekst, og ikke et element. Fontstørrelsen på addonen er også feil, så det ser misaligned ut:

```
<TextField leftAddon="(+47)"  label="Telefonnummer" />
```

<img width="283" alt="Screenshot 2024-02-16 at 08 37 51" src="https://github.com/code-obos/grunnmuren/assets/81577/12e2ebd7-9f62-4dfa-a45d-c416f3f44c24">



Tidligere var det noen ikke så smarte forsøk på en blanding av paddings og margins for å støtte margins. Ved å gå over til `gap` fikses problemet og ting blir litt enklere.


<img width="160" alt="Screenshot 2024-02-17 at 06 38 44" src="https://github.com/code-obos/grunnmuren/assets/81577/1bf4313e-3bc7-480c-afba-4a83d3f26341">