### PR TITLE
Button: use isPending instead of isLoading

### DIFF
--- a/.changeset/clever-geckos-press.md
+++ b/.changeset/clever-geckos-press.md
@@ -1,0 +1,11 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Button: deprecate isLoading in favor of isPending
+
+* change prop name to align with React Aria and the useActionState hook in React.
+* improved accessibility for pending state by [utilizing React aria](https://react-spectrum.adobe.com/react-aria/Button.html#pending)
+* button events are now disabled when the button is in a pending state.
+* refactor to CSS instead of useLayoutEffect when button is in a pending state.
+

--- a/form-demo/app/uncontrolled/SubmitButton.tsx
+++ b/form-demo/app/uncontrolled/SubmitButton.tsx
@@ -5,5 +5,5 @@ import { Button } from '@obosbbl/grunnmuren-react';
 export default function SubmitButton(props) {
   const { pending } = useFormStatus();
 
-  return <Button isLoading={pending} type="submit" {...props} />;
+  return <Button isPending={pending} type="submit" {...props} />;
 }

--- a/packages/react/src/__stories__/FormValidation.stories.tsx
+++ b/packages/react/src/__stories__/FormValidation.stories.tsx
@@ -17,7 +17,7 @@ const Form = (props: {
   serverValidate?: boolean;
 }) => {
   const [errors, setErrors] = useState({});
-  const [isLoading, setIsLoading] = useState(false);
+  const [isPending, setIsPending] = useState(false);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -29,12 +29,12 @@ const Form = (props: {
       return;
     }
 
-    setIsLoading(true);
+    setIsPending(true);
 
     // Fake a delay here, so it looks like we're submitting the data to a server
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    setIsLoading(false);
+    setIsPending(false);
 
     if (!(data['email'] as string).endsWith('.no')) {
       setErrors({ email: emailErrorMessage });
@@ -54,7 +54,7 @@ const Form = (props: {
       validationErrors={errors}
     >
       {props.children}
-      <Button type="submit" isLoading={isLoading}>
+      <Button type="submit" isPending={isPending}>
         Send inn
       </Button>
     </RACForm>

--- a/packages/react/src/button/Button.stories.tsx
+++ b/packages/react/src/button/Button.stories.tsx
@@ -39,7 +39,7 @@ export const Primary: Story = {
   args: {
     color: 'green',
     variant: 'primary',
-    isLoading: false,
+    isPending: false,
   },
 };
 

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -187,7 +187,7 @@ function Button(
     <>
       {_children}
       <LoadingSpinner
-        className="absolute m-auto animate-spin"
+        className="absolute m-auto motion-safe:animate-spin"
         {...progressBarProps}
       />
     </>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -53,44 +53,54 @@ const buttonVariants = cva({
       color: 'green',
       variant: 'primary',
       // Darken bg by 20% on hover. The color is manually crafted
-      className: 'bg-green text-white hover:bg-green-dark active:bg-[#007352]',
+      className:
+        'bg-green text-white hover:bg-green-dark active:bg-[#007352] [&_[role="progressbar"]]:text-white',
     },
     {
       color: 'green',
       variant: 'secondary',
       className:
-        'text-black shadow-green hover:bg-green hover:text-white active:bg-green',
+        'text-black shadow-green hover:bg-green hover:text-white active:bg-green [&:hover_[role="progressbar"]]:text-white [&_[role="progressbar"]]:text-black',
+    },
+    {
+      color: 'green',
+      variant: 'tertiary',
+      className: '[&_[role="progressbar"]]:text-black',
     },
     {
       color: 'mint',
       variant: 'primary',
       // Darken bg by 20% on hover. The color is manually crafted
-      className: 'active:[#9ddac6] bg-mint text-black hover:bg-[#8dd4bd]',
+      className:
+        'active:[#9ddac6] bg-mint text-black hover:bg-[#8dd4bd] [&_[role="progressbar"]]:text-black',
     },
     {
       color: 'mint',
       variant: 'secondary',
-      className: 'text-mint shadow-mint hover:bg-mint hover:text-black',
+      className:
+        'text-mint shadow-mint hover:bg-mint hover:text-black [&:hover_[role="progressbar"]]:text-black [&_[role="progressbar"]]:text-mint',
     },
     {
       color: 'mint',
       variant: 'tertiary',
-      className: 'text-mint',
+      className: 'text-mint [&_[role="progressbar"]]:text-mint',
     },
     {
       color: 'white',
       variant: 'primary',
-      className: 'bg-white text-black hover:bg-sky active:bg-sky-light',
+      className:
+        'bg-white text-black hover:bg-sky active:bg-sky-light [&_[role="progressbar"]]:text-black',
     },
     {
       color: 'white',
       variant: 'secondary',
-      className: 'text-white shadow-white hover:bg-white hover:text-black',
+      className:
+        'text-white shadow-white hover:bg-white hover:text-black [&:hover_[role="progressbar"]]:text-black [&_[role="progressbar"]]:text-white',
     },
     {
       color: 'white',
       variant: 'tertiary',
-      className: 'text-white',
+      className: 'text-white [&_[role="progressbar"]]:text-white',
     },
   ],
   defaultVariants: {
@@ -110,6 +120,8 @@ type ButtonOrLinkProps = VariantProps<typeof buttonVariants> & {
    * @default false
    */
   isLoading?: boolean;
+  /** Additional style properties for the element. */
+  style?: React.CSSProperties;
 };
 
 type ButtonProps = (
@@ -175,7 +187,7 @@ function Button(
     <>
       {_children}
       <LoadingSpinner
-        className="absolute m-auto animate-spin text-[white]"
+        className="absolute m-auto animate-spin"
         {...progressBarProps}
       />
     </>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -7,6 +7,7 @@ import {
   type ButtonProps as RACButtonProps,
 } from 'react-aria-components';
 import { LoadingSpinner } from '@obosbbl/grunnmuren-icons-react';
+import { useLocale, type Locale } from '../use-locale';
 
 /**
  * Figma: https://www.figma.com/file/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=30%3A2574&mode=dev
@@ -123,6 +124,22 @@ function isLinkProps(
   return !!props.href;
 }
 
+type Translation = {
+  [key in Locale]: string;
+};
+
+type Translations = {
+  [x: string]: Translation;
+};
+
+const translations: Translations = {
+  pending: {
+    nb: 'venter',
+    sv: 'väntar',
+    en: 'pending',
+  },
+};
+
 function Button(
   props: ButtonProps,
   ref: Ref<HTMLButtonElement | HTMLAnchorElement>,
@@ -147,9 +164,11 @@ function Button(
     isPending,
   });
 
+  const locale = useLocale();
+
   const { progressBarProps } = useProgressBar({
     isIndeterminate: true,
-    'aria-label': 'Venter',
+    'aria-label': translations.pending[locale],
   });
 
   const children = isPending ? (


### PR DESCRIPTION
* use [isPending](https://react-spectrum.adobe.com/react-aria/Button.html#pending) in RAC for better screen reader support for buttons that are in a loading/pending state
* Deprecate isLoading in favor of isPending (this aligns with both RAC's naming convention and [React's useActionState hook](https://react.dev/reference/react/useActionState))
* Use text transparency for the button content instead of state/layoutEffect to maintain the button's size while in a pending state.

Note that when the button is in a pendingstate it can't be interacted with. This means you don't have to disable a button to prevent multiple submissions etc. Note that our Button component also can render a RAC Link, which technically doesn't support isPending. It will render to look the same as a pending button, but interactions won't be disabled. This is a tradeoff we'll have to make..