### PR TITLE
fix(breadcrumbs): remove outline, use focus-visible for focus ring

### DIFF
--- a/.changeset/small-shoes-greet.md
+++ b/.changeset/small-shoes-greet.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Breadcrumbs: remove browser's default outline for the links, use focus-visible for focus ring

--- a/packages/react/src/breadcrumbs/Breadcrumb.tsx
+++ b/packages/react/src/breadcrumbs/Breadcrumb.tsx
@@ -28,7 +28,11 @@ function Breadcrumb(props: BreadcrumbProps, ref: Ref<HTMLLIElement>) {
       ref={ref}
     >
       {href ? (
-        <Link href={href} className="group-last:no-underline">
+        <Link
+          href={href}
+          // use outline instead of ring for focus marker that can be offset without creating a white background between the focus marker and the element content
+          className="rounded-sm focus:outline-none group-last:no-underline data-[focus-visible]:outline data-[focus-visible]:outline-offset-2 data-[focus-visible]:outline-black"
+        >
           {children}
         </Link>
       ) : (


### PR DESCRIPTION
Lenkesmulene i breadcrumbs-komponenten hadde ikke custom fokus-stiler, dermed ble browser defaults brukt.

## Før
All klikking på en lenke gir en outline

<img width="324" alt="Screenshot 2024-05-31 at 05 25 36" src="https://github.com/code-obos/grunnmuren/assets/81577/08cca1c8-c651-44a5-a479-a50e12530e2c">



## Etter
Fokusring bare synlig ved tastaturnavigering

<img width="301" alt="Screenshot 2024-05-31 at 05 26 43" src="https://github.com/code-obos/grunnmuren/assets/81577/caedbe23-db9e-4d3e-94c6-30f7b4cc759f">
