### PR TITLE
Fixup focus styles

### DIFF
--- a/.changeset/selfish-kids-greet.md
+++ b/.changeset/selfish-kids-greet.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fixes focus styles on all components using either `<Link>` or `<Button>` from react-aria-components internally.

--- a/packages/react/src/backlink/Backlink.tsx
+++ b/packages/react/src/backlink/Backlink.tsx
@@ -39,7 +39,7 @@ function Backlink(
     <Component
       className={cx(
         className,
-        'group flex max-w-fit cursor-pointer items-center gap-3 rounded-md p-2.5 no-underline focus-visible:outline-focus',
+        'group flex max-w-fit cursor-pointer items-center gap-3 rounded-md p-2.5 no-underline data-[focus-visible]:outline-focus [&:not([data-focus-visible])]:outline-none',
       )}
       {...restProps}
       // @ts-expect-error ignore the type of the ref here

--- a/packages/react/src/breadcrumbs/Breadcrumb.tsx
+++ b/packages/react/src/breadcrumbs/Breadcrumb.tsx
@@ -32,7 +32,7 @@ function Breadcrumb(props: BreadcrumbProps, ref: Ref<HTMLLIElement>) {
         <Link
           href={href}
           // use outline instead of ring for focus marker that can be offset without creating a white background between the focus marker and the element content
-          className="rounded-sm data-[focus-visible]:focus-visible:outline-focus focus:outline-none group-last:no-underline"
+          className="rounded-sm data-[focus-visible]:outline-focus group-last:no-underline [&:not([data-focus-visible])]:outline-none"
         >
           {children}
         </Link>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -15,7 +15,7 @@ import { useLocale, type Locale } from '../use-locale';
 
 const buttonVariants = cva({
   base: [
-    'relative inline-flex min-h-[44px] cursor-pointer items-center justify-center whitespace-nowrap rounded-lg font-medium transition-colors duration-200 focus-visible:outline-focus-offset',
+    'inline-flex min-h-[44px] cursor-pointer items-center justify-center whitespace-nowrap rounded-lg font-medium transition-colors duration-200 focus-visible:outline-focus-offset [&:not([data-focus-visible])]:outline-none',
   ],
   variants: {
     /**
@@ -33,9 +33,10 @@ const buttonVariants = cva({
      * @default green
      */
     color: {
-      green: 'focus-visible:outline-focus',
-      mint: 'focus-visible:outline-focus focus-visible:outline-mint',
-      white: 'focus-visible:outline-focus focus-visible:outline-white',
+      green: 'data-[focus-visible]:outline-focus',
+      mint: 'data-[focus-visible]:outline-focus data-[focus-visible]:outline-mint',
+      white:
+        'data-[focus-visible]:outline-focus data-[focus-visible]:outline-white',
     },
     /**
      * When the button is without text, but with a single icon.
@@ -46,7 +47,7 @@ const buttonVariants = cva({
       false: 'gap-2.5 px-4 py-2',
     },
     // Make the content of the button transparent to hide it's content, but keep the button width
-    isPending: { true: '!text-transparent', false: null },
+    isPending: { true: 'relative !text-transparent', false: null },
   },
   compoundVariants: [
     {

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -53,6 +53,8 @@ const cardVariants = cva({
     // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
     // The card is made clickable by a pseudo-element on the heading that covers the entire card
     '[&:not(:has([data-slot="card-link"]_a))_a:not([data-slot="card-link"])]:relative [&_button]:relative [&_input]:relative',
+    // Our Button component has position: relative by default, so we need to override that if it is used in a CardLink (to make the entire card clickable)
+    '[&_[data-slot="card-link"]_a]:static',
     // Place other interactive on top of the pseudo-element that makes the entire card clickable
     // by setting a higher z-index than the pseudo-element (which implicitly z-index 0)
     '[&_a:not([data-slot="card-link"])]:z-[1] [&_button]:z-[1] [&_input]:z-[1]',
@@ -116,8 +118,8 @@ const cardLinkVariants = cva({
         'after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
         // **** Focus ****
         'focus-visible:outline-none',
-        'focus-visible:after:outline-focus',
-        'focus-visible:after:outline-offset-2',
+        'data-[focus-visible]:after:outline-focus',
+        'data-[focus-visible]:after:outline-offset-2',
         // **** Hover ****
         // Links are underlined by default, and the underline is removed on hover.
         // So we make sure that also happens when the user hovers the clickable area.
@@ -130,9 +132,9 @@ const cardLinkVariants = cva({
         '[&_a]:after:inset-[calc(theme(borderWidth.DEFAULT)*-1)]',
         '[&_a]:after:rounded-[calc(theme(borderRadius.2xl)-theme(borderWidth.DEFAULT))]',
         // **** Focus ****
-        '[&_a:focus-visible]:outline-none',
-        '[&_a:focus-visible]:after:outline-focus',
-        '[&_a:focus-visible]:after:outline-offset-2',
+        '[&_a[data-focus-visible]]:outline-none',
+        '[&_a[data-focus-visible]]:after:outline-focus',
+        '[&_a[data-focus-visible]]:after:outline-offset-2',
         // **** Hover ****
         // Links are underlined by default, and the underline is removed on hover.
         // So we make sure that also happens when the user hovers the card.


### PR DESCRIPTION
## Fixup - focus-visible

I komponenter som internt bruker enten `<Button>` eller `<Link>` fra `react-aria-components` må man sette stylingen for `focus-visible` på en litt spesiell måte for at stylingen skal appliseres som forventet.

Man må bruke attributtet `data-focus-visible` istedenfor vanlig `focus-visible`. Hvis ikke så får elementet fokus-styling når man trykker på det (akkurat som for en god gammeldags `focus`).

Flytter også `relative` på Button slik at den kun appliseres når knappen har et absolutt loading-spinner. Dette gjør at click-area på Cards fortsetter å fungere som den skal. Og `isPending` i knapp fungerer også likt som før.