### PR TITLE
Date formatter

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,7 @@
     "@react-aria/utils": "^3.25.1",
     "@types/node": "^22.0.0",
     "cva": "1.0.0-beta.1",
+    "react-aria": "3.35.1",
     "react-aria-components": "^1.3.1"
   },
   "peerDependencies": {

--- a/packages/react/src/dateformatter/DateFormatter.stories.tsx
+++ b/packages/react/src/dateformatter/DateFormatter.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta } from '@storybook/react';
+import { DateFormatter } from './DateFormatter';
+
+export const Default = () => <DateFormatter value={new Date()} />;
+
+export const LongDate = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }}
+  />
+);
+
+export const FullDateTime = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    }}
+  />
+);
+
+export const WithCustomTimeZone = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      timeZone: 'EST',
+    }}
+  />
+);
+
+export const Year = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      year: 'numeric',
+    }}
+  />
+);
+
+export const ShortYear = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      year: '2-digit',
+    }}
+  />
+);
+
+export const Month = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      month: 'numeric',
+    }}
+  />
+);
+
+export const LongMonth = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      month: 'long',
+    }}
+  />
+);
+
+export const ShortMonth = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      month: 'short',
+    }}
+  />
+);
+
+export const CapitalizedMonth = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      month: 'long',
+    }}
+    render={(formattedDate: string) =>
+      formattedDate.charAt(0).toUpperCase() + formattedDate.slice(1)
+    }
+  />
+);
+
+export const Day = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      day: 'numeric',
+    }}
+  />
+);
+
+export const ShortDay = () => (
+  <DateFormatter
+    value={new Date()}
+    options={{
+      day: '2-digit',
+    }}
+  />
+);
+
+const meta: Meta = {
+  title: 'DateFormatter',
+};
+
+export default meta;

--- a/packages/react/src/dateformatter/DateFormatter.tsx
+++ b/packages/react/src/dateformatter/DateFormatter.tsx
@@ -1,10 +1,10 @@
 'use client';
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useDateFormatter, type DateFormatterOptions } from 'react-aria';
 
 type DateFormatterProps = {
   value: Date | string;
-  options: DateFormatterOptions;
+  options?: DateFormatterOptions;
   /** Callback to customize the rendering of the date */
   render?: (formattedDate: string) => ReactNode;
 };
@@ -29,7 +29,7 @@ const DateFormatter = ({
 
   const formatted = formatter.format(date);
 
-  return render ? render(formatted) : formatted;
+  return <>{render ? render(formatted) : formatted}</>;
 };
 
 export { DateFormatter, type DateFormatterProps };

--- a/packages/react/src/dateformatter/DateFormatter.tsx
+++ b/packages/react/src/dateformatter/DateFormatter.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { ReactNode } from 'react';
+import { useDateFormatter, type DateFormatterOptions } from 'react-aria';
+
+type DateFormatterProps = {
+  value: Date | string;
+  options: DateFormatterOptions;
+  /** Callback to customize the rendering of the date */
+  render?: (formattedDate: string) => ReactNode;
+};
+
+/**
+ * A React component that wraps https://react-spectrum.adobe.com/react-aria/useDateFormatter.html
+ * By default it sets the timeZone to `Europe/Berlin` to prevent the server's timezone from affecting
+ * the localized format
+ */
+const DateFormatter = ({
+  options: _options,
+  value,
+  render,
+}: DateFormatterProps) => {
+  const options = {
+    timeZone: 'Europe/Berlin',
+    ..._options,
+  };
+  const formatter = useDateFormatter(options);
+
+  const date = typeof value === 'string' ? new Date(value) : value;
+
+  const formatted = formatter.format(date);
+
+  return render ? render(formatted) : formatted;
+};
+
+export { DateFormatter, type DateFormatterProps };

--- a/packages/react/src/dateformatter/index.ts
+++ b/packages/react/src/dateformatter/index.ts
@@ -1,0 +1,1 @@
+export * from './DateFormatter';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,3 +17,4 @@ export * from './alertbox';
 export * from './content';
 export * from './breadcrumbs';
 export * from './backlink';
+export * from './dateformatter';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       react:
         specifier: ^18
         version: 18.3.1
+      react-aria:
+        specifier: ^3.35.1
+        version: 3.35.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-aria-components:
         specifier: ^1.3.1
         version: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Legger til DateFormatter

Legger til en ny komponent `<DateFormatter/>` som kan brukes for datoformattering.

Den bruker useDateFormatter fra `react-aria` _"under the hood"_.