### PR TITLE
Remove I18nProvider in favor of GrunnmurenProvider

### DIFF
--- a/.changeset/honest-items-tap.md
+++ b/.changeset/honest-items-tap.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": minor
 ---
 
-Rename `<I18nProvider />` to `<GrunnmurenProvider />`
+Rename `<I18nProvider />` to `<GrunnmurenProvider />`. Explicitly set supported languages to `nb,`, `sv` and `en`, with `nb` as the default.

--- a/.changeset/honest-items-tap.md
+++ b/.changeset/honest-items-tap.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Rename `<I18nProvider />` to `<GrunnmurenProvider />`

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,6 @@
-const path = require('path');
-const { mergeConfig } = require('vite');
+import { mergeConfig } from 'vite';
+import path from 'path';
+import optimizeLocales from '@react-aria/optimize-locales-plugin';
 
 module.exports = {
   stories: ['../packages/react/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
@@ -22,6 +23,15 @@ module.exports = {
   async viteFinal(config) {
     // Merge custom configuration into the default config
     return mergeConfig(config, {
+      plugins: [
+        {
+          ...optimizeLocales.vite({
+            // Keep only the supported locales
+            locales: ['nb', 'sv', 'en'],
+          }),
+          enforce: 'pre',
+        },
+      ],
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '../src/'),

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Preview } from '@storybook/react';
-import { I18nProvider } from '../packages/react/src/index';
+import { GrunnmurenProvider } from '../packages/react/src/index';
 
 import './storybook.css';
 
 const preview: Preview = {
   decorators: [
     (Story) => (
-      <I18nProvider locale="nb">
+      <GrunnmurenProvider locale="nb">
         <Story />
-      </I18nProvider>
+      </GrunnmurenProvider>
     ),
   ],
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Preview } from '@storybook/react';
-import { GrunnmurenProvider } from '../packages/react/src/index';
+import { GrunnmurenProvider } from '../packages/react/src';
 
 import './storybook.css';
 

--- a/form-demo/app/layout.tsx
+++ b/form-demo/app/layout.tsx
@@ -1,3 +1,4 @@
+import { GrunnmurenProvider } from '@obosbbl/grunnmuren-react';
 import './globals.css';
 
 export const metadata = {
@@ -9,11 +10,15 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const locale = 'nb';
+
   return (
-    <html lang="no">
-      <body>
-        <main className="container-prose">{children}</main>
-      </body>
-    </html>
+    <GrunnmurenProvider locale={locale}>
+      <html lang={locale}>
+        <body>
+          <main className="container-prose">{children}</main>
+        </body>
+      </html>
+    </GrunnmurenProvider>
   );
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@changesets/cli": "2.27.1",
     "@obosbbl/grunnmuren-tailwind": "workspace:*",
+    "@react-aria/optimize-locales-plugin": "1.0.2",
     "@storybook/addon-actions": "7.6.17",
     "@storybook/addon-controls": "7.6.17",
     "@storybook/addon-docs": "7.6.17",
@@ -48,8 +49,5 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "devDependencies": {
-    "@react-aria/optimize-locales-plugin": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "devDependencies": {
+    "@react-aria/optimize-locales-plugin": "^1.0.2"
   }
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -14,19 +14,19 @@ npm install @obosbbl/grunnmuren-react@canary
 pnpm add @obosbbl/grunnmuren-react@canary
 ```
 
-## Localization configuration
+## Setup
 
 Grunnmuren uses [React Aria Components](https://react-spectrum.adobe.com/react-aria/) under the hood. RAC has built in translation strings for non visible content (for accessibility reasons). It also automatically detects the language based on the browser or system language.
 
-To ensure that the language of the page content matches the accessibility strings you should wrap your application in a `I18nProvider`. This will override RAC's automatic locale selection.
+To ensure that the language of the page content matches the accessibility strings you must wrap your application in a `GrunnmurenProvider` with a `locale` prop. This will override RAC's automatic locale selection.
 
 In [Next.js](https://nextjs.org/) you can do this in the root [root layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required).
 
-Valid locales for Norwegian are `nb-NO` or `nb`, Swedish is `sv-SE` or `sv`.
+Valid locales are `nb`, `sv` or `en`. The provider defaults to `nb` if unspecified.
 
 ```js
 // app/layout.tsx
-import { I18nProvider } from '@obosbbl/grunnmuren-react';
+import { GrunnmurenProvider } from '@obosbbl/grunnmuren-react';
 
 
 export default function RootLayout({
@@ -35,15 +35,15 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
 
-  // Either 'nb' or 'sv'
+  // Either 'nb', 'sv' or 'en'
   const locale = 'nb';
 
   return (
-    <I18nProvider locale={locale}>
+    <GrunnmurenProvider locale={locale}>
       <html lang={locale}>
         <body>{children}</body>
       </html>
-    </I18nProvider>
+    </GrunnmurenProvider>
   )
 }
 ```
@@ -76,7 +76,7 @@ module.exports = {
       optimizeLocales.webpack({
         // If you have a multitenant app, include both Norwegian and Swedish
         // If your app only serves one language, adjust accordingly
-        locales: ['nb-NO', 'sv-SE'],
+        locales: ['nb', 'sv'],
       }),
     );
     return config;

--- a/packages/react/src/GrunnmurenProvider.tsx
+++ b/packages/react/src/GrunnmurenProvider.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { I18nProvider } from 'react-aria-components';
+
+type GrunnmurenProviderProps = {
+  children: React.ReactNode;
+  /**
+   *  The locale to apply to the children.
+   *  @default nb
+   */
+  locale?: 'nb' | 'sv' | 'en';
+};
+
+function GrunnmurenProvider({
+  children,
+  locale = 'nb',
+}: GrunnmurenProviderProps) {
+  return <I18nProvider locale={locale}>{children}</I18nProvider>;
+}
+
+export { type GrunnmurenProviderProps, GrunnmurenProvider };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,6 @@
-export { Form, I18nProvider } from 'react-aria-components';
+export { Form } from 'react-aria-components';
 
+export * from './GrunnmurenProvider';
 export * from './button';
 export * from './checkbox';
 export * from './combobox';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@obosbbl/grunnmuren-tailwind':
         specifier: workspace:*
         version: link:packages/tailwind
+      '@react-aria/optimize-locales-plugin':
+        specifier: 1.0.2
+        version: 1.0.2
       '@storybook/addon-actions':
         specifier: 7.6.17
         version: 7.6.17
@@ -92,10 +95,6 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
-    devDependencies:
-      '@react-aria/optimize-locales-plugin':
-        specifier: ^1.0.2
-        version: 1.0.2
 
   form-demo:
     dependencies:
@@ -3220,7 +3219,7 @@ packages:
     resolution: {integrity: sha512-qrExP0PL446RU9o3PAOH9/8+UYjat9I1R5Vcj2ddumhso9Cv/QdOZYhLvm4f+gf7IlN3dbO9zpwpanuEdBWSfg==}
     dependencies:
       unplugin: 1.6.0
-    dev: true
+    dev: false
 
   /@react-aria/overlays@3.20.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2m7MpRJL5UucbEuu08lMHsiFJoDowkJV4JAIFBZYK1NzVH0vF/A+w9HRNM7jRwx2DUxE+iIsZnl8yKV/7KY8OQ==}
@@ -6135,6 +6134,7 @@ packages:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: false
 
   /address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
@@ -12027,6 +12027,7 @@ packages:
       chokidar: 3.5.3
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.6.1
+    dev: false
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -12197,9 +12198,11 @@ packages:
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: false
 
   /webpack-virtual-modules@0.6.1:
     resolution: {integrity: sha512-poXpCylU7ExuvZK8z+On3kX+S8o/2dQ/SVYueKA0D4WEMXROXgY8Ez50/bQEUmvoSMMrWcrJqCHuhAbsiwg7Dg==}
+    dev: false
 
   /webpack@5.89.0(@swc/core@1.3.107)(esbuild@0.18.20):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,10 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+    devDependencies:
+      '@react-aria/optimize-locales-plugin':
+        specifier: ^1.0.2
+        version: 1.0.2
 
   form-demo:
     dependencies:
@@ -3212,6 +3216,12 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@react-aria/optimize-locales-plugin@1.0.2:
+    resolution: {integrity: sha512-qrExP0PL446RU9o3PAOH9/8+UYjat9I1R5Vcj2ddumhso9Cv/QdOZYhLvm4f+gf7IlN3dbO9zpwpanuEdBWSfg==}
+    dependencies:
+      unplugin: 1.6.0
+    dev: true
+
   /@react-aria/overlays@3.20.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2m7MpRJL5UucbEuu08lMHsiFJoDowkJV4JAIFBZYK1NzVH0vF/A+w9HRNM7jRwx2DUxE+iIsZnl8yKV/7KY8OQ==}
     peerDependencies:
@@ -6125,7 +6135,6 @@ packages:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   /address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
@@ -12018,7 +12027,6 @@ packages:
       chokidar: 3.5.3
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.6.1
-    dev: false
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -12189,11 +12197,9 @@ packages:
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: false
 
   /webpack-virtual-modules@0.6.1:
     resolution: {integrity: sha512-poXpCylU7ExuvZK8z+On3kX+S8o/2dQ/SVYueKA0D4WEMXROXgY8Ez50/bQEUmvoSMMrWcrJqCHuhAbsiwg7Dg==}
-    dev: false
 
   /webpack@5.89.0(@swc/core@1.3.107)(esbuild@0.18.20):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}


### PR DESCRIPTION
Denne PRen fjerner re-eksporten av I18nProvideren fra RAC, til fordel for vår egen GrunnmurenProvider. Dette er en breaking change, men det det er egentlig bare en rename, og vi er fortsatt i canary-releases.

### Bakgrunn for endringen

#### Endringer i RAC

I RAC versjon 1.0.0 var det et `use client;` direktiv i den publiserte modulen. Dette fjernet de igjen i versjon 1.0.1 til fordel for [`client-only` modulen](https://www.npmjs.com/package/client-only). 

Det gjør at når vi reeksporterer I18nProvideren, så må konsumenten plutselig plutselig legge inn `use client` i all sin egen kode der de har Grunnmuren imports, uansett om det bruker client only features eller ikke. Dette gjør at vi foreløpig ikke har oppdatert til RAC 1.1.1. Vi har lyst til å legge inn `use client` selv der det gir mening, slik at det blir enklere for konsumentene av Grunnmuren. Se https://github.com/code-obos/grunnmuren/pull/736

#### Støttede språk

I18nProvideren til RAC støtter nærmere 30 språk, men det betyr ikke nødvendigvis at vi gjør det i Grunnmuren. For AlertBox-komponten (https://github.com/code-obos/grunnmuren/pull/734), som ikke er basert på noen RAC-primitiver, har vi lagt inn translations strings for norsk, svensk og engelsk.

Dermed gir det mening at vi bygger vår egen wrapper rundt hvor vi sier hvilke språk vi støtter.


#### Router provider

I arbeidet med Breadcrumbs https://github.com/code-obos/grunnmuren/pull/745, bruker vi Link-komponenten fra RAC.
Så dermed må vi få inn støtte/dokumentasjon for [RouterProvideren til RAC
](https://react-spectrum.adobe.com/react-aria/routing.html) på et eller annet vis.

For meg gir det mening at GrunnmurenProvider også kan få støtte for `navigate` etter hvert også, slik at vi har en provider for Grunnmuren som setter opp alt for deg.

### Andre endringer

Endret storybook config-filen fra CJS til MJS.

Tok i bruk optimizeLocales pluginet i Storybook. Greit for å få testet pluginet sammen med designsystemet.

Endringer på bundlesize før og etter:

Før:
`storybook-static/assets/import-18590f9f.js                      198.30 kB │ gzip:  59.57 kB`

Etter:
`storybook-static/assets/import-7471dc30.js                      167.92 kB │ gzip:  49.66 kB`