### PR TITLE
Remove redundant class

### DIFF
--- a/.changeset/giant-balloons-search.md
+++ b/.changeset/giant-balloons-search.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Removes group class from `Accordion` to prevent issues with content that has the `group`-class`.

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -105,7 +105,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
   return (
     <div
       {...restProps}
-      className={cx('group relative px-2', className)}
+      className={cx('relative px-2', className)}
       ref={ref}
       data-open={isOpen}
     >


### PR DESCRIPTION
## Fjerner `group` fra `Accordion`

Klassen `group` ble nok brukt på et tidspunkt i implementasjonen av `<Accordion>`. Men den brukes ikke lenger. Og den skaper problemer når man nester innhold som også har (anonym) `group`, som f.eks. `<Select>`.