### PR TITLE
More work on icons page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ and check out these packages:
 - [@obosbbl/grunnmuren-icons-react](./packages/icons-react/) - SVG icons as React components.
 - [@obosbbl/grunnmuren-icons-svg](./packages/icons-svg/) - SVG icons.
 
+and the documentation source:
+
+- [Docs](./apps/docs)
+
 ## Contributing
 
 ### Local setup

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,2 +1,3 @@
 .output
 .vinxi
+public/resources/icons/

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,0 +1,9 @@
+# Grunnmuren documentation
+
+This is the app for the Grunnmuren documentation site. It is built using [TanStack Start](https://tanstack.com/start/latest) and Grunnmuren itself.
+
+## Setup
+
+Before running the app for the first time, you should run `pnpm build:assets`. This copies the icon assets to the public folder. If the icons are updated you will need to run this again.
+
+Start the app for local development by running `pnpm run dev`.

--- a/apps/docs/app/routes/__root.tsx
+++ b/apps/docs/app/routes/__root.tsx
@@ -46,9 +46,9 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
         <Meta />
       </head>
       <body>
-        <div className="grid lg:flex">
-          <div className="grow px-6">
-            <main className="grow">{children}</main>
+        <div className="grid min-h-screen lg:flex">
+          <div className="flex grow flex-col px-6">
+            <main className="flex-1">{children}</main>
             <Footer />
           </div>
           <MainNav />

--- a/apps/docs/app/routes/__root.tsx
+++ b/apps/docs/app/routes/__root.tsx
@@ -48,7 +48,7 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
       <body>
         <div className="grid min-h-screen lg:flex">
           <div className="flex grow flex-col px-6">
-            <main className="flex-1">{children}</main>
+            <main className="grow">{children}</main>
             <Footer />
           </div>
           <MainNav />

--- a/apps/docs/app/routes/ikoner.tsx
+++ b/apps/docs/app/routes/ikoner.tsx
@@ -1,9 +1,9 @@
-import * as icons from '@obosbbl/grunnmuren-icons-react';
-import { Button, Card } from '@obosbbl/grunnmuren-react';
-import { createFileRoute } from '@tanstack/react-router';
-import { ArrowDown, Box } from '@obosbbl/grunnmuren-icons-react';
 import Figma from '@/icons/brand-figma';
 import Github from '@/icons/brand-github';
+import * as icons from '@obosbbl/grunnmuren-icons-react';
+import { ArrowDown, Box } from '@obosbbl/grunnmuren-icons-react';
+import { Button, Card } from '@obosbbl/grunnmuren-react';
+import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/ikoner')({
   component: Page,

--- a/apps/docs/app/routes/ikoner.tsx
+++ b/apps/docs/app/routes/ikoner.tsx
@@ -1,16 +1,72 @@
 import * as icons from '@obosbbl/grunnmuren-icons-react';
-import { Card } from '@obosbbl/grunnmuren-react';
+import { Button, Card } from '@obosbbl/grunnmuren-react';
 import { createFileRoute } from '@tanstack/react-router';
+import { ArrowDown, Box } from '@obosbbl/grunnmuren-icons-react';
+import Figma from '@/icons/brand-figma';
+import Github from '@/icons/brand-github';
 
 export const Route = createFileRoute('/ikoner')({
-  component: IconsGrid,
+  component: Page,
 });
+
+function Page() {
+  return (
+    <>
+      <h1 className="heading-l mb-12 mt-9">Ikoner</h1>
+      <div className="prose">
+        <p>
+          Grunnmuren sitt ikonsett består av {Object.keys(icons).length}{' '}
+          forskjellige ikoner. Settet er publisert som npm pakker både i{' '}
+          <a href="https://www.npmjs.com/package/@obosbbl/grunnmuren-icons-svg">
+            svg-format
+          </a>{' '}
+          og som{' '}
+          <a href="https://www.npmjs.com/package/@obosbbl/grunnmuren-icons-react">
+            React-komponenter
+          </a>
+          . Du kan også laste ned individuelle ikoner på denne siden.
+        </p>
+
+        <p>
+          Hvis det er et ikon du savner kan du ta kontakt med oss på{' '}
+          <a href="https://obos.slack.com/archives/C03FR05FJ9F">
+            Slack (#grunnmuren-design-system)
+          </a>
+          , så kan vi se hva vi kan gjøre.
+        </p>
+      </div>
+
+      <div className="my-12 flex gap-4">
+        <a
+          className="flex gap-2"
+          href="https://www.figma.com/design/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=30-2099&t=O9zg6ynNvNWFeOy8-4"
+        >
+          <Figma /> Figma
+        </a>
+
+        <a
+          className="flex gap-2"
+          href="https://github.com/code-obos/grunnmuren/tree/main/packages/icons-svg"
+        >
+          <Github /> GitHub
+        </a>
+
+        <a
+          className="flex gap-2"
+          href="https://www.npmjs.com/package/@obosbbl/grunnmuren-icons-react"
+        >
+          <Box /> npm
+        </a>
+      </div>
+      <IconsGrid />
+    </>
+  );
+}
 
 function IconsGrid() {
   return (
     <>
-      <h1 className="heading-l mb-12 mt-9">Ikoner</h1>
-      <div className="grid grid-cols-[repeat(auto-fill,_150px)] content-center gap-6">
+      <div className="grid grid-cols-[repeat(auto-fill,_130px)] content-center gap-6">
         {Object.entries(icons).map(([iconName, Icon]) => (
           <IconCard key={iconName} iconName={iconName} Icon={Icon} />
         ))}
@@ -20,10 +76,20 @@ function IconsGrid() {
 }
 
 function IconCard({ iconName, Icon }) {
+  const downloadSvgLink = `/resources/icons/${iconName}.svg`;
+
   return (
     <Card className="bg-gray-lightest" key={iconName}>
       <Icon className="mx-auto" />
       <span className="block text-center text-sm">{iconName}</span>
+      <Button
+        variant="tertiary"
+        href={downloadSvgLink}
+        download
+        className="ml-auto w-[44px]"
+      >
+        <ArrowDown className="flex-none" />
+      </Button>
     </Card>
   );
 }

--- a/apps/docs/app/routes/index.tsx
+++ b/apps/docs/app/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { Card, CardLink, Heading } from '@obosbbl/grunnmuren-react';
 
 export const Route = createFileRoute('/')({
   component: Home,
@@ -7,7 +8,21 @@ export const Route = createFileRoute('/')({
 function Home() {
   return (
     <>
-      <h1>Hello, Grunnmuren docs!</h1>
+      <h1 className="heading-l mb-12">Grunnmuren</h1>
+      <div className="grid grid-cols-2 gap-4">
+        <Card variant="outlined">
+          <Heading level={2}>
+            <CardLink href="/">Komponenter</CardLink>
+          </Heading>
+          Se alle byggeklossene våre
+        </Card>
+        <Card variant="outlined">
+          <Heading level={2}>
+            <CardLink href="/ikoner">Ikoner</CardLink>
+          </Heading>
+          Utforsk ikonsettet vårt
+        </Card>
+      </div>
     </>
   );
 }

--- a/apps/docs/app/routes/index.tsx
+++ b/apps/docs/app/routes/index.tsx
@@ -1,5 +1,5 @@
-import { createFileRoute } from '@tanstack/react-router';
 import { Card, CardLink, Heading } from '@obosbbl/grunnmuren-react';
+import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/')({
   component: Home,

--- a/apps/docs/app/ui/main-nav.tsx
+++ b/apps/docs/app/ui/main-nav.tsx
@@ -52,6 +52,15 @@ const mainNavItems = [
     title: 'Komponenter',
     subNavItems: [
       {
+        to: '/komponenter/button',
+        title: 'Button',
+      },
+    ],
+  },
+  {
+    title: 'Profil',
+    subNavItems: [
+      {
         to: '/ikoner',
         title: 'Ikoner',
       },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm build:assets && vinxi build",
+    "build": "pnpm build:assets && pnpm build:app",
+    "build:app": "vinxi build",
     "build:assets": "mkdir -p public/resources/icons && cp -r node_modules/@obosbbl/grunnmuren-icons-svg/src/ public/resources/icons",
     "dev": "vinxi dev",
     "start": "vinxi start"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,12 +6,14 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "vinxi build",
+    "build": "pnpm build:assets && vinxi build",
+    "build:assets": "mkdir -p public/resources/icons && cp -r node_modules/@obosbbl/grunnmuren-icons-svg/src/ public/resources/icons",
     "dev": "vinxi dev",
     "start": "vinxi start"
   },
   "dependencies": {
     "@obosbbl/grunnmuren-icons-react": "workspace:*",
+    "@obosbbl/grunnmuren-icons-svg": "workspace:*",
     "@obosbbl/grunnmuren-react": "workspace:*",
     "@tanstack/react-router": "1.82.8",
     "@tanstack/start": "1.82.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@obosbbl/grunnmuren-icons-react':
         specifier: workspace:*
         version: link:../../packages/icons-react
+      '@obosbbl/grunnmuren-icons-svg':
+        specifier: workspace:*
+        version: link:../../packages/icons-svg
       '@obosbbl/grunnmuren-react':
         specifier: workspace:*
         version: link:../../packages/react


### PR DESCRIPTION
Denne PRen fortsetter arbeidet med ikonsiden. Åpner denne PRen nå, før jeg gjør for mye greier 😅

Kommer mer etter hvert!

Endringer:

* Lagt til litt enkle kort på forsiden for å få det til å se litt bedre ut.
* Gjort at innholdet strekker seg nedover hele skjermen, med footeren i bunn.
* Lagt til/oppdatert READMEs
* Lagt til støtte for å laste ned ikonene.
* Skrevet litt dokumentasjon for ikonene.

<img width="782" alt="Screenshot 2024-11-29 at 08 55 11" src="https://github.com/user-attachments/assets/2b3e4b41-2e19-44aa-b80e-b7e7194110bd">

Merk at måten ikonene kommer over i public mappen for nedlastning nå er via en enkel `cp` command. Den vil ikke fungere på feks windows. For at nedlastningslenkene på ikonene skal fungere må dette npm scriptet kjøres manuelt første gang man kjører appen.

Prøvde litt raskt å ta i bruk [vite-plugin-static-copy](https://www.npmjs.com/package/vite-plugin-static-copy) slik at vi får det som en del av den vanlige app build pipelinen, men sleit litt å gadd ikke bruke så mye tid på det. Kan se på det mer senere.



