### PR TITLE
backlink: render as button when no href is provided

### DIFF
--- a/.changeset/twelve-pumas-report.md
+++ b/.changeset/twelve-pumas-report.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+fix: render Backlink as <button> when no href is provided, as it is more semantically correct

--- a/packages/react/src/backlink/Backlink.stories.tsx
+++ b/packages/react/src/backlink/Backlink.stories.tsx
@@ -3,7 +3,21 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Backlink, BacklinkProps } from '.';
 
 const Template = (args: BacklinkProps) => {
-  return <Backlink {...args}>Tilbake</Backlink>;
+  const { href, ...rest } = args;
+  return (
+    <div className="flex gap-20">
+      <div>
+        Link
+        <Backlink href={href} {...rest}>
+          Tilbake
+        </Backlink>
+      </div>
+      <div>
+        Button
+        <Backlink {...rest}>Tilbake</Backlink>
+      </div>
+    </div>
+  );
 };
 
 const meta: Meta<typeof Backlink> = {

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -1,36 +1,49 @@
 import { forwardRef, type Ref } from 'react';
 import { cx } from 'cva';
-import { Link as RACLink, type LinkProps } from 'react-aria-components';
+import { Button, Link, type ButtonProps } from 'react-aria-components';
 import { ChevronLeft } from '@obosbbl/grunnmuren-icons-react';
 
-type BacklinkProps = {
+type ButtonOrLinkProps = {
+  children?: React.ReactNode;
   /** Additional CSS className for the element. */
   className?: string;
-
-  /** The URL to navigate to when clicking the backlink. */
+  /** Determines whether to use an anchor or a button for the Backlink */
   href?: string;
-
-  /** The content of the link */
-  children?: React.ReactNode;
-
   /** To add a permanent underline on the link (not only on hover)
    * @default false
    */
   withUnderline?: boolean;
-} & LinkProps;
+};
 
-function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
-  const { className, children, href, withUnderline, ...restProps } = props;
+type BacklinkProps = (
+  | ButtonProps
+  | React.ComponentPropsWithoutRef<typeof Link>
+) &
+  ButtonOrLinkProps;
+
+function isLinkProps(
+  props: BacklinkProps,
+): props is ButtonOrLinkProps & React.ComponentPropsWithoutRef<typeof Link> {
+  return 'href' in props;
+}
+
+function Backlink(
+  props: BacklinkProps,
+  ref: Ref<HTMLAnchorElement | HTMLButtonElement>,
+) {
+  const { className, children, withUnderline, ...restProps } = props;
+
+  const Component = isLinkProps(props) ? Link : Button;
 
   return (
-    <RACLink
+    <Component
       className={cx(
         className,
         'group flex max-w-fit cursor-pointer items-center gap-3 rounded-md p-2.5 no-underline focus:outline-none data-[focus-visible]:ring data-[focus-visible]:ring-black',
       )}
       {...restProps}
+      // @ts-expect-error ignore the type of the ref here
       ref={ref}
-      href={href}
     >
       <ChevronLeft
         className={cx(
@@ -48,7 +61,7 @@ function Backlink(props: BacklinkProps, ref: Ref<HTMLAnchorElement>) {
           {children}
         </span>
       </span>
-    </RACLink>
+    </Component>
   );
 }
 


### PR DESCRIPTION
Denne PRen legger til støtte for at Backlink kan rendres som enten en button eller en anchor, basert på om det blir sendt inn en href eller ikke.

Dette er delvis inspirert av det vi gjorde for Button her https://github.com/code-obos/grunnmuren/pull/870.

Fikser https://dev.azure.com/obosbbl/Content%20hub/_boards/board/t/Designsystem%20-%20Grunnmuren/Stories?workitem=96988