### PR TITLE
Clickable card

### DIFF
--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -116,7 +116,7 @@ export const WithIconTop = () => (
     <PiggyBank />
     <Content>
       <Heading level={3}>Kort med ikon i topp</Heading>
-      <p>Dette kortet har svart border og et ikon</p>
+      <p>Dette kortet har svart border og et ikon i toppen</p>
     </Content>
   </Card>
 );
@@ -125,7 +125,7 @@ export const WithIconBottom = () => (
   <Card border="black">
     <Content>
       <Heading level={3}>Kort med ikon i bunn</Heading>
-      <p>Dette kortet har svart border og et ikon</p>
+      <p>Dette kortet har svart border og et ikon i bunn</p>
     </Content>
     <PiggyBank />
   </Card>
@@ -219,7 +219,7 @@ export const ClickableWithIcon = () => (
   <Card border="black">
     <Content>
       <Heading level={3}>
-        <CardLink href="#card">Klikkbar</CardLink>
+        <CardLink href="#card">Klikkbar med ikon</CardLink>
       </Heading>
       <p>Dette kortet er klikkbart og har svart border med et ikon</p>
     </Content>
@@ -240,8 +240,8 @@ export const ClickableWithImage = () => (
         <CardLink href="#card">Klikkbar med bilde</CardLink>
       </Heading>
       <p>
-        Dette kortet har et bilde og er uten border. Derfor er alle hjørner på
-        bildet avrundet.
+        Dette kortet er klikkbart. Det har et bilde og er uten border. Derfor er
+        alle hjørner på bildet avrundet.
       </p>
     </Content>
   </Card>
@@ -275,7 +275,7 @@ export const WithImageAndCTA = () => (
       </p>
       <CardLink className="group/cta">
         <Button href="#cta" variant="tertiary">
-          Klikkbar med bilde
+          Klikk her
           <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
         </Button>
       </CardLink>
@@ -293,7 +293,7 @@ export const WithBackgroundAndCTA = () => (
       </p>
       <CardLink className="group/cta mt-1">
         <Button href="#cta" variant="tertiary">
-          Klikkbar med bakgrunnsfarge
+          Klikk her
           <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
         </Button>
       </CardLink>

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -1,14 +1,16 @@
 import type { Meta } from '@storybook/react';
 import { Card, CardLink } from './Card';
-import { Heading, Content, Media } from '../content';
+import { Heading, Content, Media, Footer } from '../content';
 import { cx } from 'cva';
 import {
   ArrowRight,
   Bed,
+  Documents,
   House,
   PiggyBank,
 } from '@obosbbl/grunnmuren-icons-react';
 import { Badge } from '../badge';
+import { Button } from '../button';
 
 const meta: Meta<typeof Card> = {
   title: 'Card',
@@ -257,6 +259,48 @@ export const ClickableWithBackground = () => (
   </Card>
 );
 
+export const ClickableWithImageAndCTA = () => (
+  <Card>
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/obos-logo-socialmeta.jpg"
+      />
+    </Media>
+    <Content>
+      <Heading level={3}>Klikkbar med bakgrunnsfarge og CTA</Heading>
+      <p>
+        Dette kortet er klikkbart og har en bakgrunnsfarge og en CTA-lenke som
+        gjør at hele kortet blir klikkbart mot den lenken
+      </p>
+      <CardLink>
+        <Button href="#cta" variant="tertiary">
+          Klikkbar med bakgrunnsfarge
+          <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
+        </Button>
+      </CardLink>
+    </Content>
+  </Card>
+);
+
+export const ClickableWithBackgroundAndCTA = () => (
+  <Card className="bg-blue-dark text-white">
+    <Content>
+      <Heading level={3}>Klikkbar med bakgrunnsfarge og CTA</Heading>
+      <p>
+        Dette kortet er klikkbart og har en bakgrunnsfarge og en CTA-lenke som
+        gjør at hele kortet blir klikkbart mot den lenken
+      </p>
+      <CardLink className="mt-1">
+        <Button href="#cta" variant="tertiary">
+          Klikkbar med bakgrunnsfarge
+          <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
+        </Button>
+      </CardLink>
+    </Content>
+  </Card>
+);
+
 export const ClickableWithOtherClickableElements = () => (
   <Card border="blue-dark" className="w-72">
     <Media>
@@ -288,6 +332,13 @@ export const ClickableWithOtherClickableElements = () => (
       <Badge size="small" color="mint">
         Visning 13. oktober
       </Badge>
+      <Footer className="relative grid gap-y-2">
+        <hr className="border-t border-t-current" />
+        <Button href="#other-link" variant="tertiary">
+          Se prospekt
+          <Documents />
+        </Button>
+      </Footer>
     </Content>
   </Card>
 );
@@ -323,6 +374,17 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
       <Badge size="small" color="mint" className="text-black">
         Visning 13. oktober
       </Badge>
+      <Footer className="relative grid gap-y-2">
+        <hr className="border-t border-t-current" />
+        <Button
+          href="#other-link"
+          variant="tertiary"
+          className="focus-visible:outline-current"
+        >
+          Se prospekt
+          <Documents />
+        </Button>
+      </Footer>
     </Content>
   </Card>
 );

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -191,7 +191,7 @@ export const CardWithCoveringIllustration = () => (
       <Illustration />
     </Media>
     <Content>
-      <div className="grid">
+      <div className="grid gap-1">
         <Heading level={3}>Rødbergvn 88C</Heading>
         <small className="description">Bjerke - Oslo</small>
       </div>
@@ -259,7 +259,7 @@ export const ClickableWithBackground = () => (
   </Card>
 );
 
-export const ClickableWithImageAndCTA = () => (
+export const WithImageAndCTA = () => (
   <Card>
     <Media>
       <img
@@ -268,10 +268,10 @@ export const ClickableWithImageAndCTA = () => (
       />
     </Media>
     <Content>
-      <Heading level={3}>Klikkbar med bakgrunnsfarge og CTA</Heading>
+      <Heading level={3}>Med bilde og CTA</Heading>
       <p>
-        Dette kortet er klikkbart og har en bakgrunnsfarge og en CTA-lenke som
-        gjør at hele kortet blir klikkbart mot den lenken
+        Dette kortet er ikke klikkbart i seg selv, men har en klikkbar
+        CTA-lenke.
       </p>
       <CardLink className="group/cta">
         <Button href="#cta" variant="tertiary">
@@ -283,13 +283,13 @@ export const ClickableWithImageAndCTA = () => (
   </Card>
 );
 
-export const ClickableWithBackgroundAndCTA = () => (
+export const WithBackgroundAndCTA = () => (
   <Card className="bg-blue-dark text-white">
     <Content>
-      <Heading level={3}>Klikkbar med bakgrunnsfarge og CTA</Heading>
+      <Heading level={3}>Bakgrunnsfarge og CTA</Heading>
       <p>
-        Dette kortet er klikkbart og har en bakgrunnsfarge og en CTA-lenke som
-        gjør at hele kortet blir klikkbart mot den lenken
+        Dette kortet er ikke klikkbart i seg selv, men har en klikkbar
+        CTA-lenke.
       </p>
       <CardLink className="group/cta mt-1">
         <Button href="#cta" variant="tertiary">
@@ -310,7 +310,7 @@ export const ClickableWithOtherClickableElements = () => (
       />
     </Media>
     <Content>
-      <div className="grid">
+      <div className="grid gap-1">
         <Heading level={3}>
           <CardLink href="#card">Rødbergvn 88C</CardLink>
         </Heading>
@@ -352,7 +352,7 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
       />
     </Media>
     <Content>
-      <div className="grid">
+      <div className="grid gap-1">
         <Heading level={3}>
           <CardLink href="#card">Rødbergvn 88C</CardLink>
         </Heading>

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -273,10 +273,10 @@ export const ClickableWithImageAndCTA = () => (
         Dette kortet er klikkbart og har en bakgrunnsfarge og en CTA-lenke som
         gjør at hele kortet blir klikkbart mot den lenken
       </p>
-      <CardLink>
+      <CardLink className="group/cta">
         <Button href="#cta" variant="tertiary">
-          Klikkbar med bakgrunnsfarge
-          <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
+          Klikkbar med bilde
+          <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
         </Button>
       </CardLink>
     </Content>
@@ -291,10 +291,10 @@ export const ClickableWithBackgroundAndCTA = () => (
         Dette kortet er klikkbart og har en bakgrunnsfarge og en CTA-lenke som
         gjør at hele kortet blir klikkbart mot den lenken
       </p>
-      <CardLink className="mt-1">
+      <CardLink className="group/cta mt-1">
         <Button href="#cta" variant="tertiary">
           Klikkbar med bakgrunnsfarge
-          <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
+          <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
         </Button>
       </CardLink>
     </Content>

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -34,23 +34,6 @@ const Cards = ({ children }: { children: React.ReactNode }) => (
   <div className="grid gap-4">{children}</div>
 );
 
-export const WithBorder = () => {
-  const colors = ['black', 'blue-dark', 'green-dark'] as const;
-
-  return (
-    <Cards>
-      {colors.map((color) => (
-        <Card border={color} key={color}>
-          <Content>
-            <Heading level={3}>Border {color}</Heading>
-            <p>Dette kortet har {color} som border</p>
-          </Content>
-        </Card>
-      ))}
-    </Cards>
-  );
-};
-
 export const WithBackground = () => {
   const bgColors = [
     'bg-mint-lightest',
@@ -94,7 +77,7 @@ export const WithImage = () => (
 );
 
 export const WithImageAndBorder = () => (
-  <Card border="blue-dark">
+  <Card variant="outlined">
     <Media>
       <img
         alt=""
@@ -112,7 +95,7 @@ export const WithImageAndBorder = () => (
 );
 
 export const WithIconTop = () => (
-  <Card border="black">
+  <Card variant="outlined">
     <PiggyBank />
     <Content>
       <Heading level={3}>Kort med ikon i topp</Heading>
@@ -122,7 +105,7 @@ export const WithIconTop = () => (
 );
 
 export const WithIconBottom = () => (
-  <Card border="black">
+  <Card variant="outlined">
     <Content>
       <Heading level={3}>Kort med ikon i bunn</Heading>
       <p>Dette kortet har svart border og et ikon i bunn</p>
@@ -173,7 +156,7 @@ const Illustration = () => (
 );
 
 export const CardWithInlineTopIllustration = () => (
-  <Card border="blue-dark" className="w-72">
+  <Card variant="outlined" className="w-72">
     <Illustration />
     <Content>
       <Heading level={3}>Utemiljø og grøntanlegg</Heading>
@@ -186,7 +169,7 @@ export const CardWithInlineTopIllustration = () => (
 );
 
 export const CardWithCoveringIllustration = () => (
-  <Card border="blue-dark" className="w-72">
+  <Card variant="outlined" className="w-72">
     <Media>
       <Illustration />
     </Media>
@@ -216,7 +199,7 @@ export const CardWithCoveringIllustration = () => (
 );
 
 export const ClickableWithIcon = () => (
-  <Card border="black">
+  <Card variant="outlined">
     <Content>
       <Heading level={3}>
         <CardLink href="#card">Klikkbar med ikon</CardLink>
@@ -296,7 +279,7 @@ export const ClickableWithBackgroundAndCTA = () => (
 );
 
 export const ClickableWithOtherClickableElements = () => (
-  <Card border="blue-dark" className="w-72">
+  <Card variant="outlined" className="w-72">
     <Media>
       <img
         alt=""
@@ -338,7 +321,7 @@ export const ClickableWithOtherClickableElements = () => (
 );
 
 export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
-  <Card border="blue-dark" className="w-72 bg-blue-dark text-mint">
+  <Card variant="outlined" className="w-72 bg-blue-dark text-mint">
     <Media>
       <img
         alt=""

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react';
-import { Card } from './Card';
+import { Card, CardLink } from './Card';
 import { Heading, Content, Media } from '../content';
 import { cx } from 'cva';
 import {
@@ -214,9 +214,11 @@ export const CardWithCoveringIllustration = () => (
 );
 
 export const ClickableWithIcon = () => (
-  <Card href="#card" border="black">
+  <Card border="black">
     <Content>
-      <Heading level={3}>Klikkbart</Heading>
+      <Heading level={3}>
+        <CardLink href="#card">Klikkbar</CardLink>
+      </Heading>
       <p>Dette kortet er klikkbart og har svart border med et ikon</p>
     </Content>
     <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
@@ -224,7 +226,7 @@ export const ClickableWithIcon = () => (
 );
 
 export const ClickableWithImage = () => (
-  <Card href="#card">
+  <Card>
     <Media>
       <img
         alt=""
@@ -232,7 +234,9 @@ export const ClickableWithImage = () => (
       />
     </Media>
     <Content>
-      <Heading level={3}>Kort med bilde</Heading>
+      <Heading level={3}>
+        <CardLink href="#card">Klikkbar med bilde</CardLink>
+      </Heading>
       <p>
         Dette kortet har et bilde og er uten border. Derfor er alle hjørner på
         bildet avrundet.
@@ -242,9 +246,11 @@ export const ClickableWithImage = () => (
 );
 
 export const ClickableWithBackground = () => (
-  <Card href="#card" className="bg-blue-dark text-white">
+  <Card className="bg-blue-dark text-white">
     <Content>
-      <Heading level={3}>Klikkbart med bakgrunnsfarge</Heading>
+      <Heading level={3}>
+        <CardLink href="#card">Klikkbar med bakgrunnsfarge</CardLink>
+      </Heading>
       <p>Dette kortet er klikkbart og har en bakgrunnsfarge</p>
     </Content>
     <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
@@ -252,7 +258,7 @@ export const ClickableWithBackground = () => (
 );
 
 export const ClickableWithOtherClickableElements = () => (
-  <Card href="#card" border="blue-dark" className="w-72">
+  <Card border="blue-dark" className="w-72">
     <Media>
       <img
         alt=""
@@ -261,7 +267,9 @@ export const ClickableWithOtherClickableElements = () => (
     </Media>
     <Content>
       <div className="grid">
-        <Heading level={3}>Rødbergvn 88C</Heading>
+        <Heading level={3}>
+          <CardLink href="#card">Rødbergvn 88C</CardLink>
+        </Heading>
         <small className="description">Bjerke - Oslo</small>
       </div>
       <small className="description -order-1">
@@ -285,11 +293,7 @@ export const ClickableWithOtherClickableElements = () => (
 );
 
 export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
-  <Card
-    href="#card"
-    border="blue-dark"
-    className="w-72 bg-blue-dark text-white"
-  >
+  <Card border="blue-dark" className="w-72 bg-blue-dark text-mint">
     <Media>
       <img
         alt=""
@@ -298,7 +302,9 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
     </Media>
     <Content>
       <div className="grid">
-        <Heading level={3}>Rødbergvn 88C</Heading>
+        <Heading level={3}>
+          <CardLink href="#card">Rødbergvn 88C</CardLink>
+        </Heading>
         <small className="description">Bjerke - Oslo</small>
       </div>
       <small className="description -order-1">
@@ -314,7 +320,7 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
       <p className="flex gap-x-1">
         <PiggyBank /> Totalpris 9 989 838
       </p>
-      <Badge size="small" color="white" className="text-black">
+      <Badge size="small" color="mint" className="text-black">
         Visning 13. oktober
       </Badge>
     </Content>

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -1,9 +1,16 @@
 import type { Meta } from '@storybook/react';
 import { Card } from './Card';
-import { Heading, Content, Media } from '../content';
+import { Heading, Content, Media, Footer } from '../content';
 import { cx } from 'cva';
-import { Bed, House, PiggyBank } from '@obosbbl/grunnmuren-icons-react';
+import {
+  ArrowRight,
+  Bed,
+  House,
+  LinkExternal,
+  PiggyBank,
+} from '@obosbbl/grunnmuren-icons-react';
 import { Badge } from '../badge';
+import { Button } from '../button';
 
 const meta: Meta<typeof Card> = {
   title: 'Card',
@@ -204,6 +211,73 @@ export const CardWithCoveringIllustration = () => (
       <Badge size="small" color="mint">
         Visning 13. oktober
       </Badge>
+    </Content>
+  </Card>
+);
+
+export const ClickableWithIcon = () => (
+  <Card href="#card" border="black">
+    <Content>
+      <Heading level={3}>Klikkbart</Heading>
+      <p>Dette kortet er klikkbart og har svart border med et ikon</p>
+    </Content>
+    <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
+  </Card>
+);
+
+export const ClickableWithImage = () => (
+  <Card href="#card">
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/obos-logo-socialmeta.jpg"
+      />
+    </Media>
+    <Content>
+      <Heading level={3}>Kort med bilde</Heading>
+      <p>
+        Dette kortet har et bilde og er uten border. Derfor er alle hjørner på
+        bildet avrundet.
+      </p>
+    </Content>
+  </Card>
+);
+
+export const ClickableWithOtherClickableElements = () => (
+  <Card href="#card" border="blue-dark" className="w-72">
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
+      />
+    </Media>
+    <Content>
+      <div className="grid">
+        <Heading level={3}>Rødbergvn 88C</Heading>
+        <small className="description">Bjerke - Oslo</small>
+      </div>
+      <small className="description -order-1">
+        Forhåndsvarsling - Saksnr. F0347565
+      </small>
+      <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
+      <p className="flex gap-x-1">
+        <House /> Rekkehus/småhus
+      </p>
+      <p className="flex gap-x-1">
+        <Bed /> 3 soverom
+      </p>
+      <p className="flex gap-x-1">
+        <PiggyBank /> Totalpris 9 989 838
+      </p>
+      <Badge size="small" color="mint">
+        Visning 13. oktober
+      </Badge>
+      <Footer className="grid place-items-center">
+        <Button variant="tertiary" href="#cta">
+          Åpne finnannonsen
+          <LinkExternal />
+        </Button>
+      </Footer>
     </Content>
   </Card>
 );

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -1,16 +1,14 @@
 import type { Meta } from '@storybook/react';
 import { Card } from './Card';
-import { Heading, Content, Media, Footer } from '../content';
+import { Heading, Content, Media } from '../content';
 import { cx } from 'cva';
 import {
   ArrowRight,
   Bed,
   House,
-  LinkExternal,
   PiggyBank,
 } from '@obosbbl/grunnmuren-icons-react';
 import { Badge } from '../badge';
-import { Button } from '../button';
 
 const meta: Meta<typeof Card> = {
   title: 'Card',
@@ -282,12 +280,6 @@ export const ClickableWithOtherClickableElements = () => (
       <Badge size="small" color="mint">
         Visning 13. oktober
       </Badge>
-      <Footer className="grid place-items-center">
-        <Button variant="tertiary" href="#cta">
-          Åpne finnannonsen
-          <LinkExternal />
-        </Button>
-      </Footer>
     </Content>
   </Card>
 );
@@ -325,12 +317,6 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
       <Badge size="small" color="white" className="text-black">
         Visning 13. oktober
       </Badge>
-      <Footer className="grid place-items-center">
-        <Button variant="tertiary" color="white" href="#cta">
-          Åpne finnannonsen
-          <LinkExternal />
-        </Button>
-      </Footer>
     </Content>
   </Card>
 );

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -243,6 +243,16 @@ export const ClickableWithImage = () => (
   </Card>
 );
 
+export const ClickableWithBackground = () => (
+  <Card href="#card" className="bg-blue-dark text-white">
+    <Content>
+      <Heading level={3}>Klikkbart med bakgrunnsfarge</Heading>
+      <p>Dette kortet er klikkbart og har en bakgrunnsfarge</p>
+    </Content>
+    <ArrowRight className="transition-transform group-hover/card:motion-safe:translate-x-1" />
+  </Card>
+);
+
 export const ClickableWithOtherClickableElements = () => (
   <Card href="#card" border="blue-dark" className="w-72">
     <Media>
@@ -274,6 +284,49 @@ export const ClickableWithOtherClickableElements = () => (
       </Badge>
       <Footer className="grid place-items-center">
         <Button variant="tertiary" href="#cta">
+          Åpne finnannonsen
+          <LinkExternal />
+        </Button>
+      </Footer>
+    </Content>
+  </Card>
+);
+
+export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
+  <Card
+    href="#card"
+    border="blue-dark"
+    className="w-72 bg-blue-dark text-white"
+  >
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
+      />
+    </Media>
+    <Content>
+      <div className="grid">
+        <Heading level={3}>Rødbergvn 88C</Heading>
+        <small className="description">Bjerke - Oslo</small>
+      </div>
+      <small className="description -order-1">
+        Forhåndsvarsling - Saksnr. F0347565
+      </small>
+      <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
+      <p className="flex gap-x-1">
+        <House /> Rekkehus/småhus
+      </p>
+      <p className="flex gap-x-1">
+        <Bed /> 3 soverom
+      </p>
+      <p className="flex gap-x-1">
+        <PiggyBank /> Totalpris 9 989 838
+      </p>
+      <Badge size="small" color="white" className="text-black">
+        Visning 13. oktober
+      </Badge>
+      <Footer className="grid place-items-center">
+        <Button variant="tertiary" color="white" href="#cta">
           Åpne finnannonsen
           <LinkExternal />
         </Button>

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -259,7 +259,7 @@ export const ClickableWithBackground = () => (
   </Card>
 );
 
-export const WithImageAndCTA = () => (
+export const ClickableWithImageAndCTA = () => (
   <Card>
     <Media>
       <img
@@ -269,13 +269,10 @@ export const WithImageAndCTA = () => (
     </Media>
     <Content>
       <Heading level={3}>Med bilde og CTA</Heading>
-      <p>
-        Dette kortet er ikke klikkbart i seg selv, men har en klikkbar
-        CTA-lenke.
-      </p>
+      <p>Dette kortet har bilde og er klikkbart mot en CTA-lenke</p>
       <CardLink className="group/cta">
         <Button href="#cta" variant="tertiary">
-          Klikk her
+          Les mer
           <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
         </Button>
       </CardLink>
@@ -283,17 +280,14 @@ export const WithImageAndCTA = () => (
   </Card>
 );
 
-export const WithBackgroundAndCTA = () => (
+export const ClickableWithBackgroundAndCTA = () => (
   <Card className="bg-blue-dark text-white">
     <Content>
       <Heading level={3}>Bakgrunnsfarge og CTA</Heading>
-      <p>
-        Dette kortet er ikke klikkbart i seg selv, men har en klikkbar
-        CTA-lenke.
-      </p>
+      <p>Dette kortet har bakgrunnsfarge og er klikkbart mot en CTA-lenke.</p>
       <CardLink className="group/cta mt-1">
         <Button href="#cta" variant="tertiary">
-          Klikk her
+          Les mer
           <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
         </Button>
       </CardLink>

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -76,7 +76,7 @@ export const WithImage = () => (
   </Card>
 );
 
-export const WithImageAndBorder = () => (
+export const OutlinedWithImageAnd = () => (
   <Card variant="outlined">
     <Media>
       <img

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -32,11 +32,10 @@ const cardVariants = cva({
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
     '[&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out [&_[data-slot="media"]>*]:motion-safe:transition-transform',
 
-    // **** Card link ****
-    // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
-    '[&:has([data-slot="card-link"]:hover)_[data-slot="media"]>*]:scale-110',
     // **** Card link in Heading ****
-    // **** Hover: custom underline ****
+    // **** Hover ****
+    // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
+    '[&:has([data-slot="heading"]_[data-slot="card-link"]:hover)_[data-slot="media"]>*]:scale-110',
     // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
     // Border top is set to even out the border bottom used for the underline
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:no-underline',

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -27,19 +27,6 @@ const cardVariants = cva({
     '[&_[data-slot="media"]>*]:aspect-[3/2] [&_[data-slot="media"]>*]:w-full [&_[data-slot="media"]_img]:object-cover',
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
     '[&_[data-slot="media"]>*]:transition-transform [&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out',
-
-    // **** Footer ****
-    // Content of the footer is intended to be outside the clickable area of the card
-    // This serves as an area where the consumer can place other interactive elements that should not trigger the card click
-    '[&_[data-slot="footer"]]:relative', // Setting it to relative will place it on top of the clickable pseudo-element
-    // Position footer at the edges of the card, but give it the same padding as the rest of the card
-    '[&_[data-slot="footer"]]:py-3',
-    '[&_[data-slot="footer"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
-    '[&_[data-slot="footer"]]:mb-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
-    // Creates a divider line between the footer and the rest of the card that follows the card padding (the CSS would become even more complex if the border was placed on the card itself)
-    '[&_[data-slot="footer"]]:before:absolute',
-    '[&_[data-slot="footer"]]:before:left-3 [&_[data-slot="footer"]]:before:right-3 [&_[data-slot="footer"]]:before:top-0',
-    '[&_[data-slot="footer"]]:before:border-t [&_[data-slot="footer"]]:before:border-t-current',
   ],
   variants: {
     border: {
@@ -58,7 +45,7 @@ const cardVariants = cva({
         // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
         '[&:has([data-slot="card-heading-link"]:hover)_[data-slot="media"]>*]:scale-110',
 
-        // **** Fail-safe for interactive elements not placed in a <Footer> ****
+        // **** Fail-safe for interactive elements ****
         // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
         // The card is then made clickable by a pseudo-element on the heading that covers the entire card
         '[&_a:not([data-slot="card-heading-link"])]:relative [&_button]:relative [&_input]:relative',

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -1,25 +1,44 @@
-import { cva, VariantProps } from 'cva';
+import { cva, cx, VariantProps } from 'cva';
+import { Link, LinkProps, Provider } from 'react-aria-components';
+import { HeadingContext } from '../content';
 
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
   className?: string;
+  href?: LinkProps['href'];
 };
 
 const cardVariants = cva({
   base: [
+    'group/card',
     'rounded-2xl border p-3',
     'grid auto-rows-max gap-y-4',
-    // Heading styles:
-    '[&_[data-slot="heading"]]:heading-s [&_[data-slot="heading"]]:text-pretty',
-    // Content styles:
+    'relative', // Needed for positiong of the clickable pseudo-element (and can also be used for other absolute positioned elements the consumer might add)
+    // **** Content ****
     '[&_[data-slot="content"]]:grid [&_[data-slot="content"]]:auto-rows-max [&_[data-slot="content"]]:gap-y-4',
-    // Media styles:
+
+    // **** Media ****
     '[&_[data-slot="media"]]:overflow-hidden', // Prevent content from overflowing the rounded corners
     '[&_[data-slot="media"]]:rounded-t-2xl', // Top corners are always rounded
     // Position media at the edges of the card (because of these negative margins the media-element must be a wrapper around the actual image or other media content)
     '[&_[data-slot="media"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] [&_[data-slot="media"]]:mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
     // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work in FF)
     '[&_[data-slot="media"]>*]:aspect-[3/2] [&_[data-slot="media"]>*]:w-full [&_[data-slot="media"]_img]:object-cover',
+    // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
+    '[&_[data-slot="media"]>*]:transition-transform [&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out',
+
+    // **** Footer ****
+    // Footer content of the footer is intended to be outside the clickable area of the card
+    // Fot this reason the CSS of the footer becomes a little bit more complex
+    '[&_[data-slot="footer"]]:relative', // Setting it to relative will place it on top of the clickable pseudo-element
+    // Position footer at the edges of the card, but give it the same padding as the rest of the card
+    '[&_[data-slot="footer"]]:py-3',
+    '[&_[data-slot="footer"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
+    '[&_[data-slot="footer"]]:mb-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
+    // Creates a divider line between the footer and the rest of the card that follows the card padding (the CSS would become even more complex if the border was placed on the card itself)
+    '[&_[data-slot="footer"]]:before:absolute',
+    '[&_[data-slot="footer"]]:before:left-3 [&_[data-slot="footer"]]:before:right-3 [&_[data-slot="footer"]]:before:top-0',
+    '[&_[data-slot="footer"]]:before:border-t [&_[data-slot="footer"]]:before:border-t-current',
   ],
   variants: {
     border: {
@@ -32,6 +51,19 @@ const cardVariants = cva({
         '[&_[data-slot="media"]]:rounded-b-2xl',
       ],
     },
+    hasHref: {
+      false: '',
+      true: [
+        // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
+        '[&:has([data-slot="card-heading-link"]:hover)_[data-slot="media"]>*]:scale-110',
+
+        // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
+        // The card is then made clickable by a pseudo-element on the heading that covers the entire card
+        '[&_a:not([data-slot="card-heading-link"])]:relative [&_button]:relative [&_input]:relative',
+        // Place other interactive on top of the pseudo-element that makes the entire card clickable by setting a higher z-index than the pseudo-element
+        '[&_a:not([data-slot="card-heading-link"])]:z-[2] [&_button]:z-[2] [&_input]:z-[2]',
+      ],
+    },
   },
 });
 
@@ -39,15 +71,58 @@ const Card = ({
   children,
   className: _className,
   border,
+  href,
   ...restProps
 }: CardProps) => {
   const className = cardVariants({
     className: _className,
     border,
+    hasHref: !!href,
   });
   return (
     <div className={className} {...restProps}>
-      {children}
+      <Provider
+        values={[
+          [
+            HeadingContext,
+            {
+              className: cx(
+                'inline',
+                // Styles for the heading when content is not wrapped in a link
+                !href && 'heading-s w-fit text-pretty',
+              ),
+              _innerWrapper: (children) =>
+                href ? (
+                  <Link
+                    href={href}
+                    // Uses a pseudo-element with absolute position to make the entire card focusable and clickable
+                    className={cx(
+                      'cursor-pointer',
+                      // Note that the border-radius is set 1px less then the card radius
+                      // This is due to the fact that the card as a 1px border and needs to be adjusted to align perfectly
+                      'no-underline after:absolute after:inset-[calc(theme(borderWidth.DEFAULT)*-1)] after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
+                      // focus styles
+                      'focus-visible:after:outline-focus focus-visible:outline-none focus-visible:after:outline-offset-2',
+                      // hover styles
+                      // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
+                      // Border top is set to even out the border bottom used for the underline
+                      'border-y-2 border-y-transparent transition-colors hover:border-b-current',
+                      // Match the heading styles (especially important when the content spans mulitple lines)
+                      'heading-s text-pretty',
+                    )}
+                    data-slot="card-heading-link"
+                  >
+                    {children}
+                  </Link>
+                ) : (
+                  children
+                ),
+            },
+          ],
+        ]}
+      >
+        {children}
+      </Provider>
     </div>
   );
 };

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -70,12 +70,15 @@ const cardVariants = cva({
       outlined: 'border border-black',
     },
   },
+  defaultVariants: {
+    variant: 'subtle',
+  },
 });
 
 const Card = ({
   children,
   className: _className,
-  variant = 'subtle',
+  variant,
   ...restProps
 }: CardProps) => {
   const className = cardVariants({

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -89,9 +89,7 @@ const Card = ({
 
 type RACLinkProps = Pick<LinkProps, 'href' | 'routerOptions' | 'children'>;
 
-type CardLinkWrapperProps = {
-  [Key in keyof RACLinkProps]: LinkProps[Key];
-} & {
+type CardLinkWrapperProps = RACLinkProps & {
   // Override children type of LinkProps as it also allows a callback which is not allowed in HTMLProps
   children: React.ReactNode;
 };

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -1,12 +1,10 @@
 import { cva, cx, VariantProps } from 'cva';
-import { Link, LinkProps, Provider } from 'react-aria-components';
-import { HeadingContext } from '../content';
+import { Link, LinkProps } from 'react-aria-components';
 
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
   className?: string;
   /** Makes the entire card clickable by wrapping the content of the <Heading> in a <Link> */
-  href?: LinkProps['href'];
 };
 
 const cardVariants = cva({
@@ -15,6 +13,13 @@ const cardVariants = cva({
     'rounded-2xl border p-3',
     'grid auto-rows-max gap-y-4',
     'relative', // Needed for positiong of the clickable pseudo-element (and can also be used for other absolute positioned elements the consumer might add)
+
+    // **** Heading ****
+    '[&_[data-slot="heading"]]:inline',
+    '[&:not(:has([data-slot="card-link"]))_[data-slot="heading"]]:heading-s',
+    '[&:not(:has([data-slot="card-link"]))_[data-slot="heading"]]:w-fit',
+    '[&:not(:has([data-slot="card-link"]))_[data-slot="heading"]]:text-pretty',
+
     // **** Content ****
     '[&_[data-slot="content"]]:grid [&_[data-slot="content"]]:auto-rows-max [&_[data-slot="content"]]:gap-y-4',
 
@@ -26,7 +31,37 @@ const cardVariants = cva({
     // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work in FF)
     '[&_[data-slot="media"]>*]:aspect-[3/2] [&_[data-slot="media"]>*]:w-full [&_[data-slot="media"]_img]:object-cover',
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
-    '[&_[data-slot="media"]>*]:transition-transform [&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out',
+    '[&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out [&_[data-slot="media"]>*]:motion-safe:transition-transform',
+
+    // **** Card link ****
+    // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
+    '[&:has([data-slot="card-link"]:hover)_[data-slot="media"]>*]:scale-110',
+    // **** Card link in Heading ****
+    // **** Hover: custom underline ****
+    // The border radius needs to be adjusted to align perfectly with the card border
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:no-underline',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:after:absolute',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:after:inset-[calc(theme(borderWidth.DEFAULT)*-1)]',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
+    // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
+    // Border top is set to even out the border bottom used for the underline
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-2',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-transparent',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:transition-colors',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:hover:border-b-current',
+    // **** Focus ****
+    '[&_[data-slot="heading"]_[data-slot="card-link"]:focus-visible]:after:outline-focus',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]:focus-visible]:outline-none',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]:focus-visible]:after:outline-offset-2',
+    // Mimic heading styles for the card link if placed in the heading slot
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:heading-s [&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty',
+
+    // **** Fail-safe for interactive elements ****
+    // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
+    // The card is then made clickable by a pseudo-element on the heading that covers the entire card
+    '[&_a:not([data-slot="card-link"])]:relative [&_button]:relative [&_input]:relative',
+    // Place other interactive on top of the pseudo-element that makes the entire card clickable by setting a higher z-index than the pseudo-element
+    '[&_a:not([data-slot="card-link"])]:z-[2] [&_button]:z-[2] [&_input]:z-[2]',
   ],
   variants: {
     border: {
@@ -39,20 +74,6 @@ const cardVariants = cva({
         '[&_[data-slot="media"]]:rounded-b-2xl',
       ],
     },
-    hasHref: {
-      false: '',
-      true: [
-        // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
-        '[&:has([data-slot="card-heading-link"]:hover)_[data-slot="media"]>*]:scale-110',
-
-        // **** Fail-safe for interactive elements ****
-        // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
-        // The card is then made clickable by a pseudo-element on the heading that covers the entire card
-        '[&_a:not([data-slot="card-heading-link"])]:relative [&_button]:relative [&_input]:relative',
-        // Place other interactive on top of the pseudo-element that makes the entire card clickable by setting a higher z-index than the pseudo-element
-        '[&_a:not([data-slot="card-heading-link"])]:z-[2] [&_button]:z-[2] [&_input]:z-[2]',
-      ],
-    },
   },
 });
 
@@ -60,59 +81,27 @@ const Card = ({
   children,
   className: _className,
   border,
-  href,
   ...restProps
 }: CardProps) => {
   const className = cardVariants({
     className: _className,
     border,
-    hasHref: !!href,
   });
   return (
     <div className={className} {...restProps}>
-      <Provider
-        values={[
-          [
-            HeadingContext,
-            {
-              className: cx(
-                'inline',
-                // Styles for the heading when content is not wrapped in a link
-                !href && 'heading-s w-fit text-pretty',
-              ),
-              _innerWrapper: (children) =>
-                href ? (
-                  <Link
-                    href={href}
-                    // Uses a pseudo-element with absolute position to make the entire card focusable and clickable
-                    className={cx(
-                      'cursor-pointer',
-                      // **** Hover: custom underline ****
-                      // The border radius needs to be adjusted to align perfectly with the card border
-                      'no-underline after:absolute after:inset-[calc(theme(borderWidth.DEFAULT)*-1)] after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
-                      // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
-                      // Border top is set to even out the border bottom used for the underline
-                      'border-y-2 border-y-transparent transition-colors hover:border-b-current',
-                      // Match the heading styles (especially important when the content spans mulitple lines)
-                      'heading-s text-pretty',
-                      // **** Focus ****
-                      'focus-visible:after:outline-focus focus-visible:outline-none focus-visible:after:outline-offset-2',
-                    )}
-                    data-slot="card-heading-link"
-                  >
-                    {children}
-                  </Link>
-                ) : (
-                  children
-                ),
-            },
-          ],
-        ]}
-      >
-        {children}
-      </Provider>
+      {children}
     </div>
   );
 };
 
-export { Card, type CardProps };
+type CardLinkProps = LinkProps;
+
+const CardLink = ({ className, ...restProps }: CardLinkProps) => (
+  <Link
+    data-slot="card-link"
+    {...restProps}
+    className={cx(className, 'cursor-pointer')}
+  />
+);
+
+export { Card, type CardProps, type CardLinkProps, CardLink };

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -48,7 +48,7 @@ const cardVariants = cva({
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-2',
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-transparent',
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:transition-colors',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:hover:border-b-current',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]:hover]:border-b-current',
     // **** Focus ****
     '[&_[data-slot="heading"]_[data-slot="card-link"]:focus-visible]:after:outline-focus',
     '[&_[data-slot="heading"]_[data-slot="card-link"]:focus-visible]:outline-none',

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -57,15 +57,17 @@ const cardVariants = cva({
     '[&_a:not([data-slot="card-link"])]:z-[1] [&_button]:z-[1] [&_input]:z-[1]',
   ],
   variants: {
-    border: {
-      black: 'border-black',
-      'blue-dark': 'border-blue-dark',
-      'green-dark': 'border-green-dark',
-      undefined: [
+    /**
+     * The variant of the card
+     * @default subtle
+     */
+    variant: {
+      subtle: [
         'border-transparent',
         // Media styles:
         '[&_[data-slot="media"]]:rounded-b-2xl',
       ],
+      outlined: 'border border-black',
     },
   },
 });
@@ -73,12 +75,12 @@ const cardVariants = cva({
 const Card = ({
   children,
   className: _className,
-  border,
+  variant = 'subtle',
   ...restProps
 }: CardProps) => {
   const className = cardVariants({
     className: _className,
-    border,
+    variant,
   });
   return (
     <div className={className} {...restProps}>

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -100,16 +100,14 @@ type CardLinkProps = {
 } & (RACLinkProps | CardLinkWrapperProps);
 
 const cardLinkVariants = cva({
-  base: [
-    'cursor-pointer',
-    // **** Clickarea ****
-    'after:absolute',
-    'after:inset-[calc(theme(borderWidth.DEFAULT)*-1)]',
-    'after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
-  ],
   variants: {
     withHref: {
       true: [
+        // **** Clickarea ****
+        'cursor-pointer',
+        'after:absolute',
+        'after:inset-[calc(theme(borderWidth.DEFAULT)*-1)]',
+        'after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
         // **** Focus ****
         'focus-visible:outline-none',
         'focus-visible:after:outline-focus',
@@ -120,10 +118,12 @@ const cardLinkVariants = cva({
         'hover:no-underline',
       ],
       false: [
+        // **** Clickarea ****
+        '[&_a]:after:cursor-pointer',
+        '[&_a]:after:absolute',
+        '[&_a]:after:inset-[calc(theme(borderWidth.DEFAULT)*-1)]',
+        '[&_a]:after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
         // **** Focus ****
-        '[&_a:focus-visible]:outline-none',
-        '[&:has(a:focus-visible)]:after:outline-focus',
-        '[&:has(a:focus-visible)]:after:outline-offset-2',
         // **** Hover ****
         // Links are underlined by default, and the underline is removed on hover.
         // So we make sure that also happens when the user hovers the card.

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -99,6 +99,7 @@ type CardLinkProps = {
 } & (RACLinkProps | CardLinkWrapperProps);
 
 const cardLinkVariants = cva({
+  base: 'w-fit max-w-full',
   variants: {
     withHref: {
       true: [
@@ -122,12 +123,6 @@ const cardLinkVariants = cva({
         '[&_a]:after:absolute',
         '[&_a]:after:inset-[calc(theme(borderWidth.DEFAULT)*-1)]',
         '[&_a]:after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
-        // **** Focus ****
-        // **** Hover ****
-        // Links are underlined by default, and the underline is removed on hover.
-        // So we make sure that also happens when the user hovers the card.
-        // The group-hover ensures that the hover effect also applies when this component is used as a wrapper around a link.
-        '[&_a]:group-hover/card:no-underline',
       ],
     },
   },

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -59,8 +59,9 @@ const cardVariants = cva({
     // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
     // The card is then made clickable by a pseudo-element on the heading that covers the entire card
     '[&_a:not([data-slot="card-link"])]:relative [&_button]:relative [&_input]:relative',
-    // Place other interactive on top of the pseudo-element that makes the entire card clickable by setting a higher z-index than the pseudo-element
-    '[&_a:not([data-slot="card-link"])]:z-[2] [&_button]:z-[2] [&_input]:z-[2]',
+    // Place other interactive on top of the pseudo-element that makes the entire card clickable
+    // by setting a higher z-index than the pseudo-element (which implicitly z-index 0)
+    '[&_a:not([data-slot="card-link"])]:z-[1] [&_button]:z-[1] [&_input]:z-[1]',
   ],
   variants: {
     border: {

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -4,7 +4,6 @@ import { Link, LinkProps } from 'react-aria-components';
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
   className?: string;
-  /** Makes the entire card clickable by wrapping the content of the <Heading> in a <Link> */
 };
 
 const cardVariants = cva({

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -15,9 +15,9 @@ const cardVariants = cva({
 
     // **** Heading ****
     '[&_[data-slot="heading"]]:inline',
-    '[&:not(:has([data-slot="card-link"]))_[data-slot="heading"]]:heading-s',
-    '[&:not(:has([data-slot="card-link"]))_[data-slot="heading"]]:w-fit',
-    '[&:not(:has([data-slot="card-link"]))_[data-slot="heading"]]:text-pretty',
+    '[&_[data-slot="heading"]]:heading-s',
+    '[&_[data-slot="heading"]]:w-fit',
+    '[&_[data-slot="heading"]]:text-pretty',
 
     // **** Content ****
     '[&_[data-slot="content"]]:grid [&_[data-slot="content"]]:auto-rows-max [&_[data-slot="content"]]:gap-y-4',
@@ -39,11 +39,12 @@ const cardVariants = cva({
     // **** Hover: custom underline ****
     // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
     // Border top is set to even out the border bottom used for the underline
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:no-underline',
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-2',
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-transparent',
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:transition-colors',
     '[&_[data-slot="heading"]_[data-slot="card-link"]:hover]:border-b-current',
-    // Mimic heading styles for the card link if placed in the heading slot
+    // Mimic heading styles for the card link if placed in the heading slot. This is necessary to make the custom underline align with the link text
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:heading-s [&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty',
 
     // **** Fail-safe for interactive elements ****

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -29,8 +29,8 @@ const cardVariants = cva({
     '[&_[data-slot="media"]>*]:transition-transform [&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out',
 
     // **** Footer ****
-    // Footer content of the footer is intended to be outside the clickable area of the card
-    // Fot this reason the CSS of the footer becomes a little bit more complex
+    // Content of the footer is intended to be outside the clickable area of the card
+    // This serves as an area where the consumer can place other interactive elements that should not trigger the card click
     '[&_[data-slot="footer"]]:relative', // Setting it to relative will place it on top of the clickable pseudo-element
     // Position footer at the edges of the card, but give it the same padding as the rest of the card
     '[&_[data-slot="footer"]]:py-3',
@@ -58,6 +58,7 @@ const cardVariants = cva({
         // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
         '[&:has([data-slot="card-heading-link"]:hover)_[data-slot="media"]>*]:scale-110',
 
+        // **** Fail-safe for interactive elements not placed in a <Footer> ****
         // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
         // The card is then made clickable by a pseudo-element on the heading that covers the entire card
         '[&_a:not([data-slot="card-heading-link"])]:relative [&_button]:relative [&_input]:relative',
@@ -99,17 +100,16 @@ const Card = ({
                     // Uses a pseudo-element with absolute position to make the entire card focusable and clickable
                     className={cx(
                       'cursor-pointer',
-                      // Note that the border-radius is set 1px less then the card radius
-                      // This is due to the fact that the card as a 1px border and needs to be adjusted to align perfectly
+                      // **** Hover: custom underline ****
+                      // The border radius needs to be adjusted to align perfectly with the card border
                       'no-underline after:absolute after:inset-[calc(theme(borderWidth.DEFAULT)*-1)] after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
-                      // focus styles
-                      'focus-visible:after:outline-focus focus-visible:outline-none focus-visible:after:outline-offset-2',
-                      // hover styles
                       // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
                       // Border top is set to even out the border bottom used for the underline
                       'border-y-2 border-y-transparent transition-colors hover:border-b-current',
                       // Match the heading styles (especially important when the content spans mulitple lines)
                       'heading-s text-pretty',
+                      // **** Focus ****
+                      'focus-visible:after:outline-focus focus-visible:outline-none focus-visible:after:outline-offset-2',
                     )}
                     data-slot="card-heading-link"
                   >

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -32,9 +32,11 @@ const cardVariants = cva({
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
     '[&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out [&_[data-slot="media"]>*]:motion-safe:transition-transform',
 
-    // **** Card link in Heading ****
+    // **** Card link ****
     // **** Hover ****
     // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
+    '[&:has([data-slot="card-link"]_a:hover)_[data-slot="media"]>*]:scale-110',
+    // **** Card link in Heading ****
     '[&:has([data-slot="heading"]_[data-slot="card-link"]:hover)_[data-slot="media"]>*]:scale-110',
     // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
     // Border top is set to even out the border bottom used for the underline
@@ -48,8 +50,8 @@ const cardVariants = cva({
 
     // **** Fail-safe for interactive elements ****
     // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
-    // The card is then made clickable by a pseudo-element on the heading that covers the entire card
-    '[&_a:not([data-slot="card-link"])]:relative [&_button]:relative [&_input]:relative',
+    // The card is made clickable by a pseudo-element on the heading that covers the entire card
+    '[&:not(:has([data-slot="card-link"]_a))_a:not([data-slot="card-link"])]:relative [&_button]:relative [&_input]:relative',
     // Place other interactive on top of the pseudo-element that makes the entire card clickable
     // by setting a higher z-index than the pseudo-element (which implicitly z-index 0)
     '[&_a:not([data-slot="card-link"])]:z-[1] [&_button]:z-[1] [&_input]:z-[1]',
@@ -123,6 +125,15 @@ const cardLinkVariants = cva({
         '[&_a]:after:absolute',
         '[&_a]:after:inset-[calc(theme(borderWidth.DEFAULT)*-1)]',
         '[&_a]:after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
+        // **** Focus ****
+        '[&_a:focus-visible]:outline-none',
+        '[&_a:focus-visible]:after:outline-focus',
+        '[&_a:focus-visible]:after:outline-offset-2',
+        // **** Hover ****
+        // Links are underlined by default, and the underline is removed on hover.
+        // So we make sure that also happens when the user hovers the card.
+        // The group-hover ensures that the hover effect also applies when this component is used as a wrapper around a link.
+        '[&_a]:group-hover/card:no-underline',
       ],
     },
   },

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -5,6 +5,7 @@ import { HeadingContext } from '../content';
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
   className?: string;
+  /** Makes the entire card clickable by wrapping the content of the <Heading> in a <Link> */
   href?: LinkProps['href'];
 };
 

--- a/packages/react/src/content/Content.tsx
+++ b/packages/react/src/content/Content.tsx
@@ -55,19 +55,11 @@ const Content = (props: ContentProps, ref: ForwardedRef<HTMLDivElement>) => {
   return outerWrapper ? outerWrapper(content) : content;
 };
 
-const MediaContext = createContext<
-  ContextValue<Partial<MediaProps>, HTMLDivElement>
->({});
-
 type MediaProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
 };
 
-const Media = (props: MediaProps, ref: ForwardedRef<HTMLDivElement>) => {
-  [props] = useContextProps(props, ref, MediaContext);
-
-  return <div {...props} data-slot="media" />;
-};
+const Media = (props: MediaProps) => <div {...props} data-slot="media" />;
 
 type FooterProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
@@ -82,7 +74,6 @@ export {
   type ContentProps,
   Content,
   ContentContext,
-  MediaContext,
   type MediaProps,
   Media,
   type FooterProps,


### PR DESCRIPTION
## Klikkbare kort

Legger til støtte for klikkbare kort gjennom å eksponere en `href`-prop på `<Card>`. Hele kortet blir gjort klikkbart ved å wrappe `children` til `<Heading>` i en `<Link>`. 


https://github.com/user-attachments/assets/a0458753-0275-45c5-9a92-825424c9d77a



Det er også lagt til rette for at konsumenten skal kunne plassere andre klikkbare elementer i kortet, som fortsatt skal være klikkbare i seg selv. For å legge tilrette for en så god brukeropplevelse som mulig mtp. klikkflate, har jeg lagt til rette for at man kan bruke `<Footer>` for å skille ut andre klikkbare elementer. Men jeg har også lagt inn en failsafe, i tilfelle noen skulle ha behov for å plassere klikkbare elementer andre steder i kortet.

Stylingen for `<Footer>` blir litt kompleks, men jeg syns det var den _minst_ komplekse måten å løse det på. Ved å sette samme padding som resten av kortet og negativ margin som får den til å gå ut helt i kantene, og så bruke et pseudo-element for å få til en divider line løser vi både det at `<Footer>` blir skilt ut fra kortets egen click area og at divider-linen følger paddingen på kortet. Fargen på divider-en er `currentColor`. Jeg prøvde å finne en måte å sette litt opacity på `currentColor`, men fant ingen løsning. Skal være mulig å sette `opacity` på border color i `tailwind`: [https://tailwindcss.com/docs/border-color#changing-the-opacity](https://tailwindcss.com/docs/border-color#changing-the-opacity), men det støttes visst ikke for custom-farger.


https://github.com/user-attachments/assets/f682a09d-36d8-40e5-9409-6ae13a601d4f




https://github.com/user-attachments/assets/e7f085c7-dac5-43b1-8f2a-3a68de5e5958

