### PR TITLE
Bugfix/combobox scrolling

### DIFF
--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -38,9 +38,11 @@ const inputGroup = cx([
 
 const dropdown = {
   popover: cx(
-    'min-w-[--trigger-width] overflow-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
+    'min-w-[--trigger-width] rounded-md bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
   ),
-  listbox: cx('text-sm outline-none'),
+  listbox: cx(
+    'max-h-[25rem] overflow-y-scroll rounded-md border border-black text-sm outline-none',
+  ),
   chevronIcon: cx(
     'text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none',
   ),

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -96,7 +96,7 @@ function Combobox<T extends object>(
         )}
         crossOffset={-13}
       >
-        <ListBox>{children}</ListBox>
+        <ListBox className={dropdown.listbox}>{children}</ListBox>
       </Popover>
     </RACCombobox>
   );

--- a/packages/react/src/select/Select.stories.tsx
+++ b/packages/react/src/select/Select.stories.tsx
@@ -24,9 +24,11 @@ type Story = StoryObj<typeof Select>;
 const Template = <T extends object>(args: SelectProps<T>) => {
   const select = (
     <Select {...args}>
-      {counties.map(({ name }) => (
-        <SelectItem key={name}>{name}</SelectItem>
-      ))}
+      {counties.map((county) =>
+        county.municipalities.map((municipality) => (
+          <SelectItem key={municipality.name}>{municipality.name}</SelectItem>
+        )),
+      )}
     </Select>
   );
   return args.isRequired ? (

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -81,7 +81,7 @@ function Select<T extends object>(
       <ErrorMessageOrFieldError errorMessage={errorMessage} />
 
       <Popover className={dropdown.popover}>
-        <ListBox>{children}</ListBox>
+        <ListBox className={dropdown.listbox}>{children}</ListBox>
       </Popover>
     </RACSelect>
   );


### PR DESCRIPTION
Fikser autoscrolling ved navigasjon med piltaster i `Combobox` og `Select`. Dette gjøres ved å sette en begrenset høyde på `ListBox`, og la denne være scrollbar istedenfor `Popover`. Dette fikser også problemet at det ikke er mulig å scrolle `Popover` når den overflower viewporten.

Se oppgave: [93710](https://dev.azure.com/obosbbl/Content%20hub/_workitems/edit/93710?src=WorkItemMention&src-action=artifact_link)