### PR TITLE
move more linting to biome

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,13 @@
     "es2021": true,
     "node": true
   },
-  "ignorePatterns": ["form-demo/", "apps"],
+  "ignorePatterns": [
+    "form-demo/",
+    "apps",
+    "packages/icons-react",
+    "packages/icons-svg",
+    "packages/tailwind"
+  ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,21 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
-    "ignore": ["dist/", ".next/", ".output/", ".vinxi/", "routetree.gen.ts"],
-    "include": ["apps/", "form-demo"]
+    "ignore": [
+      "dist/",
+      ".next/",
+      ".output/",
+      ".vinxi/",
+      "routetree.gen.ts",
+      "packages/icons-react/src"
+    ],
+    "include": [
+      "apps/",
+      "form-demo",
+      "packages/icons-react",
+      "packages/icons-svg",
+      "packages/tailwind"
+    ]
   },
   "linter": {
     "enabled": true,

--- a/packages/icons-react/scripts/make-react-icons.mjs
+++ b/packages/icons-react/scripts/make-react-icons.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
+import path from 'node:path';
 import { transform } from '@svgr/core';
-import path from 'path';
 import fs from 'fs-extra';
 import { __dirname, listSvgs } from './utils.mjs';
 
@@ -20,9 +20,10 @@ const files = listSvgs(SVG_PATH);
 fs.outputFileSync(REACT_FILE, '');
 fs.appendFile(REACT_FILE, 'import type { SVGProps } from "react";\n');
 
+// biome-ignore lint/complexity/noForEach: leaving this as is in biome migration. Fix when updating this script
 files.forEach(async (file) => {
   const jsx = await toReact(file);
-  fs.appendFile(REACT_FILE, jsx + '\n');
+  fs.appendFile(REACT_FILE, `${jsx}\n`);
 });
 
 // Inline SVGs doesn't need the namespace

--- a/packages/icons-react/scripts/utils.mjs
+++ b/packages/icons-react/scripts/utils.mjs
@@ -1,6 +1,6 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
 export const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/icons-svg/scripts/figma-import.mjs
+++ b/packages/icons-svg/scripts/figma-import.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import ora from 'ora';
+import path from 'node:path';
 import fs from 'fs-extra';
-import path from 'path';
+import ora from 'ora';
 import prompts from 'prompts';
 import { __dirname } from './utils.mjs';
 
@@ -18,13 +18,13 @@ const FIGMA_TOKEN_PATH = path.join(__dirname, '../', '.FIGMA_TOKEN');
 
 (async function main() {
   const spinner = ora(
-    'Reading Figma access token from ' + FIGMA_TOKEN_PATH,
+    `Reading Figma access token from ${FIGMA_TOKEN_PATH}`,
   ).start();
 
   let figmaToken = await readTokenFromDisk();
 
   if (figmaToken) {
-    spinner.succeed('Using Figma access token from ' + FIGMA_TOKEN_PATH);
+    spinner.succeed(`Using Figma access token from ${FIGMA_TOKEN_PATH}`);
   } else {
     spinner.warn('No Figma access token found');
 
@@ -45,7 +45,7 @@ const FIGMA_TOKEN_PATH = path.join(__dirname, '../', '.FIGMA_TOKEN');
 
     if (saveToken) {
       await writeTokenToDisk(figmaToken);
-      spinner.succeed('Saved token to ' + FIGMA_TOKEN_PATH);
+      spinner.succeed(`Saved token to ${FIGMA_TOKEN_PATH}`);
     }
   }
 
@@ -54,9 +54,9 @@ const FIGMA_TOKEN_PATH = path.join(__dirname, '../', '.FIGMA_TOKEN');
   let components;
   try {
     components = await fetchComponents(figmaToken);
-    spinner.succeed(`Loaded Figma components`);
+    spinner.succeed('Loaded Figma components');
   } catch (e) {
-    spinner.fail('Unable to load Figma components: ' + e.message);
+    spinner.fail(`Unable to load Figma components: ${e.message}`);
     return;
   }
 
@@ -66,7 +66,7 @@ const FIGMA_TOKEN_PATH = path.join(__dirname, '../', '.FIGMA_TOKEN');
     icons = processComponents(components);
     spinner.succeed(`Parsed ${icons.length} components into icons`);
   } catch (e) {
-    spinner.fail('Unable to parse icons from Figma components: ' + e.message);
+    spinner.fail(`Unable to parse icons from Figma components: ${e.message}`);
     return;
   }
 
@@ -76,7 +76,7 @@ const FIGMA_TOKEN_PATH = path.join(__dirname, '../', '.FIGMA_TOKEN');
     urls = await fetchImageUrls(icons, figmaToken);
     spinner.succeed();
   } catch (e) {
-    spinner.fail('Unable to get icon URLs: ' + e.message);
+    spinner.fail(`Unable to get icon URLs: ${e.message}`);
     return;
   }
 

--- a/packages/icons-svg/scripts/optimize.mjs
+++ b/packages/icons-svg/scripts/optimize.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { optimize } from 'svgo';
-import path from 'path';
-import pc from 'picocolors';
+import path from 'node:path';
 import fs from 'fs-extra';
+import pc from 'picocolors';
+import { optimize } from 'svgo';
 import { __dirname, listSvgs } from './utils.mjs';
 
 const DIST_DIR = path.join(__dirname, '../src');
@@ -34,7 +34,7 @@ const config = {
 };
 
 const files = listSvgs();
-
+// biome-ignore lint/complexity/noForEach: leaving this as is in biome migration. Fix when updating this script
 files.forEach(async (filePath) => {
   const rawData = await fs.readFile(filePath, 'utf-8');
 
@@ -62,12 +62,14 @@ files.forEach(async (filePath) => {
  * Copied from https://github.com/svg/svgo/blob/fdf9236d12b861cee926d7ba3f00284ff7884eab/lib/svgo/coa.js#L512
  */
 function printProfitInfo(inBytes, outBytes) {
-  var profitPercents = 100 - (outBytes * 100) / inBytes;
+  const profitPercents = 100 - (outBytes * 100) / inBytes;
 
   console.log(
+    // biome-ignore lint/style/useTemplate: leaving this as non template literal as it is copied
     Math.round((inBytes / 1024) * 1000) / 1000 +
       ' KiB' +
       (profitPercents < 0 ? ' + ' : ' - ') +
+      // biome-ignore lint/style/useTemplate: leaving this as non template literal as it is copied
       pc.green(Math.abs(Math.round(profitPercents * 10) / 10) + '%') +
       ' = ' +
       Math.round((outBytes / 1024) * 1000) / 1000 +

--- a/packages/icons-svg/scripts/utils.mjs
+++ b/packages/icons-svg/scripts/utils.mjs
@@ -1,6 +1,6 @@
-import path from 'path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { globSync } from 'glob';
-import { fileURLToPath } from 'url';
 
 export const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/tailwind/fonts/generate-font-fallback.ts
+++ b/packages/tailwind/fonts/generate-font-fallback.ts
@@ -1,5 +1,5 @@
 import { Glob } from 'bun';
-import { readMetrics, generateFontFace } from 'fontaine';
+import { generateFontFace, readMetrics } from 'fontaine';
 
 /**
  * This script parses all the OBOS fonts and generates
@@ -31,7 +31,7 @@ for (const [fontFamilyName, fontFiles] of Object.entries(fontFilesByFamily)) {
     const fontMetrics = await readMetrics(Bun.pathToFileURL(fontFile));
 
     if (fontMetrics == null) {
-      throw new Error('Unable to read metrics for ' + fontFile);
+      throw new Error(`Unable to read metrics for ${fontFile}`);
     }
     console.log(fontFile, fontMetrics);
 

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -159,7 +159,7 @@ module.exports = (options = {}) => {
       ...v1CompatibilityPlugins,
       require('@tailwindcss/typography'),
       require('tailwindcss-animate'),
-      plugin(function ({ addBase, addComponents, theme }) {
+      plugin(({ addBase, addComponents, theme }) => {
         addBase({
           html: {
             '@apply text-black antialiased font-normal font-text': {},
@@ -243,7 +243,7 @@ module.exports = (options = {}) => {
         });
       }),
 
-      plugin(function ({ addBase, addComponents }) {
+      plugin(({ addBase, addComponents }) => {
         const {
           headingXlText,
           headingLText,
@@ -355,7 +355,7 @@ module.exports = (options = {}) => {
           },
         });
       }),
-      plugin(function ({ addBase }) {
+      plugin(({ addBase }) => {
         addBase(
           Object.entries(fontDeclarations).flatMap(
             ([fontFamily, fontFamilyDeclarations]) =>
@@ -570,7 +570,7 @@ module.exports = (options = {}) => {
 };
 
 // These custom components are only used for v1 compat
-const button = plugin(function ({ addComponents, theme }) {
+const button = plugin(({ addComponents, theme }) => {
   const hoverLoadingBgColor = 'rgba(0, 0, 0, 0.1)';
 
   addComponents({
@@ -627,7 +627,7 @@ const button = plugin(function ({ addComponents, theme }) {
   });
 });
 
-const radio = plugin(function ({ addComponents, theme }) {
+const radio = plugin(({ addComponents, theme }) => {
   addComponents({
     '.radio': {
       // hide the native radio input
@@ -672,7 +672,7 @@ const radio = plugin(function ({ addComponents, theme }) {
   });
 });
 
-const checkbox = plugin(function ({ addComponents, theme }) {
+const checkbox = plugin(({ addComponents, theme }) => {
   addComponents({
     '.checkbox': {
       '&::before': {
@@ -693,7 +693,7 @@ const checkbox = plugin(function ({ addComponents, theme }) {
   });
 });
 
-const snackbar = plugin(function ({ addComponents, theme }) {
+const snackbar = plugin(({ addComponents, theme }) => {
   addComponents({
     '.snackbar': {
       'grid-template-columns': 'min-content auto',


### PR DESCRIPTION
Denne PRen fortsetter arbeidet med å migrere fra eslint til biome.

pakkene `icons-react`, `icons-svg` og `tailwind` flyttes over.

Det betyr at bare `react` er igjen på eslint. Når den er over kan vi fjerne eslint helt.