### PR TITLE
tailwind: add back default `font-mono` utility

### DIFF
--- a/.changeset/chatty-bags-exist.md
+++ b/.changeset/chatty-bags-exist.md
@@ -1,0 +1,7 @@
+---
+'@obosbbl/grunnmuren-tailwind': patch
+---
+
+include Tailwind's default `font-mono` utility for setting the font family.
+
+OBOS doesn't have a monospaced font, so we use Tailwind's default here.

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -1,3 +1,4 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
 const plugin = require('tailwindcss/plugin');
 const fontFallbacks = require('./fonts/font-fallback');
 
@@ -445,6 +446,8 @@ module.exports = (options = {}) => {
             fontFallbacks.OBOSDisplay['font-family'],
           'sans-serif',
         ],
+        // OBOS doesn't have monospaced font, so we keep Tailwind's default here
+        mono: defaultTheme.fontFamily.mono,
       },
       extend: {
         maxWidth: {


### PR DESCRIPTION
Vi overstyrer Tailwind sine font family utilties til å bruke OBOS fonten, eg `font-display`og `font-text` i stedet for Tailwind sine default `font-sans` og `font-serif`. Se https://tailwindcss.com/docs/font-family

Det betyr at vi fjernet `font-mono` utilen. Monospaced fonter er nyttig i for eksempel kodeeksempler, som vi trenger i Grunnmurens dokumentasjon. Siden OBOS ikke har en monospaced font inkluderer vi Tailwind sin default her.