### PR TITLE
Props table on button

### DIFF
--- a/apps/docs/app/routes/komponenter/button.tsx
+++ b/apps/docs/app/routes/komponenter/button.tsx
@@ -1,7 +1,9 @@
 import { ComponentPreview } from '@/ui/component-preview';
+import { PropsTable } from '@/ui/props-table';
 import { Edit, Search } from '@obosbbl/grunnmuren-icons-react';
 import { Button } from '@obosbbl/grunnmuren-react';
 import { createFileRoute } from '@tanstack/react-router';
+import { ButtonDoc } from 'docgen';
 
 export const Route = createFileRoute('/komponenter/button')({
   component: Page,
@@ -142,9 +144,9 @@ const examples = [
 function Page() {
   return (
     <>
-      <h1 className="heading-l mb-12 mt-9">Button</h1>
+      <h1 className="heading-l mb-12 mt-9">{ButtonDoc.displayName}</h1>
       <div className="prose">
-        <p>Info om knapper her...</p>
+        <p>{ButtonDoc.description}</p>
       </div>
 
       {examples.map(({ title, code }) => (
@@ -155,6 +157,7 @@ function Page() {
           code={code}
         />
       ))}
+      <PropsTable props={ButtonDoc.props} />
     </>
   );
 }

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -6,6 +6,7 @@ import {
   Button as RACButton,
   type ButtonProps as RACButtonProps,
   Link as RACLink,
+  type LinkProps as RACLinkProps,
 } from 'react-aria-components';
 import { type Locale, useLocale } from '../use-locale';
 
@@ -125,15 +126,11 @@ type ButtonOrLinkProps = VariantProps<typeof buttonVariants> & {
   style?: React.CSSProperties;
 };
 
-type ButtonProps = (
-  | RACButtonProps
-  | React.ComponentPropsWithoutRef<typeof RACLink>
-) &
-  ButtonOrLinkProps;
+type ButtonProps = (RACButtonProps | RACLinkProps) & ButtonOrLinkProps;
 
 function isLinkProps(
   props: ButtonProps,
-): props is ButtonOrLinkProps & React.ComponentPropsWithoutRef<typeof RACLink> {
+): props is ButtonOrLinkProps & RACLinkProps {
   return !!props.href;
 }
 


### PR DESCRIPTION
## Props-table in `button` docs

Ads a props table to the bottom of the `button` docs.

Had to tweak the props typing on the button component to enable `docgen` to parse the props. From what I can tell the type is just the same with this change, only difference is that`docgen` is able to auto generate alle the types for us. I suspect either the `typeof` keywoid or the generic `ComponentPropsWithoutRef` was the problem.

<img width="1343" alt="Screenshot 2024-12-10 at 18 39 06" src="https://github.com/user-attachments/assets/1bc03b81-4be3-4532-b9d2-a6940269e6ac">
