### PR TITLE
Replace RAC link with native HTML anchor element

### DIFF
--- a/.changeset/dry-boats-tap.md
+++ b/.changeset/dry-boats-tap.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixes focus-visible styling for Backlinks.

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -1,32 +1,25 @@
-import { forwardRef, type Ref } from 'react';
+import { forwardRef, type Ref, HTMLProps } from 'react';
 import { cx } from 'cva';
-import { Link as RACLink, type LinkProps } from 'react-aria-components';
 import { ChevronLeft } from '@obosbbl/grunnmuren-icons-react';
 
 type BacklinkProps = {
   /** Additional CSS className for the element. */
   className?: string;
 
-  /** Additional style properties for the element. */
-  style?: React.CSSProperties;
-
   /** The URL to navigate to when clicking the backlink. */
   href?: string;
-
-  /** The content of the link */
-  children?: React.ReactNode;
 
   /** To add a permanent underline on the link (not only on hover)
    * @default false
    */
   withUnderline?: boolean;
-} & Omit<LinkProps, 'className' | 'style'>;
+} & HTMLProps<HTMLAnchorElement>;
 
 function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
   const { className, children, href, withUnderline, ...restProps } = props;
 
   return (
-    <RACLink
+    <a
       className={cx(
         className,
         'group flex max-w-fit items-center gap-3 rounded-md p-2.5 no-underline focus:outline-none focus-visible:ring focus-visible:ring-black',
@@ -48,7 +41,7 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
       >
         {children}
       </span>
-    </RACLink>
+    </a>
   );
 }
 

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -35,7 +35,7 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
       />
       <span
         className={cx(
-          'border-b-[1px] border-t-[1px] border-transparent leading-none transition-colors duration-300',
+          'border-b-[1px] border-t-[1px] border-transparent transition-colors duration-300',
           withUnderline ? 'border-b-black' : 'group-hover:border-b-black',
         )}
       >


### PR DESCRIPTION
Gjør at focus-visible funker slik at vi kun får fokusmarkering ved tastaturnavigering. Det er noe i den innebygde RAC link komponenten som gjør at focus-visible stylingen også vises ved klikk på `Backlink`.