### PR TITLE
Ignore docs apps in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["form-demo"],
+  "ignore": ["form-demo", "apps/docs"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@obosbbl/grunnmuren-docs",
-  "version": "0.0.1",
   "private": true,
   "description": "Grunnmuren documentation",
   "license": "MIT",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@obosbbl/grunnmuren-docs",
+  "version": "0.0.1",
   "private": true,
   "description": "Grunnmuren documentation",
   "license": "MIT",


### PR DESCRIPTION
## Fiks changeset prerelease action

~~Det ser ut som at grunnen til at bygget for `changeset` feiler på grunn av at pakken `apps/docs` er private og mangler `version`. Så prøver meg på det som en fiks.~~

Vi ignorer den pakken i `changeset`-config istedenfor (forlsag fra @alexanbj) 

Se: [https://github.com/changesets/changesets/pull/847](https://github.com/changesets/changesets/pull/847)