### PR TITLE
Feature/accordion with background

### DIFF
--- a/.changeset/stupid-suits-dress.md
+++ b/.changeset/stupid-suits-dress.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Adds support for accordions that are wrapped by a container with a background color.

--- a/packages/react/src/accordion/Accordion.stories.tsx
+++ b/packages/react/src/accordion/Accordion.stories.tsx
@@ -109,7 +109,51 @@ const ControlledTemplate = () => {
 
 const ColoredTemplate = (args: AccordionItemProps) => {
   return (
-    <div className="bg-mint p-10">
+    <div className="bg-green-dark p-10">
+      <Accordion>
+        <AccordionItem
+          onOpenChange={args.onOpenChange}
+          defaultOpen={args.defaultOpen}
+        >
+          <Heading level={2}>Bør jeg velge rammelån eller boliglån?</Heading>
+          <Content className="prose">
+            <p>
+              Hvis du har glemt passordet ditt kan du sende oss en melding i
+              mobilbanken eller nettbanken, så sender vi deg et nytt passord. Du
+              kan også ringe oss på telefon{' '}
+              <a href="tel:+4722865800">22 86 58 00</a>, så hjelper vi deg.
+            </p>
+            <p>
+              <strong>NB:</strong> Har du BankID fra en annen bank, må du
+              kontakte den banken du har fått BankID fra for å få tilbakestilt
+              passordet ditt.
+            </p>
+          </Content>
+        </AccordionItem>
+        <AccordionItem
+          onOpenChange={args.onOpenChange}
+          defaultOpen={args.defaultOpen}
+        >
+          <Heading level={2}>Overfør penger fra Boligspar Ung?</Heading>
+          <Content className="prose">
+            <p>
+              Ønsker du å overføre penger fra Boligspar Ung til en av dine andre
+              kontoer, er det en enkel sak.{' '}
+              <a href="#">Logg inn i nettbanken</a> og velg &quot;Uttak
+              Boligspar&quot; Ung i menyen. Slik som BSU, kan du ta ut det du
+              har spart inneværende år. Om du vil ta ut mer vil kontoen
+              avsluttes.
+            </p>
+          </Content>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+};
+
+const ColoredStandaloneTemplate = (args: AccordionItemProps) => {
+  return (
+    <div className="bg-green-dark p-10">
       <Accordion>
         <AccordionItem
           onOpenChange={args.onOpenChange}
@@ -164,6 +208,13 @@ export const Controlled = {
 
 export const Colored: Story = {
   render: ColoredTemplate,
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const ColoredStandalone: Story = {
+  render: ColoredStandaloneTemplate,
   args: {
     ...defaultProps,
   },

--- a/packages/react/src/accordion/Accordion.stories.tsx
+++ b/packages/react/src/accordion/Accordion.stories.tsx
@@ -110,7 +110,7 @@ const ControlledTemplate = () => {
 const ColoredTemplate = (args: AccordionItemProps) => {
   return (
     <div className="bg-mint p-10">
-      <Accordion className="bg-white">
+      <Accordion>
         <AccordionItem
           onOpenChange={args.onOpenChange}
           defaultOpen={args.defaultOpen}

--- a/packages/react/src/accordion/Accordion.stories.tsx
+++ b/packages/react/src/accordion/Accordion.stories.tsx
@@ -107,6 +107,34 @@ const ControlledTemplate = () => {
   );
 };
 
+const ColoredTemplate = (args: AccordionItemProps) => {
+  return (
+    <div className="bg-mint p-10">
+      <Accordion className="bg-white">
+        <AccordionItem
+          onOpenChange={args.onOpenChange}
+          defaultOpen={args.defaultOpen}
+        >
+          <Heading level={2}>Bør jeg velge rammelån eller boliglån?</Heading>
+          <Content className="prose">
+            <p>
+              Hvis du har glemt passordet ditt kan du sende oss en melding i
+              mobilbanken eller nettbanken, så sender vi deg et nytt passord. Du
+              kan også ringe oss på telefon{' '}
+              <a href="tel:+4722865800">22 86 58 00</a>, så hjelper vi deg.
+            </p>
+            <p>
+              <strong>NB:</strong> Har du BankID fra en annen bank, må du
+              kontakte den banken du har fått BankID fra for å få tilbakestilt
+              passordet ditt.
+            </p>
+          </Content>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+};
+
 const meta: Meta<typeof AccordionItem> = {
   title: 'Accordion',
   component: AccordionItem,
@@ -132,4 +160,11 @@ export const Default: Story = {
 
 export const Controlled = {
   render: ControlledTemplate,
+};
+
+export const Colored: Story = {
+  render: ColoredTemplate,
+  args: {
+    ...defaultProps,
+  },
 };

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -122,8 +122,8 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
                 <button
                   aria-controls={contentId}
                   aria-expanded={isOpen}
-                  // the z-index is necessary for the focus ring to be drawn above the left border of the content
-                  className="relative z-10 flex min-h-[44px] w-full items-center justify-between gap-1.5 rounded-sm px-2 py-3.5 text-left focus:outline-none focus-visible:ring  focus-visible:ring-black"
+                  // Use outline with offset as focus indicator, this does not cover the left mint border on the expanded content and works with or without a background color on the accordion container
+                  className="flex min-h-[44px] w-full items-center justify-between gap-1.5 rounded-lg px-2 py-3.5 text-left focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-[-6px] focus-visible:outline-black"
                   id={buttonId}
                   onClick={handleOpenChange}
                 >

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -48,7 +48,7 @@ function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
         <>
           {child}
           {index < childCount - 1 && (
-            // Margin is added to enable support for containers with background colors
+            // Margin is added to enable support for containers with a background color
             <hr className="mx-2 border-gray-light" aria-hidden />
           )}
         </>

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -48,7 +48,7 @@ function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
         <>
           {child}
           {index < childCount - 1 && (
-            // Margin is added to enable support containers with background colors
+            // Margin is added to enable support for containers with background colors
             <hr className="mx-2 border-gray-light" aria-hidden />
           )}
         </>

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -34,17 +34,17 @@ type AccordionItemProps = {
 };
 
 function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
-  const { children, ...restProps } = props;
+  const { children, className, ...restProps } = props;
 
   const childCount = Children.count(children);
 
   return (
-    <div {...restProps} ref={ref}>
+    <div {...restProps} ref={ref} className={cx('rounded-lg', className)}>
       {Children.map(children, (child, index) => (
         <>
           {child}
           {index < childCount - 1 && (
-            <hr className="border-gray-light" aria-hidden />
+            <hr className="mx-2 border-gray-light" aria-hidden />
           )}
         </>
       ))}
@@ -100,7 +100,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
   return (
     <div
       {...restProps}
-      className={cx('group relative', className)}
+      className={cx('group relative px-2', className)}
       ref={ref}
       data-open={isOpen}
     >
@@ -109,7 +109,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
           [
             HeadingContext,
             {
-              className: 'font-semibold leading-7',
+              className: 'font-semibold leading-7 -mx-2',
               // Supply a default level here to make this typecheck ok. Will be overwritten with the consumers set heading level anyways
               level: 3,
               _innerWrapper: (children) => (
@@ -117,7 +117,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
                   aria-controls={contentId}
                   aria-expanded={isOpen}
                   // the z-index is necessary for the focus ring to be drawn above the left border of the content
-                  className="relative z-10 flex min-h-[44px] w-full items-center justify-between gap-1.5 rounded-sm py-3.5 text-left focus:outline-none focus-visible:ring  focus-visible:ring-black"
+                  className="relative z-10 flex min-h-[44px] w-full items-center justify-between gap-1.5 rounded-sm px-2 py-3.5 text-left focus:outline-none focus-visible:ring  focus-visible:ring-black"
                   id={buttonId}
                   onClick={handleOpenChange}
                 >

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -39,7 +39,11 @@ function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
   const childCount = Children.count(children);
 
   return (
-    <div {...restProps} ref={ref} className={cx('rounded-lg', className)}>
+    <div
+      {...restProps}
+      ref={ref}
+      className={cx('rounded-lg bg-white', className)}
+    >
       {Children.map(children, (child, index) => (
         <>
           {child}

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -44,6 +44,7 @@ function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
         <>
           {child}
           {index < childCount - 1 && (
+            // Margin is added to enable support background colors
             <hr className="mx-2 border-gray-light" aria-hidden />
           )}
         </>
@@ -109,6 +110,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
           [
             HeadingContext,
             {
+              // Negative margin to strech the button to the entire with of the accordion (to support background colors)
               className: 'font-semibold leading-7 -mx-2',
               // Supply a default level here to make this typecheck ok. Will be overwritten with the consumers set heading level anyways
               level: 3,

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -44,7 +44,7 @@ function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
         <>
           {child}
           {index < childCount - 1 && (
-            // Margin is added to enable support background colors
+            // Margin is added to enable support containers with background colors
             <hr className="mx-2 border-gray-light" aria-hidden />
           )}
         </>
@@ -110,7 +110,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
           [
             HeadingContext,
             {
-              // Negative margin to strech the button to the entire with of the accordion (to support background colors)
+              // Negative margin to strech the button to the entire with of the accordion (to support containers with a background color)
               className: 'font-semibold leading-7 -mx-2',
               // Supply a default level here to make this typecheck ok. Will be overwritten with the consumers set heading level anyways
               level: 3,


### PR DESCRIPTION
Tilrettelagt CSS for å kunne legge inn accordion på bakgrunnsfarge:

![Screenshot 2024-03-26 at 10 04 26](https://github.com/code-obos/grunnmuren/assets/6680533/97a1d9ef-5ace-463e-b8ae-60244d6bd010)

Og fikset sånn at fokusmarkering er synlig uansett om det er en bakgrunnsfarge eller ikke:

![Screenshot 2024-03-26 at 10 12 14](https://github.com/code-obos/grunnmuren/assets/6680533/ed93fb38-4d05-410f-82c2-c2598b6bb6dd)

![Screenshot 2024-03-26 at 10 12 36](https://github.com/code-obos/grunnmuren/assets/6680533/d756a06c-58e9-4130-9d84-f6d95e83b915)

