### PR TITLE
Fix input bg color

### DIFF
--- a/.changeset/green-stingrays-vanish.md
+++ b/.changeset/green-stingrays-vanish.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes background color on inputs with type="search" in Safari

--- a/packages/react/src/classes.ts
+++ b/packages/react/src/classes.ts
@@ -7,6 +7,8 @@ const formFieldError = cx(
 
 const input = cva({
   base: [
+    // All inputs should always have a white background (this also ensures that type="search" on Safri doesn't get a gray background)
+    'bg-white',
     // Use box-content to enable auto width based on number of characters (size)
     // Setting min-height to prevent the input from collapsing in Safari
     // Combining these with a padding-y as base classes makes it easier to standardize the height (44px) of all inputs
@@ -25,7 +27,7 @@ const input = cva({
         'data-[focus-visible]:ring-2 group-data-[invalid]:data-[focus-visible]:ring',
     },
     isGrouped: {
-      false: 'bg-white px-3',
+      false: 'px-3',
       true: 'flex-1 !ring-0',
     },
   },


### PR DESCRIPTION
## Fikser input-farge in Safari

Setter alltid hvit farge på input, slik at vi overstyrer grå bakgrunn på `type="search"` i Safari:

![TextField - Required ⋅ Storybook](https://github.com/user-attachments/assets/ec7e3cbd-e513-42ec-8bbf-d4d3cc9637b8)

Dette problemet kan ses f.eks. i boligsøket i Safari på iPhone:
![IMG_D06962A3BDF9-1](https://github.com/user-attachments/assets/56c711ad-4c09-49b2-a232-5ef44becd775)
