### PR TITLE
Secondary button

### DIFF
--- a/.changeset/friendly-dolls-protect.md
+++ b/.changeset/friendly-dolls-protect.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': major
+---
+
+Removes white background color on `<Button variant="secondary"/>` to make it transparent and work well in a conatiner with any light color (not just white)

--- a/.changeset/friendly-dolls-protect.md
+++ b/.changeset/friendly-dolls-protect.md
@@ -1,5 +1,5 @@
 ---
-'@obosbbl/grunnmuren-react': major
+'@obosbbl/grunnmuren-react': patch
 ---
 
 Removes white background color on `<Button variant="secondary"/>` to make it transparent and work well in a conatiner with any light color (not just white)

--- a/packages/react/src/button/Button.stories.tsx
+++ b/packages/react/src/button/Button.stories.tsx
@@ -105,6 +105,14 @@ export const ButtonSandbox = () => {
         <Button variant="tertiary">Tertiary</Button>
       </div>
 
+      <div className="bg-mint-lightest p-8">
+        <div className="flex gap-8">
+          <Button>Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="tertiary">Tertiary</Button>
+        </div>
+      </div>
+
       <div className="bg-green-dark">
         <div className="flex gap-8 p-8">
           <Button color="mint">Primary</Button>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -55,8 +55,7 @@ const buttonVariants = cva({
     {
       color: 'green',
       variant: 'secondary',
-      className:
-        'bg-white text-black shadow-green hover:bg-green hover:text-white active:bg-green',
+      className: 'shadow-green hover:bg-green hover:text-white active:bg-green',
     },
     {
       color: 'mint',

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -55,7 +55,8 @@ const buttonVariants = cva({
     {
       color: 'green',
       variant: 'secondary',
-      className: 'shadow-green hover:bg-green hover:text-white active:bg-green',
+      className:
+        'text-black shadow-green hover:bg-green hover:text-white active:bg-green',
     },
     {
       color: 'mint',


### PR DESCRIPTION
## Fjerne hvit bakgrunn på secondary-knapp

Fjerner `bg-white` fra `<Button variant="secondary"/>`. Dette gjør at disse knappene ser bra ut mot en hvilken som helst lys bakgrunn, ikke bare hvit. Mens man fortsatt har mulighet til å bruke `<Button variant="mint"/>` eller `<Button variant="white"/>` mot en mørk bakgrunn.

### Før denne endringen
<img width="1069" alt="Screenshot 2024-09-19 at 14 07 59" src="https://github.com/user-attachments/assets/015c5eb5-24fe-426b-9936-83d02f9397ee">


### Etter denne endringen
<img width="1050" alt="Screenshot 2024-09-19 at 14 07 25" src="https://github.com/user-attachments/assets/ce087100-3b6b-45df-9acb-793903dee4f1">
