### PR TITLE
Add code examples

### DIFF
--- a/apps/docs/app/routes/komponenter/badge.tsx
+++ b/apps/docs/app/routes/komponenter/badge.tsx
@@ -1,10 +1,10 @@
-import { PropsTable } from '@/ui/props-table';
-import { createFileRoute } from '@tanstack/react-router';
-import { BadgeDoc } from '../../../docgen';
 import { ComponentPreview } from '@/ui/component-preview';
-import { Badge } from '@obosbbl/grunnmuren-react';
+import { PropsTable } from '@/ui/props-table';
 import { PaintRoller } from '@obosbbl/grunnmuren-icons-react';
+import { Badge } from '@obosbbl/grunnmuren-react';
+import { createFileRoute } from '@tanstack/react-router';
 import { cx } from 'cva';
+import { BadgeDoc } from '../../../docgen';
 
 export const Route = createFileRoute('/komponenter/badge')({
   component: Page,

--- a/apps/docs/app/routes/komponenter/badge.tsx
+++ b/apps/docs/app/routes/komponenter/badge.tsx
@@ -33,7 +33,10 @@ const examples = [
   ...colors.map((color) => ({
     title: color.charAt(0).toUpperCase() + color.slice(1),
     code: (
-      <div className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}>
+      <div
+        className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}
+        key={color}
+      >
         <Badge color={color} size="small">
           small
         </Badge>
@@ -49,7 +52,10 @@ const examples = [
   ...colors.map((color) => ({
     title: `${color.charAt(0).toUpperCase() + color.slice(1)} med ikon`,
     code: (
-      <div className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}>
+      <div
+        className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}
+        key={color}
+      >
         <Badge color={color} size="small">
           <PaintRoller />
           small

--- a/apps/docs/app/routes/komponenter/badge.tsx
+++ b/apps/docs/app/routes/komponenter/badge.tsx
@@ -25,7 +25,9 @@ const examples = [
     code: (
       <>
         {colors.map((color) => (
-          <Badge color={color}>{color}</Badge>
+          <Badge color={color} key={color}>
+            {color}
+          </Badge>
         ))}
       </>
     ),

--- a/apps/docs/app/routes/komponenter/badge.tsx
+++ b/apps/docs/app/routes/komponenter/badge.tsx
@@ -1,10 +1,71 @@
 import { PropsTable } from '@/ui/props-table';
 import { createFileRoute } from '@tanstack/react-router';
 import { BadgeDoc } from '../../../docgen';
+import { ComponentPreview } from '@/ui/component-preview';
+import { Badge } from '@obosbbl/grunnmuren-react';
+import { PaintRoller } from '@obosbbl/grunnmuren-icons-react';
+import { cx } from 'cva';
 
 export const Route = createFileRoute('/komponenter/badge')({
   component: Page,
 });
+
+const colors = [
+  'mint',
+  'sky',
+  'blue-dark',
+  'green-dark',
+  'gray-dark',
+  'white',
+] as const;
+
+const examples = [
+  {
+    title: 'Badge',
+    code: (
+      <>
+        {colors.map((color) => (
+          <Badge color={color}>{color}</Badge>
+        ))}
+      </>
+    ),
+  },
+  ...colors.map((color) => ({
+    title: color.charAt(0).toUpperCase() + color.slice(1),
+    code: (
+      <div className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}>
+        <Badge color={color} size="small">
+          small
+        </Badge>
+        <Badge color={color} size="medium">
+          medium
+        </Badge>
+        <Badge color={color} size="large">
+          large
+        </Badge>
+      </div>
+    ),
+  })),
+  ...colors.map((color) => ({
+    title: `${color.charAt(0).toUpperCase() + color.slice(1)} med ikon`,
+    code: (
+      <div className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}>
+        <Badge color={color} size="small">
+          <PaintRoller />
+          small
+        </Badge>
+        <Badge color={color} size="medium">
+          <PaintRoller />
+          medium
+        </Badge>
+        <Badge color={color} size="large">
+          <PaintRoller />
+          large
+        </Badge>
+      </div>
+    ),
+  })),
+];
 
 function Page() {
   return (
@@ -13,6 +74,16 @@ function Page() {
       <div className="prose">
         <p>{BadgeDoc.description}</p>
       </div>
+
+      {examples.map(({ title, code }) => (
+        <ComponentPreview
+          scope={{ Badge, PaintRoller }}
+          key={title}
+          title={title}
+          code={code}
+        />
+      ))}
+
       <PropsTable props={BadgeDoc.props} />
     </>
   );


### PR DESCRIPTION
## Code examples for `Badge`

Adds code snippet examples to the `Badge` docs. Very simliar examples to those in the [storybook](https://obos-grunnmuren.netlify.app/?path=/docs/badge--docs).

This follows the same pattern as the code snippet examples for the `Button` component.


<img width="1279" alt="Screenshot 2024-12-10 at 19 00 16" src="https://github.com/user-attachments/assets/0a42e448-b122-4c0f-a178-44fef31576d3">
