### PR TITLE
Button: use react-aria-components primitives

### DIFF
--- a/.changeset/cyan-kangaroos-poke.md
+++ b/.changeset/cyan-kangaroos-poke.md
@@ -1,0 +1,9 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Button: change implementation to use Button/Link from react-aria-components.
+
+* `onClick` prop is now called `onPress`.
+* Button, when used with a href, now works as expected with the `navigate` prop in `<GrunnmurenProvider>`.
+

--- a/packages/react/src/alertbox/Alertbox.stories.tsx
+++ b/packages/react/src/alertbox/Alertbox.stories.tsx
@@ -43,7 +43,7 @@ const ControlledTemplate = (args: AlertboxProps) => {
   return (
     <>
       <Button
-        onClick={() => setIsDismissed((prevState) => !prevState)}
+        onPress={() => setIsDismissed((prevState) => !prevState)}
         className="mb-4"
       >
         {`${isDismissed ? 'Vis' : 'Skjul'} alert`}

--- a/packages/react/src/button/Button.stories.tsx
+++ b/packages/react/src/button/Button.stories.tsx
@@ -23,7 +23,6 @@ const meta: Meta<typeof Button> = {
     return (
       <div className={cx(bgColor, 'flex gap-4 p-6')}>
         <Button {...props}>Button</Button>
-        {/* @ts-expect-error ts doesn't like the prop spread here, because props is typed as "ButtonLinkProps", which doesn't sit well when passing an href which only works with LinkProps */}
         <Button href="#" {...props}>
           Link
         </Button>


### PR DESCRIPTION
Denne PRen endrer vår Button-komponent til å bruke Button og Link-primitivene fra react-aria-components. Dette som avtalt i https://obos.slack.com/archives/C03FR05FJ9F/p1719491526889589.

Dette gjør at knappen kan integreres bedre med resten av react-aria-components, og det gjør også at når knappen brukes som en anchor/link så fungerer den med `navigate` propen i `GrunnmurenProvider` (på lik linje med feks Backlink og Breadcrumbs-komponentene).

Merk at dette gjør at `onClick` på Button nå må skrives om til `onPress`. Det er fordi det er det det heter i RAC.

Inspirasjon for selve implementasjonen er tatt herfra https://github.com/figma/sds/blob/main/src/ui/utils/AnchorOrButton.tsx