### PR TITLE
fix: textarea/select should have a white background

### DIFF
--- a/.changeset/giant-sloths-grab.md
+++ b/.changeset/giant-sloths-grab.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+fix: make TextArea/Select usable against non white backgrounds

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -21,7 +21,7 @@ const input = cva({
         'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
     },
     isGrouped: {
-      false: 'px-3',
+      false: 'bg-white px-3',
       true: 'flex-1 !ring-0',
     },
   },


### PR DESCRIPTION
Denne PRen passer på at form inputs som Select og Textarea har hvit bakgrunn.

Fikser https://obos.slack.com/archives/C03FR05FJ9F/p1716800143200029