### PR TITLE
Add version field

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@obosbbl/grunnmuren-docs",
+  "version": "0.0.1",
   "private": true,
   "description": "Grunnmuren documentation",
   "license": "MIT",


### PR DESCRIPTION
Får fortsatt feilen `error TypeError: Cannot read properties of null (reading 'prerelease')` selv etter ignore av docs-pakken. Prøver å legge til et `version`-felt.