### PR TITLE
Feature/custom width on fields

### DIFF
--- a/.changeset/silly-ghosts-dress.md
+++ b/.changeset/silly-ghosts-dress.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": minor
 ---
 
-Adds support for custom size on `TextField` and `NumberField`, and max-length for the input content of `NumberField` (already supported in `TextField`).
+Adds support for custom size on `TextField` and `NumberField`.

--- a/.changeset/silly-ghosts-dress.md
+++ b/.changeset/silly-ghosts-dress.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": minor
 ---
 
-Adds support for custom size on `TextField` and `NumberField`, and max-length for their input content.
+Adds support for custom size on `TextField` and `NumberField`, and max-length for the input content of `NumberField` (already supported in `TextField`).

--- a/.changeset/silly-ghosts-dress.md
+++ b/.changeset/silly-ghosts-dress.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Adds support for custom size on `TextField` and `NumberField`, and max-length for their input content.

--- a/packages/react/src/numberfield/NumberField.stories.tsx
+++ b/packages/react/src/numberfield/NumberField.stories.tsx
@@ -185,7 +185,7 @@ export const CustomWidth: Story = {
     label: 'Husstandends samlede lån og gjeld utenom boliglån',
     description:
       'Samlet lån og gjeld inkluderer studielån, billån, forbrukslån og rammer på kredittkort.',
-    size: 16,
-    maxLength: 21,
+    size: 10,
+    maxValue: 99999999,
   },
 };

--- a/packages/react/src/numberfield/NumberField.stories.tsx
+++ b/packages/react/src/numberfield/NumberField.stories.tsx
@@ -177,3 +177,15 @@ export const MaxValue = {
     maxValue: 1000,
   },
 };
+
+export const CustomWidth: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    label: 'Husstandends samlede lån og gjeld utenom boliglån',
+    description:
+      'Samlet lån og gjeld inkluderer studielån, billån, forbrukslån og rammer på kredittkort.',
+    size: 16,
+    maxLength: 21,
+  },
+};

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -105,7 +105,7 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
             className={inputVariants({
               textAlign,
               isGrouped: true,
-              autoWidth: typeof size === 'number',
+              autoWidth: !!size,
             })}
             ref={ref}
             size={size}
@@ -115,10 +115,7 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
         </Group>
       ) : (
         <Input
-          className={inputVariants({
-            textAlign,
-            autoWidth: typeof size === 'number',
-          })}
+          className={inputVariants({ textAlign, autoWidth: !!size })}
           ref={ref}
           size={size}
         />

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -38,7 +38,7 @@ type NumberFieldProps = {
   style?: React.CSSProperties;
   /** Add a divider between the left/right addons and the input */
   withAddonDivider?: boolean;
-  /** Defines the number of characters and determines the width of the input element, a value of 0 will be ignored */
+  /** Defines the number of characters and determines the width of the input element */
   size?: number;
   /** Defines the maximum numeric value */
   maxValue?: number;

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -62,7 +62,7 @@ const inputVariants = compose(
         left: '',
       },
       autoWidth: {
-        true: 'max-w-fit',
+        true: 'box-content max-w-fit',
         false: '',
       },
     },
@@ -107,9 +107,7 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
               autoWidth: !!size,
             })}
             ref={ref}
-            size={
-              size && size + 1
-            } /** Add one extra character for a more precise width */
+            size={size}
             maxLength={maxLength}
           />
           {withAddonDivider && rightAddon && <InputAddonDivider />}
@@ -119,9 +117,7 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
         <Input
           className={inputVariants({ textAlign, autoWidth: !!size })}
           ref={ref}
-          size={
-            size && size + 1
-          } /** Add one extra character for a more precise width */
+          size={size}
           maxLength={maxLength}
         />
       )}

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -38,6 +38,10 @@ type NumberFieldProps = {
   style?: React.CSSProperties;
   /** Add a divider between the left/right addons and the input */
   withAddonDivider?: boolean;
+  /** Defines the number of characters and determines the width of the input element */
+  size?: number;
+  /** Defines the maximum string length for the input (including formatting characters) */
+  maxLength?: number;
 } & Omit<
   RACNumberFieldProps,
   | 'className'
@@ -48,7 +52,7 @@ type NumberFieldProps = {
   | 'hideStepper'
 >;
 
-const inputWithAlignment = compose(
+const inputVariants = compose(
   input,
   cva({
     base: '',
@@ -56,6 +60,10 @@ const inputWithAlignment = compose(
       textAlign: {
         right: 'text-right',
         left: '',
+      },
+      autoWidth: {
+        true: 'max-w-fit',
+        false: '',
       },
     },
   }),
@@ -72,6 +80,8 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
     textAlign,
     rightAddon,
     withAddonDivider,
+    size,
+    maxLength,
     ...restProps
   } = props;
 
@@ -91,14 +101,29 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
           {leftAddon}
           {withAddonDivider && leftAddon && <InputAddonDivider />}
           <Input
-            className={inputWithAlignment({ textAlign, isGrouped: true })}
+            className={inputVariants({
+              textAlign,
+              isGrouped: true,
+              autoWidth: !!size,
+            })}
             ref={ref}
+            size={
+              size && size + 1
+            } /** Add one extra character for a more precise width */
+            maxLength={maxLength}
           />
           {withAddonDivider && rightAddon && <InputAddonDivider />}
           {rightAddon}
         </Group>
       ) : (
-        <Input className={inputWithAlignment({ textAlign })} ref={ref} />
+        <Input
+          className={inputVariants({ textAlign, autoWidth: !!size })}
+          ref={ref}
+          size={
+            size && size + 1
+          } /** Add one extra character for a more precise width */
+          maxLength={maxLength}
+        />
       )}
 
       <ErrorMessageOrFieldError errorMessage={errorMessage} />

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -40,8 +40,10 @@ type NumberFieldProps = {
   withAddonDivider?: boolean;
   /** Defines the number of characters and determines the width of the input element, a value of 0 will be ignored */
   size?: number;
-  /** Defines the maximum string length for the input (including formatting characters) */
-  maxLength?: number;
+  /** Defines the maximum numeric value */
+  maxValue?: number;
+  /** Defines the minimum numeric value */
+  minValue?: number;
 } & Omit<
   RACNumberFieldProps,
   | 'className'

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -105,7 +105,7 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
             className={inputVariants({
               textAlign,
               isGrouped: true,
-              autoWidth: !!size,
+              autoWidth: typeof size === 'number',
             })}
             ref={ref}
             size={size}
@@ -115,7 +115,10 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
         </Group>
       ) : (
         <Input
-          className={inputVariants({ textAlign, autoWidth: !!size })}
+          className={inputVariants({
+            textAlign,
+            autoWidth: typeof size === 'number',
+          })}
           ref={ref}
           size={size}
         />

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -83,7 +83,6 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
     rightAddon,
     withAddonDivider,
     size,
-    maxLength,
     ...restProps
   } = props;
 
@@ -110,7 +109,6 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
             })}
             ref={ref}
             size={size}
-            maxLength={maxLength}
           />
           {withAddonDivider && rightAddon && <InputAddonDivider />}
           {rightAddon}
@@ -120,7 +118,6 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
           className={inputVariants({ textAlign, autoWidth: !!size })}
           ref={ref}
           size={size}
-          maxLength={maxLength}
         />
       )}
 

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -38,7 +38,7 @@ type NumberFieldProps = {
   style?: React.CSSProperties;
   /** Add a divider between the left/right addons and the input */
   withAddonDivider?: boolean;
-  /** Defines the number of characters and determines the width of the input element */
+  /** Defines the number of characters and determines the width of the input element, a value of 0 will be ignored */
   size?: number;
   /** Defines the maximum numeric value */
   maxValue?: number;

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -38,7 +38,7 @@ type NumberFieldProps = {
   style?: React.CSSProperties;
   /** Add a divider between the left/right addons and the input */
   withAddonDivider?: boolean;
-  /** Defines the number of characters and determines the width of the input element */
+  /** Defines the number of characters and determines the width of the input element, a value of 0 will be ignored */
   size?: number;
   /** Defines the maximum string length for the input (including formatting characters) */
   maxLength?: number;

--- a/packages/react/src/textfield/TextField.stories.tsx
+++ b/packages/react/src/textfield/TextField.stories.tsx
@@ -183,3 +183,15 @@ export const Controlled = {
     ...defaultProps,
   },
 };
+
+export const CustomWidth: Story = {
+  render: Template,
+  args: {
+    ...defaultProps,
+    label: 'Bruksenhetsnummer',
+    description:
+      'Bruksenhetsnummeret, som tidligere ble kalt bolignummer, består av en bokstav og fire tall. F.eks. H0101',
+    size: 5,
+    maxLength: 5,
+  },
+};

--- a/packages/react/src/textfield/TextField.stories.tsx
+++ b/packages/react/src/textfield/TextField.stories.tsx
@@ -193,5 +193,6 @@ export const CustomWidth: Story = {
       'Bruksenhetsnummeret, som tidligere ble kalt bolignummer, består av en bokstav og fire tall. F.eks. H0101',
     size: 5,
     maxLength: 5,
+    minLength: 5,
   },
 };

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -54,7 +54,7 @@ const inputVariants = compose(
         left: '',
       },
       autoWidth: {
-        true: 'max-w-fit',
+        true: 'box-content max-w-fit',
         false: '',
       },
     },
@@ -98,9 +98,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
               autoWidth: !!size,
             })}
             ref={ref}
-            size={
-              size && size + 1
-            } /** Add one extra character for a more precise width */
+            size={size}
           />
           {withAddonDivider && rightAddon && <InputAddonDivider />}
           {rightAddon}
@@ -109,9 +107,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
         <Input
           className={inputVariants({ textAlign, autoWidth: !!size })}
           ref={ref}
-          size={
-            size && size + 1
-          } /** Add one extra character for a more precise width */
+          size={size}
         />
       )}
 

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -37,12 +37,14 @@ type TextFieldProps = {
   style?: React.CSSProperties;
   /** Add a divider between the left/right addons and the input */
   withAddonDivider?: boolean;
+  /** Defines the number of characters and determines the width of the input element */
+  size?: number;
 } & Omit<
   RACTextFieldProps,
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-const inputWithAlignment = compose(
+const inputVariants = compose(
   input,
   cva({
     base: '',
@@ -50,6 +52,10 @@ const inputWithAlignment = compose(
       textAlign: {
         right: 'text-right',
         left: '',
+      },
+      autoWidth: {
+        true: 'max-w-fit',
+        false: '',
       },
     },
   }),
@@ -66,6 +72,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
     textAlign,
     rightAddon,
     withAddonDivider,
+    size,
     ...restProps
   } = props;
 
@@ -85,14 +92,27 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
           {leftAddon}
           {withAddonDivider && leftAddon && <InputAddonDivider />}
           <Input
-            className={inputWithAlignment({ textAlign, isGrouped: true })}
+            className={inputVariants({
+              textAlign,
+              isGrouped: true,
+              autoWidth: !!size,
+            })}
             ref={ref}
+            size={
+              size && size + 1
+            } /** Add one extra character for a more precise width */
           />
           {withAddonDivider && rightAddon && <InputAddonDivider />}
           {rightAddon}
         </Group>
       ) : (
-        <Input className={inputWithAlignment({ textAlign })} ref={ref} />
+        <Input
+          className={inputVariants({ textAlign, autoWidth: !!size })}
+          ref={ref}
+          size={
+            size && size + 1
+          } /** Add one extra character for a more precise width */
+        />
       )}
 
       <ErrorMessageOrFieldError errorMessage={errorMessage} />

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -35,7 +35,7 @@ type TextFieldProps = {
   textAlign?: 'left' | 'right';
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
-  /** Add a divider between the left/right addons and the input */
+  /** Add a divider between the left/right addons and the input, a value of 0 will be ignored */
   withAddonDivider?: boolean;
   /** Defines the number of characters and determines the width of the input element */
   size?: number;

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -95,7 +95,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
             className={inputVariants({
               textAlign,
               isGrouped: true,
-              autoWidth: !!size,
+              autoWidth: typeof size === 'number',
             })}
             ref={ref}
             size={size}
@@ -105,7 +105,10 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
         </Group>
       ) : (
         <Input
-          className={inputVariants({ textAlign, autoWidth: !!size })}
+          className={inputVariants({
+            textAlign,
+            autoWidth: typeof size === 'number',
+          })}
           ref={ref}
           size={size}
         />

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -95,7 +95,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
             className={inputVariants({
               textAlign,
               isGrouped: true,
-              autoWidth: typeof size === 'number',
+              autoWidth: !!size,
             })}
             ref={ref}
             size={size}
@@ -105,10 +105,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
         </Group>
       ) : (
         <Input
-          className={inputVariants({
-            textAlign,
-            autoWidth: typeof size === 'number',
-          })}
+          className={inputVariants({ textAlign, autoWidth: !!size })}
           ref={ref}
           size={size}
         />

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -35,7 +35,7 @@ type TextFieldProps = {
   textAlign?: 'left' | 'right';
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
-  /** Add a divider between the left/right addons and the input, a value of 0 will be ignored */
+  /** Add a divider between the left/right addons and the input */
   withAddonDivider?: boolean;
   /** Defines the number of characters and determines the width of the input element */
   size?: number;


### PR DESCRIPTION
Bruker `size` attributtet for å tilpasse bredden på inputfeltet i `TextField` og `NumberField`.

<img width="923" alt="Screenshot 2024-04-10 at 08 56 34" src="https://github.com/code-obos/grunnmuren/assets/6680533/67341e87-6995-4f1f-b08f-3ef7fe2c71fd">

<img width="922" alt="Screenshot 2024-04-10 at 08 56 10" src="https://github.com/code-obos/grunnmuren/assets/6680533/8ba9f24b-02fe-4d3b-9391-8a402f35a58c">
