### PR TITLE
Bugfix/revert to rac link in backlink

### DIFF
--- a/.changeset/dry-boats-tap.md
+++ b/.changeset/dry-boats-tap.md
@@ -1,5 +1,0 @@
----
-"@obosbbl/grunnmuren-react": patch
----
-
-Fixes focus-visible styling for Backlinks.

--- a/.changeset/wet-lobsters-hang.md
+++ b/.changeset/wet-lobsters-hang.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Reverts back to using the Link component from RAC in Backlink.

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -1,25 +1,32 @@
-import { forwardRef, type Ref, HTMLProps } from 'react';
+import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
+import { Link as RACLink, type LinkProps } from 'react-aria-components';
 import { ChevronLeft } from '@obosbbl/grunnmuren-icons-react';
 
 type BacklinkProps = {
   /** Additional CSS className for the element. */
   className?: string;
 
+  /** Additional style properties for the element. */
+  style?: React.CSSProperties;
+
   /** The URL to navigate to when clicking the backlink. */
   href?: string;
+
+  /** The content of the link */
+  children?: React.ReactNode;
 
   /** To add a permanent underline on the link (not only on hover)
    * @default false
    */
   withUnderline?: boolean;
-} & HTMLProps<HTMLAnchorElement>;
+} & Omit<LinkProps, 'className' | 'style'>;
 
 function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
   const { className, children, href, withUnderline, ...restProps } = props;
 
   return (
-    <a
+    <RACLink
       className={cx(
         className,
         'group flex max-w-fit items-center gap-3 rounded-md p-2.5 no-underline focus:outline-none focus-visible:ring focus-visible:ring-black',
@@ -44,7 +51,7 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
           {children}
         </span>
       </span>
-    </a>
+    </RACLink>
   );
 }
 


### PR DESCRIPTION
Revert: Gå tilbake til å bruke RAC sin `Link` i `Backlink`. Å erstatte med native `<a/>` var en tabbe da RAC sin innebygde `Link` støtter next routing. Keyboardnavigasjon uten href støttes i RAC sin `Link` hvis man sender med en `onPress`-handler.