### PR TITLE
fix: increase font size for input fields to prevent zooming

### DIFF
--- a/.changeset/pink-olives-look.md
+++ b/.changeset/pink-olives-look.md
@@ -3,5 +3,7 @@
 ---
 
 TextField, Select, TextArea, Combobox:
-increase font size from 14px to 16px to prevent zooming on iOS
-when input field is focused
+Increase font size from 14px to 16px to prevent zooming on iOS
+when input field is focused.
+
+TextField: Fix issue with `type="date"` where the size of the input was off.

--- a/.changeset/pink-olives-look.md
+++ b/.changeset/pink-olives-look.md
@@ -1,0 +1,7 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+TextField, Select, TextArea, Combobox:
+increase font size from 14px to 16px to prevent zooming on iOS
+when input field is focused

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -7,7 +7,7 @@ const formFieldError = cx(
 
 const input = cva({
   base: [
-    'rounded-md py-2.5 text-sm font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
+    'rounded-md py-2.5 text-base font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
     // invalid styles
     'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
     // Fix invisible ring on safari: https://github.com/tailwindlabs/tailwindcss.com/issues/1135
@@ -32,10 +32,8 @@ const input = cva({
 });
 
 const inputGroup = cx([
-  'inline-flex items-center gap-3 overflow-hidden rounded-md bg-white px-3 text-sm ring-1 ring-black focus-within:ring-2',
+  'inline-flex items-center gap-3 overflow-hidden rounded-md bg-white px-3 text-base ring-1 ring-black focus-within:ring-2',
   'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red group-data-[invalid]:focus-within:ring',
-  // Make sure icons are the correct size
-  '[&_svg]:text-base',
 ]);
 
 const dropdown = {


### PR DESCRIPTION
with a smaller font size in input fields, iOS will automatically zoom in on the field.

Se https://obos.slack.com/archives/C03FR05FJ9F/p1713434756897919

Løser https://dev.azure.com/obosbbl/Content%20hub/_workitems/edit/98781.

Edit: Denne løser også https://github.com/code-obos/grunnmuren/pull/691

<img width="511" alt="Screenshot 2024-05-06 at 10 58 38" src="https://github.com/code-obos/grunnmuren/assets/81577/868b3cc7-752f-4bf2-bf74-b4284403086b">
