### PR TITLE
Applies hover when any part of a Backlink is hovered

### DIFF
--- a/.changeset/small-lies-turn.md
+++ b/.changeset/small-lies-turn.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixes hover style on backlink so that underline is applied even when something other than the text is hovered in the link.

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -43,7 +43,7 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
       <span
         className={cx(
           'border-b-[1px] border-t-[1px] border-transparent leading-none transition-colors duration-300',
-          withUnderline ? 'border-b-black' : 'hover:border-b-black',
+          withUnderline ? 'border-b-black' : 'group-hover:border-b-black',
         )}
       >
         {children}


### PR DESCRIPTION
Fikser sånn at hover-style appliseres også når man hover over noe annet enn teksten i backlink