### PR TITLE
Fix border on popover

### DIFF
--- a/.changeset/tender-walls-beg.md
+++ b/.changeset/tender-walls-beg.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes an issue with scrollbars overflowing the border radius on popovers, and incorrect painting of the popover border in some browsers. This affects both the `<Select/>` component and the `<ComboBox/>` component.

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -38,10 +38,10 @@ const inputGroup = cx([
 
 const dropdown = {
   popover: cx(
-    // Use outline + clip-path hack instead of border to prevent scrollbars from overflowing border-radius
-    'min-w-[--trigger-width] overflow-y-auto rounded-md bg-white shadow outline outline-1 outline-offset-[-1px] outline-black [clip-path:content-box] data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
+    'min-w-[--trigger-width] overflow-y-auto rounded-md border border-black bg-white shadow data-[entering]:animate-in data-[exiting]:animate-out data-[entering]:fade-in data-[exiting]:fade-out',
   ),
-  listbox: cx('max-h-[25rem] text-sm outline-none'),
+  // overflow-x-hidden is needed to prevent visible vertical scrollbars from overflowing the border radius of the popover
+  listbox: cx('max-h-[25rem] overflow-x-hidden text-sm outline-none'),
   chevronIcon: cx(
     'text-base transition-transform duration-150 group-data-[open]:rotate-180 motion-reduce:transition-none',
   ),


### PR DESCRIPTION
### Fikser optegning av border og scrollbars i popover

Fikser problem med at scrollbar og borders på popover til å tegnes opp riktig i alle browsere. Vi gjorde en fiks med clip-path og outline som funket i noen browsere. Men har fortsatt vært et issue i Safari (hvis brukeren har eneblet scrollbars) og chrome på ubuntu: [891](https://github.com/code-obos/grunnmuren/issues/891)

Safari, før:
<img width="1080" alt="Screenshot 2024-08-12 at 10 12 51" src="https://github.com/user-attachments/assets/ab2d8daa-68c1-465d-840e-fd8577c7cef3">

Safari nå:
<img width="1133" alt="Screenshot 2024-08-12 at 10 13 30" src="https://github.com/user-attachments/assets/9967ffab-4a3a-4abb-96d2-ba714621c0cc">
