### PR TITLE
Standardize heights on ALL inputs

### DIFF
--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -7,7 +7,11 @@ const formFieldError = cx(
 
 const input = cva({
   base: [
-    'min-h-11 rounded-md py-2.5 text-base font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
+    // Use box-content to enable auto width based on number of characters (size)
+    // Setting min-height to prevent the input from collapsing in Safari
+    // Combining these with a padding-y as base classes makes it easier to standardize the height (44px) of all inputs
+    'box-content min-h-6 py-2.5',
+    'rounded-md text-base font-normal leading-6 placeholder-[#727070] outline-none ring-1 ring-black',
     // invalid styles
     'group-data-[invalid]:ring-2 group-data-[invalid]:ring-red',
     // Fix invisible ring on safari: https://github.com/tailwindlabs/tailwindcss.com/issues/1135

--- a/packages/react/src/numberfield/NumberField.tsx
+++ b/packages/react/src/numberfield/NumberField.tsx
@@ -64,7 +64,7 @@ const inputVariants = compose(
         left: '',
       },
       autoWidth: {
-        true: 'box-content max-w-fit',
+        true: 'max-w-fit',
         false: '',
       },
     },

--- a/packages/react/src/textfield/TextField.tsx
+++ b/packages/react/src/textfield/TextField.tsx
@@ -54,7 +54,7 @@ const inputVariants = compose(
         left: '',
       },
       autoWidth: {
-        true: 'box-content max-w-fit',
+        true: 'max-w-fit',
         false: '',
       },
     },


### PR DESCRIPTION
## Standardiserer høyden på input-felter

Setter `content-box` på alle input-felter slik at vi lettere kan sette samme høyde på alle.

Vi bruker `content-box` for å kunne sette en auto-bredde på felter som har en `size`. Ved å flytte over dette til base-klassen på input-feltene er det lettere å sikre at alle har samme høyde (44px).

