### PR TITLE
docs: add bridge between RAC and TanStack router

### DIFF
--- a/apps/docs/app/routes/__root.tsx
+++ b/apps/docs/app/routes/__root.tsx
@@ -3,12 +3,14 @@ import { Footer } from '@/ui/footer';
 import { MainNav } from '@/ui/main-nav';
 import { GrunnmurenProvider } from '@obosbbl/grunnmuren-react';
 import {
+  type NavigateOptions,
   Outlet,
   ScrollRestoration,
+  type ToOptions,
   createRootRoute,
+  useRouter,
 } from '@tanstack/react-router';
 import { Meta, Scripts } from '@tanstack/start';
-import type { ReactNode } from 'react';
 
 export const Route = createRootRoute({
   head: () => ({
@@ -26,36 +28,47 @@ export const Route = createRootRoute({
     ],
     links: [{ rel: 'stylesheet', href: appCss }],
   }),
-  component: RootComponent,
+  component: RootDocument,
 });
 
-function RootComponent() {
-  return (
-    <RootDocument>
-      <GrunnmurenProvider locale="nb">
-        <Outlet />
-      </GrunnmurenProvider>
-    </RootDocument>
-  );
-}
+function RootDocument() {
+  const router = useRouter();
 
-function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html lang="no">
       <head>
         <Meta />
       </head>
       <body>
-        <div className="grid min-h-screen lg:flex">
-          <div className="flex grow flex-col px-6">
-            <main className="grow">{children}</main>
-            <Footer />
+        <GrunnmurenProvider
+          locale="nb"
+          // This integrates RAC/Grunnmuren with TanStack router
+          // Giving us typesafe routes
+          // See https://react-spectrum.adobe.com/react-aria/routing.html#tanstack-router
+          navigate={(to, options) => router.navigate({ to, ...options })}
+          useHref={(to) => router.buildLocation({ to }).href}
+        >
+          <div className="grid min-h-screen lg:flex">
+            <div className="flex grow flex-col px-6">
+              <main className="grow">
+                <Outlet />
+              </main>
+              <Footer />
+            </div>
+            <MainNav />
           </div>
-          <MainNav />
-        </div>
+        </GrunnmurenProvider>
         <ScrollRestoration />
         <Scripts />
       </body>
     </html>
   );
+}
+
+// See comments on GrunnmurenProvider in <RootDocument />
+declare module 'react-aria-components' {
+  interface RouterConfig {
+    href: ToOptions['to'];
+    routerOptions: Omit<NavigateOptions, keyof ToOptions>;
+  }
 }

--- a/apps/docs/app/routes/ikoner.tsx
+++ b/apps/docs/app/routes/ikoner.tsx
@@ -85,6 +85,7 @@ function IconCard({ iconName, Icon }) {
       <Button
         variant="tertiary"
         href={downloadSvgLink}
+        // @ts-expect-error fix in Grunnmuren so we're allowed to pass download when href is set
         download
         className="ml-auto w-[44px]"
       >


### PR DESCRIPTION
Denne PRen integrererer RAC Links med TanStack Router. Dette enabler client side routing selv om vi bruker en RAC/Grunnmuren Link i stedet for TanStack sin egen. Se https://react-spectrum.adobe.com/react-aria/routing.html

Det gjør også at vi får ta nytte av TanStack Router sine typesafe routes.

Flytter også på GrunnmurenProvider slik at den wrapper sidenav og footer, før wrappet den kun `<Outlet />`

Før:
<img width="410" alt="Screenshot 2024-11-30 at 07 25 41" src="https://github.com/user-attachments/assets/6c74581f-3741-40c0-8bf8-922c3542f7bf">

Etter:
<img width="884" alt="Screenshot 2024-11-30 at 06 59 23" src="https://github.com/user-attachments/assets/fb0c1b24-5170-460a-8be8-3aa550389df9">


Når jeg satte opp dette så viser det seg at det er en feil i typelogikken i Grunnmuren. Egentlig skal `download` propen kun være tilgjengelig når `href` er satt til Button, men dette ser ikke ut til å funke 🤔 Ser på det i en egen PR.
