### PR TITLE
fix(backlink): add cursor pointer

### DIFF
--- a/.changeset/weak-turkeys-teach.md
+++ b/.changeset/weak-turkeys-teach.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Backlink: use cursor-pointer

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -26,7 +26,7 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
     <RACLink
       className={cx(
         className,
-        'group flex max-w-fit items-center gap-3 rounded-md p-2.5 no-underline focus:outline-none data-[focus-visible]:ring data-[focus-visible]:ring-black',
+        'group flex max-w-fit cursor-pointer items-center gap-3 rounded-md p-2.5 no-underline focus:outline-none data-[focus-visible]:ring data-[focus-visible]:ring-black',
       )}
       {...restProps}
       ref={ref}


### PR DESCRIPTION
Legger til manglende `cursor-pointer` på Backlink, slik at den oppfører seg som andre linker ved hover.