### PR TITLE
fix: missing error messages for form fields with native validation

### DIFF
--- a/.changeset/modern-apricots-invite.md
+++ b/.changeset/modern-apricots-invite.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+fix: error messages were missing when using native validation

--- a/packages/react/src/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/checkbox/Checkbox.stories.tsx
@@ -54,7 +54,7 @@ const ControlledTemplate = (args: CheckboxProps) => {
 const defaultProps: CheckboxProps = {
   children: 'Jeg godtar medlemsvilkårene.',
   isRequired: false,
-  isInvalid: false,
+  isInvalid: undefined,
   defaultSelected: undefined,
   value: undefined,
   isSelected: undefined,

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -72,7 +72,7 @@ function Checkbox(props: CheckboxProps, ref: Ref<HTMLLabelElement>) {
   const descriptionId = 'desc' + id;
   const errorMessageId = 'error' + id;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <div>

--- a/packages/react/src/checkbox/CheckboxGroup.stories.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.stories.tsx
@@ -83,7 +83,7 @@ const ControlledTemplate = (args: CheckboxGroupProps) => {
 const defaultProps = {
   label: 'Jeg er interessert i',
   isRequired: false,
-  isInvalid: false,
+  isInvalid: undefined,
   defaultValue: undefined,
   name: undefined,
   value: undefined,

--- a/packages/react/src/checkbox/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox/CheckboxGroup.tsx
@@ -43,7 +43,9 @@ function CheckboxGroup(props: CheckboxGroupProps, ref: Ref<HTMLDivElement>) {
     ...restProps
   } = props;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
+  // which will override any built in validation
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <RACCheckboxGroup

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -123,7 +123,7 @@ const GroupedTemplate = <T extends object>(args: ComboboxProps<T>) => (
 const defaultProps = {
   label: 'Velg boligprosjekt',
   isRequired: false,
-  isInvalid: false,
+  isInvalid: undefined,
   name: undefined,
   defaultSelectedKey: undefined,
   selectedKey: undefined,

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -61,7 +61,9 @@ function Combobox<T extends object>(
     ...restProps
   } = props;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
+  // which will override any built in validation
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <RACCombobox

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -86,7 +86,9 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
     ...restProps
   } = props;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
+  // which will override any built in validation
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <RACNumberField

--- a/packages/react/src/radiogroup/RadioGroup.stories.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.stories.tsx
@@ -89,7 +89,7 @@ const ControlledTemplate = (args: RadioGroupProps) => {
 const defaultProps = {
   label: 'Velg hvordan du vil kjøpe boligen',
   isRequired: false,
-  isInvalid: false,
+  isInvalid: undefined,
   defaultValue: undefined,
   name: undefined,
   value: undefined,

--- a/packages/react/src/radiogroup/RadioGroup.tsx
+++ b/packages/react/src/radiogroup/RadioGroup.tsx
@@ -43,7 +43,9 @@ function RadioGroup(props: RadioGroupProps, ref: Ref<HTMLDivElement>) {
     ...restProps
   } = props;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
+  // which will override any built in validation
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <RACRadioGroup

--- a/packages/react/src/select/Select.stories.tsx
+++ b/packages/react/src/select/Select.stories.tsx
@@ -74,7 +74,7 @@ const GroupedTemplate = <T extends object>(args: SelectProps<T>) => (
 const defaultProps = {
   label: 'Velg område',
   isRequired: false,
-  isInvalid: false,
+  isInvalid: undefined,
   name: undefined,
   defaultSelectedKey: undefined,
   selectedKey: undefined,

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -54,7 +54,9 @@ function Select<T extends object>(
     ...restProps
   } = props;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
+  // which will override any built in validation
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <RACSelect

--- a/packages/react/src/textarea/TextArea.stories.tsx
+++ b/packages/react/src/textarea/TextArea.stories.tsx
@@ -44,7 +44,7 @@ const ControlledTemplate = (args: TextAreaProps) => {
 const defaultProps = {
   label: 'Beskrivelse',
   isRequired: false,
-  isInvalid: false,
+  isInvalid: undefined,
   name: undefined,
   defaultValue: undefined,
   value: undefined,

--- a/packages/react/src/textarea/TextArea.tsx
+++ b/packages/react/src/textarea/TextArea.tsx
@@ -45,7 +45,7 @@ function TextArea(props: TextAreaProps, ref: Ref<HTMLTextAreaElement>) {
     ...restProps
   } = props;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <RACTextField

--- a/packages/react/src/textfield/TextField.stories.tsx
+++ b/packages/react/src/textfield/TextField.stories.tsx
@@ -74,7 +74,7 @@ const defaultProps = {
   label: 'Epost',
   withAddonDivider: false,
   isRequired: false,
-  isInvalid: false,
+  isInvalid: undefined,
   name: undefined,
   defaultValue: undefined,
   value: undefined,

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -76,7 +76,9 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
     ...restProps
   } = props;
 
-  const isInvalid = _isInvalid || errorMessage != null;
+  // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
+  // which will override any built in validation
+  const isInvalid = errorMessage != null || _isInvalid;
 
   return (
     <RACTextField


### PR DESCRIPTION
Denne PRen fikser https://obos.slack.com/archives/C03FR05FJ9F/p1716390149188459


Grunnen til at dette sluttet å funke er fordi det har vært en endring under panseret på RAC som har truffet oss. Før så fungerte native validering selv om isInvalid var satt til false, men nå gjør isInvalid valideringen "controlled", og den overstyrer da native validering.

Den kjappe fiksen her er bare å passe på at isInvalid er `undefined` inn til RAC.

Egentlig burde vi hatt visuelle snapshot tester eller lignende for det her, men det har vi ikke akkurat nå, og det tar dessverre litt tid å få på plass også.

Edit:

Se forskjellen her

Før: https://obos-grunnmuren.netlify.app/?path=/story/textfield--required

Etter: https://deploy-preview-846--obos-grunnmuren.netlify.app/?path=/story/textfield--required