### PR TITLE
Support underline on multiline in backlinks

### DIFF
--- a/.changeset/shaggy-adults-vanish.md
+++ b/.changeset/shaggy-adults-vanish.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixes issue with custom underline on backlinks that wraps over multiple lines.

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -33,7 +33,8 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
           '-ml-[0.5em] flex-shrink-0 transition-transform duration-300 group-hover:-translate-x-1',
         )}
       />
-      <span className="block">
+      {/* This wrapper is required in order to support the custom underline created with border-bottom when the text spans over multiple lines */}
+      <span>
         <span
           className={cx(
             'border-b-[1px] border-t-[1px] border-transparent transition-colors duration-300',

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -40,13 +40,15 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
           '-ml-[0.5em] flex-shrink-0 transition-transform duration-300 group-hover:-translate-x-1',
         )}
       />
-      <span
-        className={cx(
-          'border-b-[1px] border-t-[1px] border-transparent leading-none transition-colors duration-300',
-          withUnderline ? 'border-b-black' : 'group-hover:border-b-black',
-        )}
-      >
-        {children}
+      <span className="block">
+        <span
+          className={cx(
+            'border-b-[1px] border-t-[1px] border-transparent leading-none transition-colors duration-300',
+            withUnderline ? 'border-b-black' : 'group-hover:border-b-black',
+          )}
+        >
+          {children}
+        </span>
       </span>
     </RACLink>
   );


### PR DESCRIPTION
Sørger for at custom underline også virker når linker brekker over flere linjer:

![Screenshot 2024-03-27 at 08 01 56](https://github.com/code-obos/grunnmuren/assets/6680533/7037ce12-48a4-4cf2-9ee8-91d0b8e00fe6)

Uten denne endringen blir det sånn her med lange tekster:

![Screenshot 2024-03-27 at 08 03 09](https://github.com/code-obos/grunnmuren/assets/6680533/6c2ec3bb-1d40-46b0-bd2b-c711983a3fb8)
