### PR TITLE
Make alertboxes uncontrolled dismissable

### DIFF
--- a/packages/react/src/alertbox/Alertbox.stories.tsx
+++ b/packages/react/src/alertbox/Alertbox.stories.tsx
@@ -62,7 +62,6 @@ const defaultProps = {
   variant: 'info',
   isDismissable: false,
   isExpandable: false,
-  isDismissed: false,
 } as const;
 
 export const DefaultAlert: Story = {

--- a/packages/react/src/alertbox/Alertbox.tsx
+++ b/packages/react/src/alertbox/Alertbox.tsx
@@ -183,7 +183,7 @@ const Alertbox = ({
           className={cx(
             'relative col-span-full row-start-2 -my-3 inline-flex max-w-fit cursor-pointer items-center gap-1 py-3 text-sm leading-6',
             // Focus styles:
-            'outline-none after:absolute after:bottom-3 after:left-0 after:right-0 after:h-0 after:bg-transparent after:transition-all after:duration-200',
+            'outline-none after:absolute after:bottom-3 after:left-0 after:right-0 after:h-0',
             'focus-visible:after:h-[2px] focus-visible:after:bg-black',
           )}
           onClick={() => setIsExpanded((prevState) => !prevState)}

--- a/packages/react/src/alertbox/Alertbox.tsx
+++ b/packages/react/src/alertbox/Alertbox.tsx
@@ -183,7 +183,7 @@ const Alertbox = ({
           className={cx(
             'relative col-span-full row-start-2 -my-3 inline-flex max-w-fit cursor-pointer items-center gap-1 py-3 text-sm leading-6',
             // Focus styles:
-            'outline-none after:absolute after:bottom-3 after:left-0 after:right-0 after:h-0',
+            'outline-none after:absolute after:bottom-3 after:left-0 after:right-0 after:h-0 after:bg-transparent after:transition-all after:duration-200',
             'focus-visible:after:h-[2px] focus-visible:after:bg-black',
           )}
           onClick={() => setIsExpanded((prevState) => !prevState)}

--- a/packages/react/src/alertbox/Alertbox.tsx
+++ b/packages/react/src/alertbox/Alertbox.tsx
@@ -170,7 +170,7 @@ const Alertbox = ({
         <button
           className={cx(
             '-m-2 grid h-11 w-11 place-items-center rounded-xl',
-            'focus:outline-none focus:-outline-offset-8 focus:outline-black',
+            'focus-visible:outline-none focus-visible:-outline-offset-8 focus-visible:outline-black',
           )}
           onClick={close}
           aria-label={translations.close[locale]}
@@ -184,7 +184,7 @@ const Alertbox = ({
             'relative col-span-full row-start-2 -my-3 inline-flex max-w-fit cursor-pointer items-center gap-1 py-3 text-sm leading-6',
             // Focus styles:
             'outline-none after:absolute after:bottom-3 after:left-0 after:right-0 after:h-0 after:bg-transparent after:transition-all after:duration-200',
-            'focus:after:h-[1px] focus:after:bg-black',
+            'focus-visible:after:h-[2px] focus-visible:after:bg-black',
           )}
           onClick={() => setIsExpanded((prevState) => !prevState)}
           aria-expanded={isExpanded}


### PR DESCRIPTION
## Fikser `<Alertbox>` story

Siden `isDismissed` var satt som default `false` gjorde det at alle stories der `<Alertbox>` er "_dismissable_" også at de ble _"controlled dismissable"_:

https://github.com/user-attachments/assets/b6296a4d-3810-477b-8a20-2d1e5159eeca

Dette funker bedre nå:


https://github.com/user-attachments/assets/3cba0051-4a97-4005-b312-89afead44ae6



Har ikke laget noe changeset, da dette ikke er en fiks i selve pakken. Men kun storybook.

P.S. 

Egen PR på å fikse fokusmarkering (`focus-visible`) er på vei....