### PR TITLE
Basic Card

### DIFF
--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/react';
-import { Card, CardBody } from './Card';
-import { Heading } from '../content';
+import { Card } from './Card';
+import { Heading, Content } from '../content';
 import { cx } from 'cva';
 
 const meta: Meta<typeof Card> = {
@@ -8,13 +8,13 @@ const meta: Meta<typeof Card> = {
   component: Card,
   render: () => (
     <Card>
-      <CardBody>
+      <Content>
         <Heading level={3}>Min bolig</Heading>
         <p>
           Her finner du alt om din nye bolig og hva som venter deg fremover. Du
           finner dine dokumenter, salgsoppgave og mye mer.
         </p>
-      </CardBody>
+      </Content>
     </Card>
   ),
 };
@@ -32,10 +32,10 @@ export const WithBorder = () => {
     <Cards>
       {colors.map((color) => (
         <Card border={color} key={color}>
-          <CardBody>
+          <Content>
             <Heading level={3}>Border {color}</Heading>
             <p>Dette kortet har {color} som border</p>
-          </CardBody>
+          </Content>
         </Card>
       ))}
     </Cards>
@@ -56,10 +56,10 @@ export const WithBackground = () => {
           className={cx(bgColor, bgColor.includes('dark') && 'text-white')}
           key={bgColor}
         >
-          <CardBody>
+          <Content>
             <Heading level={3}>Bakgrunn {bgColor}</Heading>
             <p>Dette kortet har {bgColor} som bakgrunnsfarge</p>
-          </CardBody>
+          </Content>
         </Card>
       ))}
     </Cards>

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta } from '@storybook/react';
+import { Card, CardBody } from './Card';
+import { Heading } from '../content';
+import { cx } from 'cva';
+
+const meta: Meta<typeof Card> = {
+  title: 'Card',
+  component: Card,
+  render: () => (
+    <Card>
+      <CardBody>
+        <Heading level={3}>Min bolig</Heading>
+        <p>
+          Her finner du alt om din nye bolig og hva som venter deg fremover. Du
+          finner dine dokumenter, salgsoppgave og mye mer.
+        </p>
+      </CardBody>
+    </Card>
+  ),
+};
+
+export default meta;
+
+const Cards = ({ children }: { children: React.ReactNode }) => (
+  <div className="grid gap-4">{children}</div>
+);
+
+export const WithBorder = () => {
+  const colors = ['black', 'blue-dark', 'green-dark'] as const;
+
+  return (
+    <Cards>
+      {colors.map((color) => (
+        <Card border={color} key={color}>
+          <CardBody>
+            <Heading level={3}>Border {color}</Heading>
+            <p>Dette kortet har {color} som border</p>
+          </CardBody>
+        </Card>
+      ))}
+    </Cards>
+  );
+};
+
+export const WithBackground = () => {
+  const bgColors = [
+    'bg-mint-lightest',
+    'bg-sky-light',
+    'bg-blue-dark',
+    'bg-green-dark',
+  ] as const;
+  return (
+    <Cards>
+      {bgColors.map((bgColor) => (
+        <Card
+          className={cx(bgColor, bgColor.includes('dark') && 'text-white')}
+          key={bgColor}
+        >
+          <CardBody>
+            <Heading level={3}>Bakgrunn {bgColor}</Heading>
+            <p>Dette kortet har {bgColor} som bakgrunnsfarge</p>
+          </CardBody>
+        </Card>
+      ))}
+    </Cards>
+  );
+};

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -1,6 +1,6 @@
-import { cva, cx, VariantProps } from 'cva';
+import { cva, VariantProps } from 'cva';
 import { Provider } from 'react-aria-components';
-import { HeadingContext } from '../content';
+import { ContentContext, HeadingContext } from '../content';
 
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
@@ -39,6 +39,12 @@ const Card = ({
               className: 'heading-s text-pretty',
             },
           ],
+          [
+            ContentContext,
+            {
+              className: 'grid gap-y-4',
+            },
+          ],
         ]}
       >
         {children}
@@ -47,15 +53,4 @@ const Card = ({
   );
 };
 
-type CardBodyProps = {
-  children?: React.ReactNode;
-  className?: string;
-};
-
-const CardBody = ({ children, className, ...restProps }: CardBodyProps) => (
-  <div className={cx(className, 'grid gap-y-4')} {...restProps}>
-    {children}
-  </div>
-);
-
-export { Card, type CardProps, type CardBodyProps, CardBody };
+export { Card, type CardProps };

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -42,7 +42,7 @@ const Card = ({
           [
             ContentContext,
             {
-              className: 'grid gap-y-4',
+              className: 'grid gap-y-4 auto-rows-max',
             },
           ],
         ]}

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -1,0 +1,61 @@
+import { cva, cx, VariantProps } from 'cva';
+import { Provider } from 'react-aria-components';
+import { HeadingContext } from '../content';
+
+type CardProps = VariantProps<typeof cardVariants> & {
+  children?: React.ReactNode;
+  className?: string;
+};
+
+const cardVariants = cva({
+  base: 'rounded-2xl border p-3',
+  variants: {
+    border: {
+      black: 'border-black',
+      'blue-dark': 'border-blue-dark',
+      'green-dark': 'border-green-dark',
+      undefined: 'border-transparent',
+    },
+  },
+});
+
+const Card = ({
+  children,
+  className: _className,
+  border,
+  ...restProps
+}: CardProps) => {
+  const className = cardVariants({
+    className: _className,
+    border,
+  });
+  return (
+    <div className={className} {...restProps}>
+      <Provider
+        values={[
+          [
+            HeadingContext,
+            {
+              className: 'heading-s text-pretty',
+            },
+          ],
+        ]}
+      >
+        {children}
+      </Provider>
+    </div>
+  );
+};
+
+type CardBodyProps = {
+  children?: React.ReactNode;
+  className?: string;
+};
+
+const CardBody = ({ children, className, ...restProps }: CardBodyProps) => (
+  <div className={cx(className, 'grid gap-y-4')} {...restProps}>
+    {children}
+  </div>
+);
+
+export { Card, type CardProps, type CardBodyProps, CardBody };

--- a/packages/react/src/card/index.ts
+++ b/packages/react/src/card/index.ts
@@ -1,0 +1,1 @@
+export * from './Card';

--- a/packages/react/src/content/Content.tsx
+++ b/packages/react/src/content/Content.tsx
@@ -37,7 +37,7 @@ const Heading = (
 };
 
 const ContentContext = createContext<
-  ContextValue<ContentProps, HTMLDivElement>
+  ContextValue<Partial<ContentProps>, HTMLDivElement>
 >({});
 
 type ContentProps = HTMLProps<HTMLDivElement> & {

--- a/packages/react/src/content/Content.tsx
+++ b/packages/react/src/content/Content.tsx
@@ -10,7 +10,7 @@ type HeadingProps = HTMLProps<HTMLHeadingElement> & {
 };
 
 const HeadingContext = createContext<
-  ContextValue<HeadingProps, HTMLHeadingElement>
+  ContextValue<Partial<HeadingProps>, HTMLHeadingElement>
 >({});
 
 const Heading = (

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,3 +17,4 @@ export * from './alertbox';
 export * from './content';
 export * from './breadcrumbs';
 export * from './backlink';
+export * from './card';


### PR DESCRIPTION
## Card

Legger til "bare minimum" for en `<Card>` komponent. 

Her det satt opp litt grunnleggende styling for kort. Og kun en variant for `border`. I følge Kristian så er bakgrunnsfarge veldig fritt, så har ikke lagt opp til noe annet enn at dette styres med `className` for nå.

Basert på erfaringene i [denne draften](https://github.com/code-obos/grunnmuren/pull/962) virker det lurt å wrappe tekstlig innhold i en container (bruker `<Content>` til dette). Dette vil forenkle veldig hvis vi skal legge tilrette for horisontal layout senere.