### PR TITLE
fix: add back layout classes that diseappeared in v2

### DIFF
--- a/.changeset/clever-frogs-breathe.md
+++ b/.changeset/clever-frogs-breathe.md
@@ -1,0 +1,8 @@
+---
+'@obosbbl/grunnmuren-tailwind': patch
+---
+
+Add back missing `.page-layout` and `.page-layout-main` classes that were removed by mistake in v2.
+This should fix layouts where the main page content isn't tall enough to push the footer down to the bottom
+of the screen.
+

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -161,7 +161,7 @@ module.exports = (options = {}) => {
       ...v1CompatibilityPlugins,
       require('@tailwindcss/typography'),
       require('tailwindcss-animate'),
-      plugin(function ({ addBase, addComponents }) {
+      plugin(function ({ addBase, addComponents, theme }) {
         addBase({
           html: {
             '@apply text-black antialiased font-normal font-text': {},
@@ -179,6 +179,15 @@ module.exports = (options = {}) => {
         });
 
         addComponents({
+          '.page-layout': {
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: '100vh',
+          },
+          '.page-layout-main': {
+            backgroundColor: theme('colors.white'),
+            flexGrow: '1',
+          },
           '.container': {
             width: '100%',
             paddingLeft: '1rem',


### PR DESCRIPTION
Denne PRen legger tilbake layout-klassene `.page-layout` og `.page-layout-main` som ved en feil ble fjernet i v2.

Når disse kommer igjen så burde det fikse utseendet på de sidene hvor innholdet på siden ikke er høyt nok til å dytte footeren ned mot bunn av skjermen.  Bank-teamet har nevnt det noen ganger for oss nå.