### PR TITLE
Disable minification of component names

### DIFF
--- a/apps/docs/app.config.ts
+++ b/apps/docs/app.config.ts
@@ -21,5 +21,9 @@ export default defineConfig({
         projects: ['./tsconfig.json'],
       }),
     ],
+    esbuild: {
+      // We need to disable minification of identifiers to preserve React component names in auto generated code snippets (see `reactElementToJSXString` in file:///./app/ui/component-preview.tsx).
+      minifyIdentifiers: false,
+    },
   },
 });


### PR DESCRIPTION
Disabler minification av funksjoner og variabler, slik at komponent-navn ikke blir borte i kode-eksempler. Dette er en litt brute, midlertidig fiks.