### PR TITLE
Fix radio click area

### DIFF
--- a/.changeset/hot-clocks-return.md
+++ b/.changeset/hot-clocks-return.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Increases click area on `Radio` and `Checkbox` so that it is minimum 44x44 px when used without children.

--- a/.changeset/six-moles-fly.md
+++ b/.changeset/six-moles-fly.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes an issue with the click area on `Radio` and `Checkbox` where the area just to the left of the radio/checkbox gave a hover effect that indicated that the pointer was in the click area, but no click event fired.

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -11,7 +11,7 @@ import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
 import { ErrorMessage } from '../label/ErrorMessage';
 
 const defaultClasses = cx([
-  'group relative left-0 -mx-2.5 inline-flex max-w-fit cursor-pointer items-start gap-4 px-2.5 py-2 leading-7',
+  'group relative left-0 -mx-2.5 inline-flex max-w-fit cursor-pointer items-start gap-4 p-2.5 leading-7',
 ]);
 
 // Pulling this out into it's own component. Will probably export it in the future

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -11,7 +11,7 @@ import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
 import { ErrorMessage } from '../label/ErrorMessage';
 
 const defaultClasses = cx([
-  'group relative left-0 inline-flex max-w-fit cursor-pointer items-start gap-4 py-2 leading-7',
+  'group relative left-0 -mx-2.5 inline-flex max-w-fit cursor-pointer items-start gap-4 px-2.5 py-2 leading-7',
 ]);
 
 // Pulling this out into it's own component. Will probably export it in the future
@@ -88,8 +88,6 @@ function Checkbox(props: CheckboxProps, ref: Ref<HTMLLabelElement>) {
           isInvalid={isInvalid}
           ref={ref}
         >
-          {/* increases the clickable area of the checkbox for accessibility */}
-          <span className="absolute -left-2.5 top-0 z-10 h-11 w-11" />
           <CheckmarkBox />
           {children}
         </RACCheckbox>

--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -8,7 +8,7 @@ import {
 import { Description } from '../label';
 
 const defaultClasses = cx([
-  'relative -ml-2.5 inline-flex max-w-fit cursor-pointer items-start gap-4 py-2 pl-2.5 leading-7',
+  'relative -ml-2.5 inline-flex max-w-fit cursor-pointer items-start gap-4 py-2.5 pl-2.5 leading-7',
   // the radio button itself
   'before:flex-none before:rounded-full before:border-2 before:border-black',
   // to vertically align the radio we need to calculate the label's height, which is equal to it's font size multiplied by the line height.

--- a/packages/react/src/radiogroup/Radio.tsx
+++ b/packages/react/src/radiogroup/Radio.tsx
@@ -8,7 +8,7 @@ import {
 import { Description } from '../label';
 
 const defaultClasses = cx([
-  'relative inline-flex max-w-fit cursor-pointer items-start gap-4 py-2 leading-7',
+  'relative -ml-2.5 inline-flex max-w-fit cursor-pointer items-start gap-4 py-2 pl-2.5 leading-7',
   // the radio button itself
   'before:flex-none before:rounded-full before:border-2 before:border-black',
   // to vertically align the radio we need to calculate the label's height, which is equal to it's font size multiplied by the line height.
@@ -45,9 +45,6 @@ function Radio(props: RadioProps, ref: Ref<HTMLLabelElement>) {
       className={cx(className, defaultClasses)}
       ref={ref}
     >
-      {/* increases the clickable area of the radio button for accessibility */}
-      <span className="absolute -left-2.5 top-0 z-10 h-11 w-11 " />
-
       <div>
         {children}
         {description && (


### PR DESCRIPTION
### Klikkflate på checkbox og radioknapper

Erstatter dummy-`span` med padding og negativ margin for å sikre god klikkflate på checkbox og radio:

![Screenshot 2024-08-02 at 13 19 26](https://github.com/user-attachments/assets/9c72ee92-5e50-4f00-a194-b1724eee57ad)

![Screenshot 2024-08-02 at 13 19 47](https://github.com/user-attachments/assets/716054fa-39d7-41e3-86d1-68c37f27f592)

![Screenshot 2024-08-02 at 13 18 54](https://github.com/user-attachments/assets/3ebce68b-47fa-4348-b2f2-e0f31c817161)


Det ble litt forskjellig på checkbox og radio. Radioknapper har display grid, med en gap til en wrapper-`div` som gjør at de ikke trenger `padding-right` for at klikkflaten skal bli stor nok når de brukes uten `children`:

![Screenshot 2024-08-02 at 13 16 48](https://github.com/user-attachments/assets/115c5279-719f-4c47-a44b-0b05257dd88e)

Mens checkbox har ikke det, og trenger dermed både `padding-right` og `padding-left`:

![Screenshot 2024-08-02 at 13 17 39](https://github.com/user-attachments/assets/e98bca6a-a44b-4cb7-a677-4589c857b524)

Siden `span`-en som var der fra før brukte `-left-2.5` for å gi minst 44 px bredde brukte jeg samme spacing for paddingen. Og da føltes det naturlig å bruke samme `padding` for `py` og. Det gjorde også at høyden gikk fra 42 px til 46 px (ideelt er minst 44 px). Så slang det med som en bonus i denne PR-en