### PR TITLE
Bugfix/infinite checkbox group re render

### DIFF
--- a/.changeset/three-glasses-behave.md
+++ b/.changeset/three-glasses-behave.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixes infinite re-renders in CheckboxGroup with Checkboxes that has the description prop set.

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -96,8 +96,9 @@ function Checkbox(props: CheckboxProps, ref: Ref<HTMLLabelElement>) {
         </RACCheckbox>
 
         {description && (
-          <Description className="block" id={descriptionId}>
-            {description}
+          <Description className="block">
+            {/* Use this wrapper div to avoid infinite re-render loops in React until this bug in RAC is fixed: https://github.com/adobe/react-spectrum/issues/6229 */}
+            <div id={descriptionId}>{description}</div>
           </Description>
         )}
         {errorMessage && (


### PR DESCRIPTION
Dette er en quick dirty work around rundt en bug i RAC som forårsaker evig re-render loop i React, har opprettet en bug i RAC og: [https://github.com/adobe/react-spectrum/issues/6229](https://github.com/adobe/react-spectrum/issues/6229)