### PR TITLE
feat: Badge component

### DIFF
--- a/.changeset/khaki-buttons-impress.md
+++ b/.changeset/khaki-buttons-impress.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+add `<Badge />` component

--- a/packages/react/src/badge/Badge.stories.tsx
+++ b/packages/react/src/badge/Badge.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { cx } from 'cva';
+import { Fragment } from 'react';
+import { PaintRoller } from '@obosbbl/grunnmuren-icons-react';
+
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Badge',
+  component: Badge,
+  render: (props) => {
+    return (
+      <div className="space-x-4">
+        <Badge {...props} size="small">
+          Small
+        </Badge>
+        <Badge {...props} size="medium">
+          Medium
+        </Badge>
+        <Badge {...props} size="large">
+          Large
+        </Badge>
+      </div>
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Sandbox = () => {
+  const colors = [
+    'mint',
+    'sky',
+    'blue-dark',
+    'green-dark',
+    'gray-dark',
+    'white',
+  ] as const;
+
+  return colors.map((color) => (
+    <Fragment key={color}>
+      <h2 className="font-medium">{color}</h2>
+      <div className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}>
+        <Badge color={color} size="small">
+          small
+        </Badge>
+        <Badge color={color} size="medium">
+          medium
+        </Badge>
+        <Badge color={color} size="large">
+          large
+        </Badge>
+      </div>
+    </Fragment>
+  ));
+};
+
+export const WithIcon = () => {
+  const colors = [
+    'mint',
+    'sky',
+    'blue-dark',
+    'green-dark',
+    'gray-dark',
+    'white',
+  ] as const;
+
+  return colors.map((color) => (
+    <Fragment key={color}>
+      <h2 className="font-medium">{color}</h2>
+      <div className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}>
+        <Badge color={color} size="small">
+          <PaintRoller />
+          small
+        </Badge>
+        <Badge color={color} size="medium">
+          <PaintRoller />
+          medium
+        </Badge>
+        <Badge color={color} size="large">
+          <PaintRoller />
+          large
+        </Badge>
+      </div>
+    </Fragment>
+  ));
+};
+
+export const Sizes: Story = {
+  args: {
+    color: 'mint',
+  },
+  render: (props) => {
+    return (
+      <div className="space-x-4">
+        <Badge {...props} size="small">
+          Small
+        </Badge>
+        <Badge {...props} size="medium">
+          Medium
+        </Badge>
+        <Badge {...props} size="large">
+          Large
+        </Badge>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/badge/Badge.tsx
+++ b/packages/react/src/badge/Badge.tsx
@@ -7,7 +7,9 @@ type BadgeProps = VariantProps<typeof badgeVariants> & {
 };
 
 const badgeVariants = cva({
-  base: ['inline-flex w-fit items-center justify-center gap-1.5 rounded-lg'],
+  base: [
+    'inline-flex w-fit items-center justify-center gap-1.5 rounded-lg [&_svg]:shrink-0',
+  ],
   variants: {
     color: {
       'gray-dark': 'bg-gray-dark text-white',

--- a/packages/react/src/badge/Badge.tsx
+++ b/packages/react/src/badge/Badge.tsx
@@ -1,0 +1,44 @@
+import { type VariantProps, cva } from 'cva';
+import { type Ref, forwardRef } from 'react';
+
+type BadgeProps = VariantProps<typeof badgeVariants> & {
+  children?: React.ReactNode;
+  className?: string;
+};
+
+const badgeVariants = cva({
+  base: ['inline-flex w-fit items-center justify-center gap-1.5 rounded-lg'],
+  variants: {
+    color: {
+      'gray-dark': 'bg-gray-dark text-white',
+      mint: 'bg-mint',
+      sky: 'bg-sky',
+      white: 'bg-white',
+      'blue-dark': 'bg-blue-dark text-white',
+      'green-dark': 'bg-green-dark text-white',
+    },
+    size: {
+      small: 'description px-2 py-0.5 [&_svg]:h-4 [&_svg]:w-4',
+      medium: 'description px-2.5 py-1.5 [&_svg]:h-4 [&_svg]:w-4',
+      large: 'paragraph px-3 py-2 [&_svg]:h-5 [&_svg]:w-5',
+    },
+  },
+  defaultVariants: {
+    size: 'medium',
+  },
+});
+
+function Badge(props: BadgeProps, ref: Ref<HTMLSpanElement>) {
+  const { className: _className, color, size, ...restProps } = props;
+
+  const className = badgeVariants({
+    className: _className,
+    color,
+    size,
+  });
+
+  return <span className={className} {...restProps} ref={ref} />;
+}
+
+const _Badge = forwardRef(Badge);
+export { _Badge as Badge, type BadgeProps };

--- a/packages/react/src/badge/index.ts
+++ b/packages/react/src/badge/index.ts
@@ -1,0 +1,1 @@
+export * from './Badge';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,6 +3,7 @@ export { Form } from 'react-aria-components';
 
 export * from './GrunnmurenProvider';
 export * from './accordion';
+export * from './badge';
 export * from './button';
 export * from './checkbox';
 export * from './combobox';


### PR DESCRIPTION
Denne PRen legger til en ny komponent, `<Badge />`.


[Figma-lenke](https://www.figma.com/design/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=3762-2595&node-type=frame&m=dev).

[Live preview eksempel](https://deploy-preview-937--obos-grunnmuren.netlify.app/?path=/docs/badge--docs)

Det er mulig å justere både størrelse og farge, og den sizer også ikoner automatisk. Merk at denne komponenten aldri skal brukes som et interaktivt element, tenk på det mer som en merkelapp. Kan brukes på feks Cards, bilder eller andre steder.




<img width="349" alt="Screenshot 2024-09-30 at 14 22 33" src="https://github.com/user-attachments/assets/19d6272d-9ecf-4467-8319-2f0cdcc01db3">






Den erstatter den gamle Chip komponenten fra v1:


<img width="550" alt="Screenshot 2024-09-30 at 14 21 32" src="https://github.com/user-attachments/assets/68a1e39d-e59d-4e33-b511-c3ca7e4d4b06">
