### PR TITLE
Enforce formatting on docgen output file

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,7 @@
     "build": "pnpm build:assets && pnpm build:docgen && pnpm build:app",
     "build:app": "vinxi build",
     "build:assets": "mkdir -p public/resources/icons && cp -r node_modules/@obosbbl/grunnmuren-icons-svg/src/ public/resources/icons",
-    "build:docgen": "node build-docs.js && prettier --write docgen.ts",
+    "build:docgen": "node build-docs.js && prettier --write docgen.ts --ignore-path",
     "dev": "vinxi dev",
     "start": "vinxi start"
   },


### PR DESCRIPTION
## Enforce formatting in docgen script

Workaround to bypass `gitignore` on the `docgen` output file. The `--ignore-path` option unsets the default ignore (`.prettierignore` and `.gitignore`). Since this command is only executed on this file alone, we can safely bypass the ignore files.

This solves a problem discussed here https://github.com/code-obos/grunnmuren/pull/1059#discussion_r1888624791