### PR TITLE
add useLocale hook

### DIFF
--- a/.changeset/quiet-insects-tickle.md
+++ b/.changeset/quiet-insects-tickle.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+add `useLocale()` hook that returns the locale set in GrunnmurenProvider

--- a/packages/react/src/GrunnmurenProvider.tsx
+++ b/packages/react/src/GrunnmurenProvider.tsx
@@ -1,4 +1,5 @@
 import { I18nProvider, RouterProvider } from 'react-aria-components';
+import type { Locale } from './use-locale';
 
 type RouterProviderProps = React.ComponentProps<typeof RouterProvider>;
 
@@ -8,7 +9,7 @@ type GrunnmurenProviderProps = {
    *  The locale to apply to the children.
    *  @default nb
    */
-  locale?: 'nb' | 'sv' | 'en';
+  locale?: Locale;
 
   /** The router to use for client side navigation */
   navigate?: RouterProviderProps['navigate'];

--- a/packages/react/src/alertbox/Alertbox.tsx
+++ b/packages/react/src/alertbox/Alertbox.tsx
@@ -1,6 +1,6 @@
 import { Children, useId } from 'react';
 import { cva, type VariantProps, cx } from 'cva';
-import { useLocale } from 'react-aria-components';
+
 import {
   Close,
   ChevronDown,
@@ -10,6 +10,7 @@ import {
   CloseCircle,
 } from '@obosbbl/grunnmuren-icons-react';
 import { useState } from 'react';
+import { useLocale, type Locale } from '../use-locale';
 
 // TODO: add new icons
 const iconMap = {
@@ -77,10 +78,8 @@ type Props = VariantProps<typeof alertVariants> & {
   onDismiss?: () => void;
 };
 
-type SupportedLocales = 'nb' | 'sv' | 'en';
-
 type Translation = {
-  [key in SupportedLocales]: string;
+  [key in Locale]: string;
 };
 
 type Translations = {
@@ -105,10 +104,6 @@ const translations: Translations = {
   },
 };
 
-type SupportedLocale = ReturnType<typeof useLocale> & {
-  locale: SupportedLocales;
-};
-
 const Alertbox = ({
   children,
   role,
@@ -121,7 +116,7 @@ const Alertbox = ({
 }: Props) => {
   const Icon = iconMap[variant];
 
-  const { locale } = useLocale() as SupportedLocale;
+  const locale = useLocale();
 
   const id = useId();
   const [isExpanded, setIsExpanded] = useState(false);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@
 export { Form } from 'react-aria-components';
 
 export * from './GrunnmurenProvider';
+export * from './use-locale';
 export * from './accordion';
 export * from './badge';
 export * from './button';

--- a/packages/react/src/use-locale.ts
+++ b/packages/react/src/use-locale.ts
@@ -1,0 +1,15 @@
+import { useLocale } from 'react-aria-components';
+
+type Locale = 'nb' | 'sv' | 'en';
+
+/**
+ * Returns the locale set in `<GrunnmurenProvider />`
+ */
+function _useLocale(): Locale {
+  // a small wrapper around react-arias useLocale with a simpler return type with only the locales that we actually support
+  const locale = useLocale();
+
+  return locale.locale as Locale;
+}
+
+export { _useLocale as useLocale, type Locale };


### PR DESCRIPTION
Denne PRen legger  til en hook, `useLocale()` som returnerer `locale` satt i `<GrunnmurenProvider />`.

Jeg PoCet litt på en kart-komponent i går, og trengte tilgang til språk/locale. Da føltes det rart ut at jeg skulle hente det via react-aria, når min avhengighet er til Grunmmuren. Derfor gir det mening at vi eksponerer en hook for dette (som vi også har nytte av internt i grunnmuren).