### PR TITLE
ci: fix release action after github registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: 22.x
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm --filter "./packages/**" install --frozen-lockfile
 
       - name: Create Release Pull Request
         uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1.4.9


### PR DESCRIPTION
Release workflowen feilet etter at vi la inn @code-obos pakker i docs-appen.

I teorien kan vi endre workflowen til at den er satt opp med github registry i setup-node reusable workflow, men samtidig så trenger release kun å forholde seg til packages (som ikke benytter noen private pakker), ikke docs appen.

Prøver dermed dette for å se om det fungerer. Kanskje det shaver av litt tid også?