### PR TITLE
Vertical icon and image cards

### DIFF
--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta } from '@storybook/react';
 import { Card } from './Card';
-import { Heading, Content } from '../content';
+import { Heading, Content, Media } from '../content';
 import { cx } from 'cva';
+import { PiggyBank } from '@obosbbl/grunnmuren-icons-react';
 
 const meta: Meta<typeof Card> = {
   title: 'Card',
@@ -65,3 +66,59 @@ export const WithBackground = () => {
     </Cards>
   );
 };
+
+export const WithImage = () => (
+  <Card>
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/obos-logo-socialmeta.jpg"
+      />
+    </Media>
+    <Content>
+      <Heading level={3}>Kort med bilde</Heading>
+      <p>
+        Dette kortet har et bilde og er uten border. Derfor er alle hjørner på
+        bildet avrundet.
+      </p>
+    </Content>
+  </Card>
+);
+
+export const WithImageAndBorder = () => (
+  <Card border="blue-dark">
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/obos-logo-socialmeta.jpg"
+      />
+    </Media>
+    <Content>
+      <Heading level={3}>Kort med bilde og border</Heading>
+      <p>
+        Dette kortet har et bilde og border. Derfor er kun hjørnene i toppen
+        avrundet.
+      </p>
+    </Content>
+  </Card>
+);
+
+export const WithIconTop = () => (
+  <Card border="black">
+    <PiggyBank />
+    <Content>
+      <Heading level={3}>Kort med ikon i topp</Heading>
+      <p>Dette kortet har svart border og et ikon</p>
+    </Content>
+  </Card>
+);
+
+export const WithIconBottom = () => (
+  <Card border="black">
+    <Content>
+      <Heading level={3}>Kort med ikon i bunn</Heading>
+      <p>Dette kortet har svart border og et ikon</p>
+    </Content>
+    <PiggyBank />
+  </Card>
+);

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta } from '@storybook/react';
 import { Card } from './Card';
 import { Heading, Content, Media } from '../content';
 import { cx } from 'cva';
-import { PiggyBank } from '@obosbbl/grunnmuren-icons-react';
+import { Bed, House, PiggyBank } from '@obosbbl/grunnmuren-icons-react';
+import { Badge } from '../badge';
 
 const meta: Meta<typeof Card> = {
   title: 'Card',
@@ -120,5 +121,89 @@ export const WithIconBottom = () => (
       <p>Dette kortet har svart border og et ikon</p>
     </Content>
     <PiggyBank />
+  </Card>
+);
+
+const Illustration = () => (
+  <svg
+    aria-hidden="true"
+    width="112"
+    height="112"
+    viewBox="0 0 112 112"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M29.8947 51.7441V25.0321H35.6627C37.6875 25.0321 39.6294 25.8364 41.0612 27.2682C42.493 28.7 43.2973 30.6419 43.2973 32.6667V44.1188C43.2973 46.1436 42.493 48.0855 41.0612 49.5173C39.6294 50.9491 37.6875 51.7534 35.6627 51.7534H29.8947V51.7441Z"
+      fill="#002169"
+    />
+    <path
+      d="M59.8827 27.4306C58.0224 25.8375 55.6539 24.9619 53.2047 24.9619C50.7555 24.9619 48.387 25.8375 46.5267 27.4306L17.304 52.4906V96.8053H89.1147V52.4906L59.8827 27.4306Z"
+      fill="#0047BA"
+    />
+    <path d="M76.468 68.3198H60.8066V96.8052H76.468V68.3198Z" fill="white" />
+    <path
+      d="M60.8066 96.8053H76.468V97.664C76.4606 98.9934 75.9273 100.266 74.9847 101.203C74.042 102.141 72.7667 102.667 71.4373 102.667H65.8373C64.5031 102.667 63.2235 102.137 62.2801 101.193C61.3367 100.25 60.8066 98.9702 60.8066 97.636V96.7773V96.8053Z"
+      fill="#BEDFEC"
+    />
+    <path
+      d="M45.444 78.3161C43.387 78.3161 41.4142 77.4989 39.9597 76.0444C38.5052 74.5898 37.688 72.6171 37.688 70.5601C37.688 72.6171 36.8709 74.5898 35.4163 76.0444C33.9618 77.4989 31.989 78.3161 29.932 78.3161V83.7294H45.444V78.3161Z"
+      fill="white"
+    />
+    <path
+      d="M37.688 70.56C37.688 71.5785 37.8886 72.587 38.2784 73.528C38.6682 74.469 39.2395 75.3241 39.9597 76.0443C40.6799 76.7645 41.5349 77.3358 42.4759 77.7256C43.4169 78.1153 44.4255 78.316 45.444 78.316V68.2173H29.932V78.316C31.989 78.316 33.9618 77.4988 35.4163 76.0443C36.8709 74.5897 37.688 72.617 37.688 70.56Z"
+      fill="#002169"
+    />
+    <path
+      d="M100.203 94.0522C100.197 92.6146 99.7328 91.2164 98.8787 90.0602C98.0245 88.9039 96.8243 88.0498 95.452 87.6215V85.6988C95.4569 84.8639 95.2966 84.0363 94.9802 83.2636C94.6638 82.4909 94.1976 81.7885 93.6085 81.1968C93.0195 80.6051 92.3191 80.1358 91.5478 79.816C90.7766 79.4963 89.9496 79.3323 89.1147 79.3335C88.2829 79.3323 87.459 79.495 86.6902 79.8125C85.9214 80.13 85.2227 80.5959 84.6341 81.1836C84.0455 81.7714 83.5785 82.4694 83.2599 83.2377C82.9413 84.0061 82.7773 84.8297 82.7773 85.6615V87.5842C81.4061 88.0128 80.2071 88.8673 79.3545 90.0237C78.5019 91.1801 78.04 92.5781 78.036 94.0148V96.7495H100.203V94.0522Z"
+      fill="#002169"
+    />
+    <path
+      d="M91.868 30.8373C97.7958 30.8373 102.601 26.0318 102.601 20.1039C102.601 14.1761 97.7958 9.37061 91.868 9.37061C85.9401 9.37061 81.1346 14.1761 81.1346 20.1039C81.1346 26.0318 85.9401 30.8373 91.868 30.8373Z"
+      fill="#BEDFEC"
+    />
+  </svg>
+);
+
+export const CardWithInlineTopIllustration = () => (
+  <Card border="blue-dark" className="w-72">
+    <Illustration />
+    <Content>
+      <Heading level={3}>Utemiljø og grøntanlegg</Heading>
+      <p>
+        Et godt utemiljø er viktig for trivselen. Vi har en egen utenhusavdeling
+        med flinke folk som kan hjelpe med realisering av nye prosjekter.
+      </p>
+    </Content>
+  </Card>
+);
+
+export const CardWithCoveringIllustration = () => (
+  <Card border="blue-dark" className="w-72">
+    <Media>
+      <Illustration />
+    </Media>
+    <Content>
+      <div className="grid">
+        <Heading level={3}>Rødbergvn 88C</Heading>
+        <small className="description">Bjerke - Oslo</small>
+      </div>
+      <small className="description -order-1">
+        Forhåndsvarsling - Saksnr. F0347565
+      </small>
+      <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
+      <p className="flex gap-x-1">
+        <House /> Rekkehus/småhus
+      </p>
+      <p className="flex gap-x-1">
+        <Bed /> 3 soverom
+      </p>
+      <p className="flex gap-x-1">
+        <PiggyBank /> Totalpris 9 989 838
+      </p>
+      <Badge size="small" color="mint">
+        Visning 13. oktober
+      </Badge>
+    </Content>
   </Card>
 );

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -1,6 +1,4 @@
 import { cva, VariantProps } from 'cva';
-import { Provider } from 'react-aria-components';
-import { ContentContext, HeadingContext, MediaContext } from '../content';
 
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
@@ -8,28 +6,31 @@ type CardProps = VariantProps<typeof cardVariants> & {
 };
 
 const cardVariants = cva({
-  base: ['rounded-2xl border p-3', 'grid auto-rows-max gap-y-4'],
+  base: [
+    'rounded-2xl border p-3',
+    'grid auto-rows-max gap-y-4',
+    // Heading styles:
+    '[&_[data-slot="heading"]]:heading-s [&_[data-slot="heading"]]:text-pretty',
+    // Content styles:
+    '[&_[data-slot="content"]]:grid [&_[data-slot="content"]]:auto-rows-max [&_[data-slot="content"]]:gap-y-4',
+    // Media styles:
+    '[&_[data-slot="media"]]:overflow-hidden', // Prevent content from overflowing the rounded corners
+    '[&_[data-slot="media"]]:rounded-t-2xl', // Top corners are always rounded
+    // Position media at the edges of the card (because of these negative margins the media-element must be a wrapper around the actual image or other media content)
+    '[&_[data-slot="media"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] [&_[data-slot="media"]]:mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
+    // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work in FF)
+    '[&_[data-slot="media"]>*]:aspect-[3/2] [&_[data-slot="media"]>*]:w-full [&_[data-slot="media"]_img]:object-cover',
+  ],
   variants: {
     border: {
       black: 'border-black',
       'blue-dark': 'border-blue-dark',
       'green-dark': 'border-green-dark',
-      undefined: 'border-transparent',
-    },
-  },
-});
-
-const cardMediaVariants = cva({
-  base: [
-    // Hide overflow (outside the border radius)
-    'overflow-hidden',
-    // Bleed to the edges of the card (over the border)
-    'mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
-  ],
-  variants: {
-    hasBorder: {
-      false: 'rounded-2xl', // All corners rounded
-      true: 'rounded-t-2xl', // Only top corners rounded
+      undefined: [
+        'border-transparent',
+        // Media styles:
+        '[&_[data-slot="media"]]:rounded-b-2xl',
+      ],
     },
   },
 });
@@ -46,33 +47,7 @@ const Card = ({
   });
   return (
     <div className={className} {...restProps}>
-      <Provider
-        values={[
-          [
-            HeadingContext,
-            {
-              className: 'heading-s text-pretty',
-            },
-          ],
-          [
-            ContentContext,
-            {
-              className: 'grid gap-y-4 auto-rows-max',
-            },
-          ],
-          [
-            MediaContext,
-            {
-              className: cardMediaVariants({
-                hasBorder: !!border,
-              }),
-              aspectRatio: '3:2',
-            },
-          ],
-        ]}
-      >
-        {children}
-      </Provider>
+      {children}
     </div>
   );
 };

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -1,6 +1,6 @@
 import { cva, VariantProps } from 'cva';
 import { Provider } from 'react-aria-components';
-import { ContentContext, HeadingContext } from '../content';
+import { ContentContext, HeadingContext, MediaContext } from '../content';
 
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
@@ -8,13 +8,28 @@ type CardProps = VariantProps<typeof cardVariants> & {
 };
 
 const cardVariants = cva({
-  base: 'rounded-2xl border p-3',
+  base: ['rounded-2xl border p-3', 'grid auto-rows-max gap-y-4'],
   variants: {
     border: {
       black: 'border-black',
       'blue-dark': 'border-blue-dark',
       'green-dark': 'border-green-dark',
       undefined: 'border-transparent',
+    },
+  },
+});
+
+const cardMediaVariants = cva({
+  base: [
+    // Hide overflow (outside the border radius)
+    'overflow-hidden',
+    // Bleed to the edges of the card (over the border)
+    'mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
+  ],
+  variants: {
+    hasBorder: {
+      false: 'rounded-2xl', // All corners rounded
+      true: 'rounded-t-2xl', // Only top corners rounded
     },
   },
 });
@@ -43,6 +58,15 @@ const Card = ({
             ContentContext,
             {
               className: 'grid gap-y-4 auto-rows-max',
+            },
+          ],
+          [
+            MediaContext,
+            {
+              className: cardMediaVariants({
+                hasBorder: !!border,
+              }),
+              aspectRatio: '3:2',
             },
           ],
         ]}

--- a/packages/react/src/content/Content.tsx
+++ b/packages/react/src/content/Content.tsx
@@ -1,3 +1,4 @@
+import { cva, VariantProps } from 'cva';
 import { HTMLProps, createContext, type ForwardedRef } from 'react';
 import { useContextProps, type ContextValue } from 'react-aria-components';
 
@@ -55,6 +56,40 @@ const Content = (props: ContentProps, ref: ForwardedRef<HTMLDivElement>) => {
   return outerWrapper ? outerWrapper(content) : content;
 };
 
+const MediaContext = createContext<
+  ContextValue<Partial<MediaProps>, HTMLDivElement>
+>({});
+
+type MediaProps = HTMLProps<HTMLDivElement> &
+  VariantProps<typeof mediaVariants> & {
+    children: React.ReactNode;
+  };
+
+const mediaVariants = cva({
+  variants: {
+    aspectRatio: {
+      // Sets the aspect ratio on any child
+      // width: 100% is necessary to make aspect ratio work in FF
+      '2:3': '*:aspect-[2/3] *:w-full [&_img]:object-cover',
+      '3:4': '*:aspect-[3/4] *:w-full [&_img]:object-cover',
+      '3:2': '*:aspect-[3/2] *:w-full [&_img]:object-cover',
+      '4:3': '*:aspect-[4/3] *:w-full [&_img]:object-cover',
+      '16:9': '*:aspect-video *:w-full [&_img]:object-cover',
+    },
+  },
+});
+
+const Media = (props: MediaProps, ref: ForwardedRef<HTMLDivElement>) => {
+  [props, ref] = useContextProps(props, ref, MediaContext);
+  const { className: _className, aspectRatio, ...restProps } = props;
+  const className = mediaVariants({
+    className: _className,
+    aspectRatio,
+  });
+
+  return <div className={className} {...restProps} data-slot="media" />;
+};
+
 type FooterProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
 };
@@ -68,6 +103,9 @@ export {
   type ContentProps,
   Content,
   ContentContext,
+  MediaContext,
+  type MediaProps,
+  Media,
   type FooterProps,
   Footer,
 };

--- a/packages/react/src/content/Content.tsx
+++ b/packages/react/src/content/Content.tsx
@@ -1,4 +1,3 @@
-import { cva, VariantProps } from 'cva';
 import { HTMLProps, createContext, type ForwardedRef } from 'react';
 import { useContextProps, type ContextValue } from 'react-aria-components';
 
@@ -60,34 +59,14 @@ const MediaContext = createContext<
   ContextValue<Partial<MediaProps>, HTMLDivElement>
 >({});
 
-type MediaProps = HTMLProps<HTMLDivElement> &
-  VariantProps<typeof mediaVariants> & {
-    children: React.ReactNode;
-  };
-
-const mediaVariants = cva({
-  variants: {
-    aspectRatio: {
-      // Sets the aspect ratio on any child
-      // width: 100% is necessary to make aspect ratio work in FF
-      '2:3': '*:aspect-[2/3] *:w-full [&_img]:object-cover',
-      '3:4': '*:aspect-[3/4] *:w-full [&_img]:object-cover',
-      '3:2': '*:aspect-[3/2] *:w-full [&_img]:object-cover',
-      '4:3': '*:aspect-[4/3] *:w-full [&_img]:object-cover',
-      '16:9': '*:aspect-video *:w-full [&_img]:object-cover',
-    },
-  },
-});
+type MediaProps = HTMLProps<HTMLDivElement> & {
+  children: React.ReactNode;
+};
 
 const Media = (props: MediaProps, ref: ForwardedRef<HTMLDivElement>) => {
-  [props, ref] = useContextProps(props, ref, MediaContext);
-  const { className: _className, aspectRatio, ...restProps } = props;
-  const className = mediaVariants({
-    className: _className,
-    aspectRatio,
-  });
+  [props] = useContextProps(props, ref, MediaContext);
 
-  return <div className={className} {...restProps} data-slot="media" />;
+  return <div {...props} data-slot="media" />;
 };
 
 type FooterProps = HTMLProps<HTMLDivElement> & {


### PR DESCRIPTION
## Bilder og ikoner i kort

Legger til støtte for ikoner og bilder (i vertikal layout) på `<Card>`.

Har også lagt inn stories for demonstrasjon av kort med ikoner i bunn/topp.

###  `<Media>`
Det er lagt til en ny komponent `<Media>` i `content`. Den kan brukes for å wrappe komponenter som `<img>`, `<Image> `(fra Next) en custom-komponent f.eks. `<CloudinaryImage>`, `<svg>` eller en `<video>`. Kort og godt alt av komponenter som er bilder, illustrasjoner eller video.

Her har man mulighet til å velge aspect-ratio, som settes med tailwind sin innebygde `aspect`-util. Måtte legge til `w-full` for at det skal funke i FF (som beregner implisitt bredde på en litt annen måte). Det er god support for `aspect-ratio `([94.59%](https://caniuse.com/?search=aspect-ratio)). Så spørs hva vi tenker om det? Et alternativ her hadde kanskje vært å bruke padding-hacken?

Det må til en wrapper rundt bilde i `Card` sånn at man kan sette negativ margin (left/right) og plassere bildet helt ut i kantene. Hvis ikke vil `margin-right` bli ignorert. I tillegg trenger vi en wrapper uansett hvis vi skal støtte horisontal layout med Overlay på bildet. [Se denne draften](https://github.com/code-obos/grunnmuren/pull/962) for eksempel.