### PR TITLE
Increase line-height on CardLink

### DIFF
--- a/.changeset/popular-jobs-drum.md
+++ b/.changeset/popular-jobs-drum.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes line-height on `<CardLink>` so that underline on hover aligns better with the text.

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -16,6 +16,7 @@ const cardVariants = cva({
     // **** Heading ****
     '[&_[data-slot="heading"]]:inline',
     '[&_[data-slot="heading"]]:heading-s',
+    '[&_[data-slot="heading"]]:leading-6', // A bit more line height than the default is necessary to make the underline align with the text if the heading has a card link
     '[&_[data-slot="heading"]]:w-fit',
     '[&_[data-slot="heading"]]:text-pretty',
 
@@ -46,7 +47,7 @@ const cardVariants = cva({
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:transition-colors',
     '[&_[data-slot="heading"]_[data-slot="card-link"]:hover]:border-b-current',
     // Mimic heading styles for the card link if placed in the heading slot. This is necessary to make the custom underline align with the link text
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:heading-s [&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:heading-s [&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty [&_[data-slot="heading"]_[data-slot="card-link"]]:leading-6',
 
     // **** Fail-safe for interactive elements ****
     // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole


### PR DESCRIPTION
## Fikser line-height på CardLink

Øker line-height på `<CardLink>` slik at custom underline aligner med teksten når den brekker over flere linjer.

### Før
<img width="543" alt="Screenshot 2024-11-26 at 10 41 54" src="https://github.com/user-attachments/assets/ecc20be0-7969-4970-b9ce-e6adf9614d6c">

### Nå
<img width="543" alt="Screenshot 2024-11-26 at 10 41 40" src="https://github.com/user-attachments/assets/356fefa4-5844-4905-9225-d51ea24090a4">
