### PR TITLE
combobox: deprecate isLoading in favor of isPending

### DIFF
--- a/.changeset/shaggy-rings-explain.md
+++ b/.changeset/shaggy-rings-explain.md
@@ -1,0 +1,7 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Combobox: deprecate isLoading in favor of isPending
+
+* change prop name to align with React Aria and the useActionState hook in React.

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -69,19 +69,19 @@ const ControlledTemplate = <T extends object>(args: ComboboxProps<T>) => {
 const AsyncTemplate = <T extends object>(args: ComboboxProps<T>) => {
   const [items, setItems] = useState<Array<{ url: string; name: string }>>([]);
   const [filterText, setFilterText] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [isPending, setIsPending] = useState(false);
 
   // TODO: Add debouncing
   useEffect(() => {
     async function fetchData() {
       if (filterText.length >= 2) {
-        setIsLoading(true);
+        setIsPending(true);
         const result = await fetch(
           `https://swapi.dev/api/people?search=${filterText}`,
         );
         const data = await result.json();
         setItems(data.results);
-        setIsLoading(false);
+        setIsPending(false);
       }
     }
     fetchData();
@@ -95,7 +95,7 @@ const AsyncTemplate = <T extends object>(args: ComboboxProps<T>) => {
       defaultFilter={() => true}
       onInputChange={setFilterText}
       inputValue={filterText}
-      isLoading={isLoading}
+      isPending={isPending}
       {...args}
     >
       {items.map((item) => (
@@ -128,7 +128,7 @@ const defaultProps = {
   defaultSelectedKey: undefined,
   selectedKey: undefined,
   placeholder: 'Velg boligprosjekt',
-  isLoading: false,
+  isPending: false,
 };
 
 export const Default: Story = {

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -31,10 +31,15 @@ type ComboboxProps<T extends object> = {
   /** Error message for the form control. Automatically sets `isInvalid` to true */
   errorMessage?: React.ReactNode;
   /**
-   * Display the dropdown button trigger in a loading state
-   * @default false
+   * Display the dropdown button trigger in a pending state
+   * @deprecated Use isPending instead.
    */
   isLoading?: boolean;
+  /**
+   * Display the dropdown button trigger in a pending state
+   * @default false
+   */
+  isPending?: boolean;
   /** Label for the form control. */
   label?: React.ReactNode;
   /** Placeholder text. Only visible when the input value is empty. */
@@ -56,10 +61,13 @@ function Combobox<T extends object>(
     description,
     errorMessage,
     isLoading,
+    isPending: _isPending,
     label,
     isInvalid: _isInvalid,
     ...restProps
   } = props;
+
+  const isPending = _isPending || isLoading;
 
   // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
   // which will override any built in validation
@@ -77,7 +85,7 @@ function Combobox<T extends object>(
       <Group className={inputGroup}>
         <Input className={input({ isGrouped: true })} ref={ref} />
         <Button>
-          {isLoading ? (
+          {isPending ? (
             <LoadingSpinner className="animate-spin" />
           ) : (
             <ChevronDown className={dropdown.chevronIcon} />


### PR DESCRIPTION
Egentlig samme som her https://github.com/code-obos/grunnmuren/pull/982, slik at APIet er alignet.

Merk at jeg faktisk ikke har tatt i bruk isPending i på selve knappen i React Aria, da disables button events der, slik at man ikke får åpnet nedtrekkslista.