### PR TITLE
Fix input height on Safari mobile

### DIFF
--- a/.changeset/friendly-boats-fold.md
+++ b/.changeset/friendly-boats-fold.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes input height issue in `<TextField/>` component on Safari mobile.

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -1,13 +1,13 @@
 import { cx, cva } from 'cva';
 
-const formField = cx('group flex flex-col gap-2 [&>input]:min-h-11');
+const formField = cx('group flex flex-col gap-2');
 const formFieldError = cx(
   'w-fit rounded-sm bg-red-light px-2 py-1 text-sm leading-6 text-red',
 );
 
 const input = cva({
   base: [
-    'rounded-md py-2.5 text-base font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
+    'min-h-11 rounded-md py-2.5 text-base font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
     // invalid styles
     'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
     // Fix invisible ring on safari: https://github.com/tailwindlabs/tailwindcss.com/issues/1135

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -1,6 +1,6 @@
 import { cx, cva } from 'cva';
 
-const formField = cx('group flex flex-col gap-2');
+const formField = cx('group flex flex-col gap-2 [&>input]:min-h-11');
 const formFieldError = cx(
   'w-fit rounded-sm bg-red-light px-2 py-1 text-sm leading-6 text-red',
 );


### PR DESCRIPTION
### Fikser høyde på datofelter (Safari mobile)

#### Før:
![image](https://github.com/user-attachments/assets/bf1a3684-6757-4e2c-92d5-6696a0ca2725)


#### Nå:
![IMG_9BCA99254D22-1](https://github.com/user-attachments/assets/cc59819a-ea58-45e6-a9b0-137a9826a9de)
