### PR TITLE
feat: add `useHref` hook to GrunnmurenProvider

### DIFF
--- a/.changeset/dull-houses-confess.md
+++ b/.changeset/dull-houses-confess.md
@@ -1,0 +1,48 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+add `useHref` to GrunnmurenProvider to simplify usage with routers such as Next when using a basepath.
+
+Example with a Next app and the [basePath](https://nextjs.org/docs/app/api-reference/next-config-js/basePath) setting set to `/medlem`.
+
+__Before__
+```tsx
+import Link from 'next/link';
+import { Button } from '@obosbbl/grunnmuren-react';
+
+// Notice how you have to handle the basepath yourself with Grunnmuren's component, but not with Next's.
+
+<Link href="/bli-medlem">Bli medlem</Link>
+<Button href="/medlem/bli-medlem">Bli medlem</Button>
+```
+
+**After**
+
+```js
+// app/providers.tsx
+'use client'
+import { GrunnmurenProvider } from '@obosbbl/grunnmuren-react';
+import { useRouter } from 'next/navigation';
+
+export function Providers({children, locale}: { children: React.ReactNode, locale: string}) {
+  const router = useRouter();
+  const useHref = (href: string) => '/medlem' + href;
+
+  return (
+    <GrunnmurenProvider locale={locale} navigate={router.push} useHref={useHref}>
+      {children}
+    </GrunnmurenProvider>
+  )
+}
+```
+
+```tsx
+import Link from 'next/link';
+import { Button } from '@obosbbl/grunnmuren-react';
+
+// The hrefs are the same, as basepath is handled by the useHref hook in the provider.
+
+<Link href="/bli-medlem">Bli medlem</Link>
+<Button href="/bli-medlem">Bli medlem</Button>
+```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -81,7 +81,7 @@ import { GrunnmurenProvider } from '@obosbbl/grunnmuren-react';
 import { useRouter } from 'next/navigation';
 
 export function Providers({children, locale}: { children: React.ReactNode, locale: string}) {
-  let router = useRouter();
+  const router = useRouter();
 
   return (
     <GrunnmurenProvider locale={locale} navigate={router.push}>
@@ -114,6 +114,52 @@ export default function RootLayout({
     </Providers>
   )
 }
+```
+
+#### Basepath
+
+If you're using a router such as Next's, then you can use the `useHref` prop to convert router-specific hrefs into native HTML hrefs. This is very useful for instance when using Next's [basepath](https://nextjs.org/docs/app/api-reference/next-config-js/basePath) setting, as you can use this to prepend the basepath to all links, similar to Next's `<Link>`.
+
+**Before**
+
+```tsx
+import Link from 'next/link';
+import { Button } from '@obosbbl/grunnmuren-react';
+
+// Notice how you have to handle the basepath yourself with Grunnmuren's component, but not with Next's.
+
+<Link href="/bli-medlem">Bli medlem</Link>
+<Button href="/medlem/bli-medlem">Bli medlem</Button>
+```
+
+**After**
+
+```js
+// app/providers.tsx
+'use client'
+import { GrunnmurenProvider } from '@obosbbl/grunnmuren-react';
+import { useRouter } from 'next/navigation';
+
+export function Providers({children, locale}: { children: React.ReactNode, locale: string}) {
+  const router = useRouter();
+  const useHref = (href: string) => '/medlem' + href;
+
+  return (
+    <GrunnmurenProvider locale={locale} navigate={router.push} useHref={useHref}>
+      {children}
+    </GrunnmurenProvider>
+  )
+}
+```
+
+```tsx
+import Link from 'next/link';
+import { Button } from '@obosbbl/grunnmuren-react';
+
+// The hrefs are the same, as basepath is handled by the useHref hook in the provider.
+
+<Link href="/bli-medlem">Bli medlem</Link>
+<Button href="/bli-medlem">Bli medlem</Button>
 ```
 
 ### Optimize bundle size by removing unused locales

--- a/packages/react/src/GrunnmurenProvider.tsx
+++ b/packages/react/src/GrunnmurenProvider.tsx
@@ -1,5 +1,7 @@
 import { I18nProvider, RouterProvider } from 'react-aria-components';
 
+type RouterProviderProps = React.ComponentProps<typeof RouterProvider>;
+
 type GrunnmurenProviderProps = {
   children: React.ReactNode;
   /**
@@ -8,19 +10,24 @@ type GrunnmurenProviderProps = {
    */
   locale?: 'nb' | 'sv' | 'en';
 
-  /** The router to use for navigation */
-  navigate?: (path: string) => void;
+  /** The router to use for client side navigation */
+  navigate?: RouterProviderProps['navigate'];
+  /** Converts a router-specific href to a native HTML href, e.g. prepending a base path */
+  useHref?: RouterProviderProps['useHref'];
 };
 
 function GrunnmurenProvider({
   children,
   locale = 'nb',
   navigate,
+  useHref,
 }: GrunnmurenProviderProps) {
   return (
     <I18nProvider locale={locale}>
       {navigate ? (
-        <RouterProvider navigate={navigate}>{children}</RouterProvider>
+        <RouterProvider navigate={navigate} useHref={useHref}>
+          {children}
+        </RouterProvider>
       ) : (
         children
       )}


### PR DESCRIPTION
Denne PRen legger til støtte for `useHref` hooken til [React Aria's RouterProvider](https://react-spectrum.adobe.com/react-aria/routing.html#routerprovider) til vår GrunnmurenProvider.

Det gjør det enklere å integrere Grunnmuren med client side routere som Next når man for eksempel har en custom basepath satt.


## Eksempel med basePath satt til `/medlem`

__Før__
```tsx
import Link from 'next/link';
import { Button } from '@obosbbl/grunnmuren-react';

// Notice how you have to handle the basepath yourself with Grunnmuren's component, but not with Next's.

<Link href="/bli-medlem">Bli medlem</Link>
<Button href="/medlem/bli-medlem">Bli medlem</Button>
```

__Etter__

```js
// app/providers.tsx
'use client'
import { GrunnmurenProvider } from '@obosbbl/grunnmuren-react';
import { useRouter } from 'next/navigation';

export function Providers({children, locale}: { children: React.ReactNode, locale: string}) {
  const router = useRouter();
  const useHref = (href: string) => '/medlem' + href;

  return (
    <GrunnmurenProvider locale={locale} navigate={router.push} useHref={useHref}>
      {children}
    </GrunnmurenProvider>
  )
}
```
```tsx
import Link from 'next/link';
import { Button } from '@obosbbl/grunnmuren-react';

// The hrefs are the same, as basepath is handled by the useHref hook in the provider.

<Link href="/bli-medlem">Bli medlem</Link>
<Button href="/bli-medlem">Bli medlem</Button>
```

