### PR TITLE
Fix popover overflows

### DIFF
--- a/.changeset/mean-kings-fold.md
+++ b/.changeset/mean-kings-fold.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes popover overflow in `Combobox` and `Select`

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -38,11 +38,10 @@ const inputGroup = cx([
 
 const dropdown = {
   popover: cx(
-    'min-w-[--trigger-width] rounded-md bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
+    // Use outline + clip-path hack instead of border to prevent scrollbars from overflowing border-radius
+    'min-w-[--trigger-width] overflow-y-auto rounded-md bg-white shadow outline outline-1 outline-offset-[-1px] outline-black [clip-path:content-box] data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
   ),
-  listbox: cx(
-    'max-h-[25rem] overflow-y-scroll rounded-md border border-black text-sm outline-none',
-  ),
+  listbox: cx('max-h-[25rem] text-sm outline-none'),
   chevronIcon: cx(
     'text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none',
   ),


### PR DESCRIPTION
Fikser overflow i `popover` ved å bruke en kombinasjon av `outline` og `clip-path` istedenfor `border`. Da går det fint å flytte ut `overflow-auto` på `popover` slik at scrollingen oppfører seg som den skal. Og vi "klipper" vekk overflowing scrollbar i browsere med synlig scrollbar:

<img width="894" alt="Screenshot 2024-05-29 at 13 38 20" src="https://github.com/code-obos/grunnmuren/assets/6680533/9595695b-196c-4ad1-abee-36234569c9a1">

<img width="322" alt="Screenshot 2024-05-29 at 13 38 34" src="https://github.com/code-obos/grunnmuren/assets/6680533/30ae075f-3ce6-4fed-8a47-a509d3a6f194">
