### PR TITLE
fix: add forwardRef to Content and Heading components

### DIFF
--- a/.changeset/gold-owls-call.md
+++ b/.changeset/gold-owls-call.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+add forwardRef to Content and Heading. Fixes issue with these components in Next 15 and React 19.

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,4 +1,4 @@
-import { type HTMLProps, type Ref, createContext } from 'react';
+import { type HTMLProps, type Ref, createContext, forwardRef } from 'react';
 import { type ContextValue, useContextProps } from 'react-aria-components';
 
 type HeadingProps = HTMLProps<HTMLHeadingElement> & {
@@ -66,12 +66,16 @@ type FooterProps = HTMLProps<HTMLDivElement> & {
 
 const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
+
+const _Heading = forwardRef(Heading);
+const _Content = forwardRef(Content);
+
 export {
   type HeadingProps,
-  Heading,
+  _Heading as Heading,
   HeadingContext,
   type ContentProps,
-  Content,
+  _Content as Content,
   ContentContext,
   type MediaProps,
   Media,

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -66,7 +66,6 @@ type FooterProps = HTMLProps<HTMLDivElement> & {
 
 const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
-
 const _Heading = forwardRef(Heading);
 const _Content = forwardRef(Content);
 


### PR DESCRIPTION
Trodde dette egentlig ble fikset av https://github.com/code-obos/grunnmuren/pull/1054, men viste seg at problemet var at disse komponentene aldri ble wrappet av forwardRef, og dermed ble typesignaturen off...

Dette burde fungere nå. Verifisert ved at @theodorSchei har testet output etter denne fiksen på sin maskin hvor han fortsatt hadde dette issuet.