### PR TITLE
Button: render button if href is undefined

### DIFF
--- a/.changeset/swift-jars-wave.md
+++ b/.changeset/swift-jars-wave.md
@@ -2,4 +2,4 @@
 '@obosbbl/grunnmuren-react': patch
 ---
 
-Button: render Button if href is undefined
+Button/Backlink: render Button if href is undefined

--- a/.changeset/swift-jars-wave.md
+++ b/.changeset/swift-jars-wave.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Button: render Button if href is undefined

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -24,7 +24,7 @@ type BacklinkProps = (
 function isLinkProps(
   props: BacklinkProps,
 ): props is ButtonOrLinkProps & React.ComponentPropsWithoutRef<typeof Link> {
-  return 'href' in props;
+  return !!props.href;
 }
 
 function Backlink(

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -118,7 +118,7 @@ type ButtonProps = (
 function isLinkProps(
   props: ButtonProps,
 ): props is ButtonOrLinkProps & React.ComponentPropsWithoutRef<typeof RACLink> {
-  return 'href' in props;
+  return 'href' in props && props.href !== undefined;
 }
 
 function Button(

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -118,7 +118,7 @@ type ButtonProps = (
 function isLinkProps(
   props: ButtonProps,
 ): props is ButtonOrLinkProps & React.ComponentPropsWithoutRef<typeof RACLink> {
-  return 'href' in props && props.href !== undefined;
+  return !!props.href;
 }
 
 function Button(


### PR DESCRIPTION
Hvis bruker sender inn undefined som href, så vet ikke RAC om det er en a-tag eller Button. Den tror det er en a-tag, men rendrer til slutt bare en span med rolle=link som blir feil. Den skal egentlig rendre en Button da det ikke er en a-tag lenger siden href er undefined. 

Raskeste fiksen, men kan godt skrive det mer eksplisitt

koden:
<img width="433" alt="image" src="https://github.com/user-attachments/assets/6d466812-f371-46f2-b922-da384584a9ca">

Rendrer:

Før:
![image](https://github.com/user-attachments/assets/e7e02007-0b01-4881-b87f-82a1693639c9)


Etter: 
![image](https://github.com/user-attachments/assets/ffad05b9-b04b-4a4e-a52a-e10faf18fcb0)
