### PR TITLE
Auto hyphenate card headings

### DIFF
--- a/.changeset/twelve-hats-jam.md
+++ b/.changeset/twelve-hats-jam.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Ensures auto hyphens on headings in the `Card` component

--- a/.changeset/twelve-hats-jam.md
+++ b/.changeset/twelve-hats-jam.md
@@ -2,4 +2,4 @@
 '@obosbbl/grunnmuren-react': patch
 ---
 
-Ensures auto hyphens on headings in the `Card` component
+Add [hyphens: auto](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens) to Card headings to ensure they don't overflow the card container.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -20,7 +20,7 @@ const cardVariants = cva({
     '[&_[data-slot="heading"]]:w-fit',
     '[&_[data-slot="heading"]]:text-pretty',
     '[&_[data-slot="heading"]]:hyphens-auto',
-    '[&_[data-slot="heading"]]:[word-break:break-word]',
+    '[&_[data-slot="heading"]]:[word-break:break-word]', // necessary to make hyphens work in grid containers in Safari
 
     // **** Content ****
     '[&_[data-slot="content"]]:grid [&_[data-slot="content"]]:auto-rows-max [&_[data-slot="content"]]:gap-y-4',
@@ -53,7 +53,7 @@ const cardVariants = cva({
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:leading-6',
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty',
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:hyphens-auto',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:[word-break:break-word]',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:[word-break:break-word]', // necessary to make hyphens work in grid containers in Safari
 
     // **** Fail-safe for interactive elements ****
     // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -19,6 +19,8 @@ const cardVariants = cva({
     '[&_[data-slot="heading"]]:leading-6', // A bit more line height than the default is necessary to make the underline align with the text if the heading has a card link
     '[&_[data-slot="heading"]]:w-fit',
     '[&_[data-slot="heading"]]:text-pretty',
+    '[&_[data-slot="heading"]]:hyphens-auto',
+    '[&_[data-slot="heading"]]:[word-break:break-word]',
 
     // **** Content ****
     '[&_[data-slot="content"]]:grid [&_[data-slot="content"]]:auto-rows-max [&_[data-slot="content"]]:gap-y-4',
@@ -47,7 +49,11 @@ const cardVariants = cva({
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:transition-colors',
     '[&_[data-slot="heading"]_[data-slot="card-link"]:hover]:border-b-current',
     // Mimic heading styles for the card link if placed in the heading slot. This is necessary to make the custom underline align with the link text
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:heading-s [&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty [&_[data-slot="heading"]_[data-slot="card-link"]]:leading-6',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:heading-s',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:leading-6',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:hyphens-auto',
+    '[&_[data-slot="heading"]_[data-slot="card-link"]]:[word-break:break-word]',
 
     // **** Fail-safe for interactive elements ****
     // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole


### PR DESCRIPTION
## Auto hypens on Card heading

Enables auto hyphens on card headings, to prevent overflow in narrow cards or headings with longer words. Adds the necessary classes both on the `heading` slot and the`card-link` slot, to make it work with and without interactive headings (where the content is wrapped in a `card-link`).

To make this work in Safari and FF we need to set `word-break: break-word`.

## Non-interactive heading
<img width="321" alt="Screenshot 2024-12-11 at 14 42 34" src="https://github.com/user-attachments/assets/737c4977-a588-43c0-9ef2-d0edaca72a85" />


## Interactive heading
<img width="298" alt="Screenshot 2024-12-11 at 14 43 05" src="https://github.com/user-attachments/assets/dbfbc3da-2188-4d49-8b87-fb6197b4450c" />
