### PR TITLE
Add code snippet component to button

### DIFF
--- a/apps/docs/app/routeTree.gen.ts
+++ b/apps/docs/app/routeTree.gen.ts
@@ -13,6 +13,7 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as IkonerImport } from './routes/ikoner'
 import { Route as IndexImport } from './routes/index'
+import { Route as KomponenterButtonImport } from './routes/komponenter/button'
 
 // Create/Update Routes
 
@@ -25,6 +26,12 @@ const IkonerRoute = IkonerImport.update({
 const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const KomponenterButtonRoute = KomponenterButtonImport.update({
+  id: '/komponenter/button',
+  path: '/komponenter/button',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -46,6 +53,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IkonerImport
       parentRoute: typeof rootRoute
     }
+    '/komponenter/button': {
+      id: '/komponenter/button'
+      path: '/komponenter/button'
+      fullPath: '/komponenter/button'
+      preLoaderRoute: typeof KomponenterButtonImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -54,36 +68,41 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/ikoner': typeof IkonerRoute
+  '/komponenter/button': typeof KomponenterButtonRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/ikoner': typeof IkonerRoute
+  '/komponenter/button': typeof KomponenterButtonRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/ikoner': typeof IkonerRoute
+  '/komponenter/button': typeof KomponenterButtonRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/ikoner'
+  fullPaths: '/' | '/ikoner' | '/komponenter/button'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/ikoner'
-  id: '__root__' | '/' | '/ikoner'
+  to: '/' | '/ikoner' | '/komponenter/button'
+  id: '__root__' | '/' | '/ikoner' | '/komponenter/button'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   IkonerRoute: typeof IkonerRoute
+  KomponenterButtonRoute: typeof KomponenterButtonRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   IkonerRoute: IkonerRoute,
+  KomponenterButtonRoute: KomponenterButtonRoute,
 }
 
 export const routeTree = rootRoute
@@ -97,7 +116,8 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
-        "/ikoner"
+        "/ikoner",
+        "/komponenter/button"
       ]
     },
     "/": {
@@ -105,6 +125,9 @@ export const routeTree = rootRoute
     },
     "/ikoner": {
       "filePath": "ikoner.tsx"
+    },
+    "/komponenter/button": {
+      "filePath": "komponenter/button.tsx"
     }
   }
 }

--- a/apps/docs/app/routes/komponenter/button.tsx
+++ b/apps/docs/app/routes/komponenter/button.tsx
@@ -1,0 +1,160 @@
+import { ComponentPreview } from '@/ui/component-preview';
+import { Edit, Search } from '@obosbbl/grunnmuren-icons-react';
+import { Button } from '@obosbbl/grunnmuren-react';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/komponenter/button')({
+  component: Page,
+});
+
+const examples = [
+  { title: 'Knapp', code: <Button>Knapp</Button> },
+  {
+    title: 'Lenke-knapp',
+    code: <Button href="#link">Lenke-knapp</Button>,
+  },
+  {
+    title: 'Primærknapp',
+    code: (
+      <>
+        <Button variant="primary">Primærknapp</Button>
+        <Button variant="primary" href="#primary-cta">
+          Primærlink
+        </Button>
+      </>
+    ),
+  },
+  {
+    title: 'Sekundærknapp',
+    code: (
+      <>
+        <Button variant="secondary">Sekundærknapp</Button>
+        <Button variant="secondary" href="#secondary-cta">
+          Sekundærlink
+        </Button>
+      </>
+    ),
+  },
+  {
+    title: 'Tertiærknapp',
+    code: (
+      <>
+        <Button variant="tertiary">Tertiærknapp</Button>
+        <Button variant="tertiary" href="#tertiary-cta">
+          Tertiærlink
+        </Button>
+      </>
+    ),
+  },
+  {
+    title: 'Knapp med ikon og tekst',
+    code: (
+      <>
+        <Button>
+          <Edit />
+          Rediger
+        </Button>
+        <Button href="#search">
+          <Search />
+          Søk
+        </Button>
+      </>
+    ),
+  },
+  {
+    title: 'Knapp med kun ikon',
+    code: (
+      <Button isIconOnly aria-label="Søk">
+        <Search />
+      </Button>
+    ),
+  },
+  {
+    title: 'Knapp med pending-tilstand',
+    code: (
+      <>
+        <Button isPending variant="primary">
+          Primærknapp
+        </Button>
+        <Button isPending variant="secondary">
+          Sekundærknapp
+        </Button>
+        <Button isPending variant="tertiary">
+          Tertiærknapp
+        </Button>
+      </>
+    ),
+  },
+  {
+    title: 'Transparent bakgrunn',
+    code: (
+      <>
+        <Button variant="primary">Primærknapp</Button>
+        <Button variant="secondary">Sekundærknapp</Button>
+        <Button variant="tertiary">Tertiærknapp</Button>
+      </>
+    ),
+  },
+  {
+    title: 'Lys bakgrunn',
+    code: (
+      <div className="flex gap-x-[inherit] bg-mint-lightest p-8">
+        <Button variant="primary">Primærknapp</Button>
+        <Button variant="secondary">Sekundærknapp</Button>
+        <Button variant="tertiary">Tertiærknapp</Button>
+      </div>
+    ),
+  },
+  {
+    title: 'Grønn bakgrunn',
+    code: (
+      <div className="flex gap-x-[inherit] bg-green-dark p-8">
+        <Button variant="primary" color="mint">
+          Primærknapp
+        </Button>
+        <Button variant="secondary" color="mint">
+          Sekundærknapp
+        </Button>
+        <Button variant="tertiary" color="mint">
+          Tertiærknapp
+        </Button>
+      </div>
+    ),
+  },
+  {
+    title: 'Blå bakgrunn',
+    code: (
+      <div className="flex gap-x-[inherit] bg-blue-dark p-8">
+        <Button variant="primary" color="mint">
+          Primærknapp
+        </Button>
+        <Button variant="secondary" color="mint">
+          Sekundærknapp
+        </Button>
+        <Button variant="tertiary" color="mint">
+          Tertiærknapp
+        </Button>
+      </div>
+    ),
+  },
+];
+
+function Page() {
+  return (
+    <>
+      <h1 className="heading-l mb-12 mt-9">Button</h1>
+      <div className="prose">
+        <p>Info om knapper her...</p>
+      </div>
+
+      {examples.map(({ title, code }) => (
+        <ComponentPreview
+          scope={{ Button, Edit, Search }}
+          key={title}
+          title={title}
+          code={code}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/docs/app/ui/component-preview.tsx
+++ b/apps/docs/app/ui/component-preview.tsx
@@ -32,7 +32,7 @@ export const ComponentPreview = ({
           <LiveEditor
             tabMode="focus"
             // Use the same black color as the background on the editor
-            className="font-mono row-span-2"
+            className="row-span-2 font-[monospace]"
             onChange={(newCode) => setCodeString(newCode)}
           />
           <div className="relative text-mint">

--- a/apps/docs/app/ui/component-preview.tsx
+++ b/apps/docs/app/ui/component-preview.tsx
@@ -1,0 +1,65 @@
+import * as GrunnmurenIconsScope from '@obosbbl/grunnmuren-icons-react';
+import * as GrunnmurenScope from '@obosbbl/grunnmuren-react';
+import { cx } from 'cva';
+import { themes } from 'prism-react-renderer';
+import { useState } from 'react';
+import reactElementToJSXString from 'react-element-to-jsx-string';
+import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
+
+type ComponentPreviewProps = {
+  title: string;
+  code: React.ReactNode;
+  /** All custom components that are rendered must be present in the scope */
+  scope: Partial<typeof GrunnmurenIconsScope & typeof GrunnmurenScope>;
+};
+
+export const ComponentPreview = ({
+  title,
+  code,
+  scope,
+}: ComponentPreviewProps) => {
+  // Keep of the code string in state to be able to copy it
+  const [codeString, setCodeString] = useState(reactElementToJSXString(code));
+
+  const [hasCopied, setHasCopied] = useState(false);
+  return (
+    <LiveProvider code={codeString} scope={scope} theme={themes.vsDark}>
+      <div className="my-8 grid gap-y-4">
+        <h2 className="heading-m">{title}</h2>
+        <hr />
+        <LivePreview className="flex gap-x-4" />
+        <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
+          <LiveEditor
+            tabMode="focus"
+            // Use the same black color as the background on the editor
+            className="font-mono row-span-2"
+            onChange={(newCode) => setCodeString(newCode)}
+          />
+          <div className="relative text-mint">
+            <GrunnmurenScope.Button
+              onPress={() =>
+                navigator.clipboard.writeText(codeString).then(() => {
+                  setHasCopied(true);
+                  setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
+                })
+              }
+              variant="tertiary"
+            >
+              <GrunnmurenIconsScope.Documents />
+            </GrunnmurenScope.Button>
+            <span
+              className={cx(
+                'absolute right-2 top-full transition-opacity duration-100',
+                hasCopied ? 'opacity-100' : 'opacity-0',
+              )}
+              aria-hidden={!hasCopied}
+              role="alert"
+            >
+              Kopiert!
+            </span>
+          </div>
+        </div>
+      </div>
+    </LiveProvider>
+  );
+};

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,9 +18,13 @@
     "@obosbbl/grunnmuren-react": "workspace:*",
     "@tanstack/react-router": "1.82.8",
     "@tanstack/start": "1.82.9",
+    "cva": "1.0.0-beta.1",
+    "prism-react-renderer": "2.4.0",
     "react": "18.3.1",
     "react-aria-components": "1.5.0",
     "react-dom": "18.3.1",
+    "react-element-to-jsx-string": "15.0.0",
+    "react-live": "4.1.8",
     "vinxi": "0.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3652,6 +3652,10 @@ packages:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
 
+  clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -3829,6 +3833,14 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  cva@1.0.0-beta.1:
+    resolution: {integrity: sha512-gznFqTgERU9q4wg7jfgqtt34+RUt9S5t0xDAAEuDwQEAXEgjdDkKXpLLNjwSxsB4Ln/sqWJEH7yhE8Ny0mxd0w==}
+    peerDependencies:
+      typescript: '>= 4.5.5 < 6'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cva@1.0.0-beta.2:
     resolution: {integrity: sha512-dqcOFe247I5pKxfuzqfq3seLL5iMYsTgo40Uw7+pKZAntPgFtR7Tmy59P5IVIq/XgB0NQWoIvYDt9TwHkuK8Cg==}
@@ -11683,6 +11695,8 @@ snapshots:
 
   clone@2.1.2: {}
 
+  clsx@2.0.0: {}
+
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.2: {}
@@ -11839,6 +11853,12 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.1.3: {}
+
+  cva@1.0.0-beta.1(typescript@5.6.3):
+    dependencies:
+      clsx: 2.0.0
+    optionalDependencies:
+      typescript: 5.6.3
 
   cva@1.0.0-beta.2(typescript@5.6.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,12 @@ importers:
       '@tanstack/start':
         specifier: 1.82.9
         version: 1.82.9(@types/node@22.9.0)(ioredis@5.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.9.0)(terser@5.36.0))
+      cva:
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(typescript@5.6.3)
+      prism-react-renderer:
+        specifier: 2.4.0
+        version: 2.4.0(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -146,6 +152,12 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-element-to-jsx-string:
+        specifier: 15.0.0
+        version: 15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-live:
+        specifier: 4.1.8
+        version: 4.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vinxi:
         specifier: 0.4.3
         version: 0.4.3(@types/node@22.9.0)(ioredis@5.4.1)(terser@5.36.0)(typescript@5.6.3)
@@ -529,6 +541,9 @@ packages:
   '@babel/types@7.26.0':
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
+
+  '@base2/pretty-print-object@1.0.1':
+    resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2903,6 +2918,9 @@ packages:
   '@types/node@22.9.0':
     resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
 
+  '@types/prismjs@1.26.5':
+    resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
+
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
 
@@ -3624,7 +3642,7 @@ packages:
     engines: {node: '>= 14'}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
@@ -3976,7 +3994,7 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ee-first@1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.32:
     resolution: {integrity: sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==}
@@ -4786,6 +4804,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -5935,6 +5957,11 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  prism-react-renderer@2.4.0:
+    resolution: {integrity: sha512-327BsVCD/unU4CNLZTWVHyUHKnsqcvj2qbPlQ8MiBE2eq2rgctjigPA1Gp9HLF83kZ20zNN6jgizHJeEsyFYOw==}
+    peerDependencies:
+      react: '>=16.0.0'
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -6017,14 +6044,30 @@ packages:
     peerDependencies:
       react: 19.0.0-rc.1
 
+  react-element-to-jsx-string@15.0.0:
+    resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
+    peerDependencies:
+      react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+      react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-is@18.1.0:
+    resolution: {integrity: sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-live@4.1.8:
+    resolution: {integrity: sha512-B2SgNqwPuS2ekqj4lcxi5TibEcjWkdVyYykBEUBshPAPDQ527x2zPEZg560n8egNtAjUpwXFQm7pcXV65aAYmg==}
+    engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -6852,6 +6895,11 @@ packages:
   urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
 
+  use-editable@2.3.3:
+    resolution: {integrity: sha512-7wVD2JbfAFJ3DK0vITvXBdpd9JAz5BcKAAolsnLBuBn6UDDwBGuCIAGvR3yA2BNKm578vAMVHFCWaOcA+BhhiA==}
+    peerDependencies:
+      react: '>= 16.8.0'
+
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
@@ -7405,6 +7453,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@base2/pretty-print-object@1.0.1': {}
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -10565,6 +10615,8 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/prismjs@1.26.5': {}
+
   '@types/prop-types@15.7.13': {}
 
   '@types/react-dom@18.3.1':
@@ -12812,6 +12864,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-plain-object@5.0.0: {}
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.6
@@ -14214,6 +14268,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  prism-react-renderer@2.4.0(react@18.3.1):
+    dependencies:
+      '@types/prismjs': 1.26.5
+      clsx: 2.1.1
+      react: 18.3.1
+
   process-nextick-args@2.0.1: {}
 
   process-on-spawn@1.1.0:
@@ -14457,11 +14517,29 @@ snapshots:
       react: 19.0.0-rc.1
       scheduler: 0.25.0-rc.1
 
+  react-element-to-jsx-string@15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@base2/pretty-print-object': 1.0.1
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.1.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
+  react-is@18.1.0: {}
+
   react-is@18.3.1: {}
+
+  react-live@4.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      prism-react-renderer: 2.4.0(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      sucrase: 3.35.0
+      use-editable: 2.3.3(react@18.3.1)
 
   react-refresh@0.14.2: {}
 
@@ -15418,6 +15496,10 @@ snapshots:
   url-join@4.0.1: {}
 
   urlpattern-polyfill@8.0.2: {}
+
+  use-editable@2.3.3(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Kode-eksempler

Legger til generell komponent som kan brukes for kode-eksempler, med funksjonalitet for å kopiere koden. Bruker [react-live](https://commerce.nearform.com/open-source/react-live/) til dette, som er en lettvekts-pakke for code-snippets.

For at det skal være litt enklere å skrive kode-eksemplene har jeg også lagt inn `react-element-to-jsx-string`, som gjør det mulig å skrive eksemplene som JSX.

Har også lagt til en custom theme som jeg syns var litt finere enn defaulten:


https://github.com/user-attachments/assets/1d41b76b-26aa-4d06-97e8-5cb41a2e58cc

Neste steg her tenker jeg er å fikse en props-tabell som kan kobles sammen med både kodeeksempler og rendering.

Dette er kun en første minimi-versjon, og vi burde (akkurat som på ikoner) fikse størrelsen på kopier-knappen.

Har lagt fokus på å få til noe som funker og kan bygges videre på, samt uu.