### PR TITLE
Enable expand/collapse without footer

### DIFF
--- a/.changeset/fresh-birds-travel.md
+++ b/.changeset/fresh-birds-travel.md
@@ -1,0 +1,6 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes expand/collapse bug in `<Alertbox>` that occured when not passing a `<Footer>`.  
+

--- a/packages/react/src/alertbox/Alertbox.tsx
+++ b/packages/react/src/alertbox/Alertbox.tsx
@@ -147,7 +147,6 @@ const Alertbox = ({
   }
 
   const [firstChild, ...restChildren] = Children.toArray(children);
-  const lastChild = restChildren.pop();
 
   return (
     <div
@@ -196,12 +195,17 @@ const Alertbox = ({
           />
         </button>
       )}
-      {!isCollapsed && restChildren.length > 0 && (
-        <div className="col-span-full grid gap-y-4" id={id}>
+      {restChildren?.length > 0 && (
+        <div
+          className={cx(
+            'col-span-full grid gap-y-4',
+            isCollapsed && '[&>*:not([data-slot="footer"])]:hidden',
+          )}
+          id={id}
+        >
           {restChildren}
         </div>
       )}
-      {lastChild}
     </div>
   );
 };


### PR DESCRIPTION
[](url)## Fikser expand/collapse bug i Alertbox

Fikser sånn at det nå er mulig å lage en `<Alertbox>` uten å ha med en `<Foote

https://github.com/user-attachments/assets/3728d57b-7731-4aaa-9c50-5c65c84c86cc



