### PR TITLE
Accordion: set font size for heading

### DIFF
--- a/.changeset/dull-days-pretend.md
+++ b/.changeset/dull-days-pretend.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Accordion: explictly set heading font size to prevents global heading styles to affect it's size

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -115,7 +115,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
             HeadingContext,
             {
               // Negative margin to strech the button to the entire with of the accordion (to support containers with a background color)
-              className: 'font-semibold leading-7 -mx-2',
+              className: 'font-semibold leading-7 -mx-2 text-base',
               // Supply a default level here to make this typecheck ok. Will be overwritten with the consumers set heading level anyways
               level: 3,
               _innerWrapper: (children) => (


### PR DESCRIPTION
Denne PRen setter font-størrelsen til headingen i Accordionen til 1rem (16px).

Dette for å forhindre at "globale heading styles" påvirker headingen.

Slik ser det ut på medlemssidene akkurat nå, hvor det er CSS som setter h4-elementer til 20 px. Se her https://www.obos.no/medlem/medlemsservice/sporsmal-og-svar/om-medlemskap-i-obos:

<img width="714" alt="Screenshot 2024-04-05 at 08 37 46" src="https://github.com/code-obos/grunnmuren/assets/81577/30607144-d680-441a-bf7e-8ac4a01279ad">


Mens egentlig skal de være 16 px, som her:
<img width="454" alt="Screenshot 2024-04-05 at 08 37 54" src="https://github.com/code-obos/grunnmuren/assets/81577/aec02c2b-dc68-437b-a9ef-dcba64cdeabc">
