### PR TITLE
Fix code snippets

### DIFF
--- a/apps/docs/app/routes/_docs/komponenter/badge.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/badge.tsx
@@ -22,56 +22,44 @@ const colors = [
 const examples = [
   {
     title: 'Badge',
-    code: (
-      <>
-        {colors.map((color) => (
-          <Badge color={color} key={color}>
-            {color}
-          </Badge>
-        ))}
-      </>
-    ),
+    code: `
+<>
+${colors.map((color) => `    <Badge color="${color}">${color}</Badge>`).join('\n')}
+</>
+    `,
   },
   ...colors.map((color) => ({
     title: color.charAt(0).toUpperCase() + color.slice(1),
-    code: (
-      <div
-        className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}
-        key={color}
-      >
-        <Badge color={color} size="small">
-          small
-        </Badge>
-        <Badge color={color} size="medium">
-          medium
-        </Badge>
-        <Badge color={color} size="large">
-          large
-        </Badge>
-      </div>
-    ),
+    code: `
+<div className="${cx('space-x-4 p-2', color === 'white' && 'bg-gray')}">
+  <Badge color="${color}" size="small">
+    small
+  </Badge>
+  <Badge color="${color}" size="medium">
+    medium
+  </Badge>
+  <Badge color="${color}" size="large">
+    large
+  </Badge>
+</div>`,
   })),
   ...colors.map((color) => ({
     title: `${color.charAt(0).toUpperCase() + color.slice(1)} med ikon`,
-    code: (
-      <div
-        className={cx('space-x-4 p-2', color === 'white' && 'bg-gray')}
-        key={color}
-      >
-        <Badge color={color} size="small">
-          <PaintRoller />
-          small
-        </Badge>
-        <Badge color={color} size="medium">
-          <PaintRoller />
-          medium
-        </Badge>
-        <Badge color={color} size="large">
-          <PaintRoller />
-          large
-        </Badge>
-      </div>
-    ),
+    code: `
+<div className="${cx('space-x-4 p-2', color === 'white' && 'bg-gray')}">
+  <Badge color="${color}" size="small">
+    <PaintRoller />
+    small
+  </Badge>
+  <Badge color="${color}" size="medium">
+    <PaintRoller />
+    medium
+  </Badge>
+  <Badge color="${color}" size="large">
+    <PaintRoller />
+    large
+  </Badge>
+</div>`,
   })),
 ];
 

--- a/apps/docs/app/routes/_docs/komponenter/button.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/button.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/_docs/komponenter/button')({
 });
 
 const examples = [
-  { title: 'Knapp', code: `<Button>Knapp</Button>` },
+  { title: 'Knapp', code: '<Button>Knapp</Button>' },
   {
     title: 'Lenke-knapp',
     code: `<Button href="#link">Lenke-knapp</Button>`,

--- a/apps/docs/app/routes/_docs/komponenter/button.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/button.tsx
@@ -10,134 +10,134 @@ export const Route = createFileRoute('/_docs/komponenter/button')({
 });
 
 const examples = [
-  { title: 'Knapp', code: <Button>Knapp</Button> },
+  { title: 'Knapp', code: `<Button>Knapp</Button>` },
   {
     title: 'Lenke-knapp',
-    code: <Button href="#link">Lenke-knapp</Button>,
+    code: `<Button href="#link">Lenke-knapp</Button>`,
   },
   {
     title: 'Primærknapp',
-    code: (
-      <>
-        <Button variant="primary">Primærknapp</Button>
-        <Button variant="primary" href="#primary-cta">
-          Primærlink
-        </Button>
-      </>
-    ),
+    code: `
+<>
+  <Button variant="primary">Primærknapp</Button>
+  <Button variant="primary" href="#primary-cta">
+    Primærlink
+  </Button>
+</>
+`,
   },
   {
     title: 'Sekundærknapp',
-    code: (
-      <>
-        <Button variant="secondary">Sekundærknapp</Button>
-        <Button variant="secondary" href="#secondary-cta">
-          Sekundærlink
-        </Button>
-      </>
-    ),
+    code: `
+<>
+  <Button variant="secondary">Sekundærknapp</Button>
+  <Button variant="secondary" href="#secondary-cta">
+    Sekundærlink
+  </Button>
+</>
+     `,
   },
   {
     title: 'Tertiærknapp',
-    code: (
-      <>
-        <Button variant="tertiary">Tertiærknapp</Button>
-        <Button variant="tertiary" href="#tertiary-cta">
-          Tertiærlink
-        </Button>
-      </>
-    ),
+    code: `
+<>
+  <Button variant="tertiary">Tertiærknapp</Button>
+  <Button variant="tertiary" href="#tertiary-cta">
+    Tertiærlink
+  </Button>
+</>
+   `,
   },
   {
     title: 'Knapp med ikon og tekst',
-    code: (
-      <>
-        <Button>
-          <Edit />
-          Rediger
-        </Button>
-        <Button href="#search">
-          <Search />
-          Søk
-        </Button>
-      </>
-    ),
+    code: `
+<>
+  <Button>
+    <Edit />
+    Rediger
+  </Button>
+  <Button href="#search">
+    <Search />
+    Søk
+  </Button>
+</>
+      `,
   },
   {
     title: 'Knapp med kun ikon',
-    code: (
-      <Button isIconOnly aria-label="Søk">
-        <Search />
-      </Button>
-    ),
+    code: `
+<Button isIconOnly aria-label="Søk">
+  <Search />
+</Button>
+ `,
   },
   {
     title: 'Knapp med pending-tilstand',
-    code: (
-      <>
-        <Button isPending variant="primary">
-          Primærknapp
-        </Button>
-        <Button isPending variant="secondary">
-          Sekundærknapp
-        </Button>
-        <Button isPending variant="tertiary">
-          Tertiærknapp
-        </Button>
-      </>
-    ),
+    code: `
+<>
+  <Button isPending variant="primary">
+    Primærknapp
+  </Button>
+  <Button isPending variant="secondary">
+    Sekundærknapp
+  </Button>
+  <Button isPending variant="tertiary">
+    Tertiærknapp
+  </Button>
+</>
+      `,
   },
   {
     title: 'Transparent bakgrunn',
-    code: (
-      <>
-        <Button variant="primary">Primærknapp</Button>
-        <Button variant="secondary">Sekundærknapp</Button>
-        <Button variant="tertiary">Tertiærknapp</Button>
-      </>
-    ),
+    code: `
+<>
+  <Button variant="primary">Primærknapp</Button>
+  <Button variant="secondary">Sekundærknapp</Button>
+  <Button variant="tertiary">Tertiærknapp</Button>
+</>
+`,
   },
   {
     title: 'Lys bakgrunn',
-    code: (
-      <div className="flex gap-x-[inherit] bg-mint-lightest p-8">
-        <Button variant="primary">Primærknapp</Button>
-        <Button variant="secondary">Sekundærknapp</Button>
-        <Button variant="tertiary">Tertiærknapp</Button>
-      </div>
-    ),
+    code: `
+<div className="flex gap-x-[inherit] bg-mint-lightest p-8">
+  <Button variant="primary">Primærknapp</Button>
+  <Button variant="secondary">Sekundærknapp</Button>
+  <Button variant="tertiary">Tertiærknapp</Button>
+</div>
+  `,
   },
   {
     title: 'Grønn bakgrunn',
-    code: (
-      <div className="flex gap-x-[inherit] bg-green-dark p-8">
-        <Button variant="primary" color="mint">
-          Primærknapp
-        </Button>
-        <Button variant="secondary" color="mint">
-          Sekundærknapp
-        </Button>
-        <Button variant="tertiary" color="mint">
-          Tertiærknapp
-        </Button>
-      </div>
-    ),
+    code: `
+<div className="flex gap-x-[inherit] bg-green-dark p-8">
+  <Button variant="primary" color="mint">
+    Primærknapp
+  </Button>
+  <Button variant="secondary" color="mint">
+    Sekundærknapp
+  </Button>
+  <Button variant="tertiary" color="mint">
+    Tertiærknapp
+  </Button>
+</div>
+`,
   },
   {
     title: 'Blå bakgrunn',
-    code: (
-      <div className="flex gap-x-[inherit] bg-blue-dark p-8">
-        <Button variant="primary" color="mint">
-          Primærknapp
-        </Button>
-        <Button variant="secondary" color="mint">
-          Sekundærknapp
-        </Button>
-        <Button variant="tertiary" color="mint">
-          Tertiærknapp
-        </Button>
-      </div>
-    ),
+    code: `
+<div className="flex gap-x-[inherit] bg-blue-dark p-8">
+  <Button variant="primary" color="mint">
+    Primærknapp
+  </Button>
+  <Button variant="secondary" color="mint">
+    Sekundærknapp
+  </Button>
+  <Button variant="tertiary" color="mint">
+    Tertiærknapp
+  </Button>
+</div>
+      `,
   },
 ];
 

--- a/apps/docs/app/ui/component-preview.tsx
+++ b/apps/docs/app/ui/component-preview.tsx
@@ -8,7 +8,8 @@ import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
 
 type ComponentPreviewProps = {
   title: string;
-  code: React.ReactNode;
+  /** @alpha - Passing a React.ReactNode is currently not compatible with React 19, pass a string to make it work with React 19 until react-element-to-jsx-string supports React 19  */
+  code: React.ReactNode | string;
   /** All custom components that are rendered must be present in the scope */
   scope: Partial<typeof GrunnmurenIconsScope & typeof GrunnmurenScope>;
 };
@@ -19,7 +20,9 @@ export const ComponentPreview = ({
   scope,
 }: ComponentPreviewProps) => {
   // Keep of the code string in state to be able to copy it
-  const [codeString, setCodeString] = useState(reactElementToJSXString(code));
+  const [codeString, setCodeString] = useState(
+    typeof code === 'string' ? code : reactElementToJSXString(code),
+  );
 
   const [hasCopied, setHasCopied] = useState(false);
   return (


### PR DESCRIPTION
## Fix code snippets 

Our `<ComponentPreview>` component relies on `react-element-to-jsx-string`, that currently doesn't support React 19. So passing a React.Element to the code prop will just render every JSX element as `<UnknownElementType>`.

 There is work in progress on adding support for React 19 in `react-element-to-jsx-string`: https://github.com/algolia/react-element-to-jsx-string/pull/865.

Until that is in place we can use strings for the code snippets. By allowing strings for the `code` prop in `<ComponentPreview>` we support both JSX and string snippets. This makes it possible to work around the problem by passing strings for now (short term), and also makes the API  more flexible (long term).

The drawback of using strings is that we don't get auto formatting and no help from TypeScript. But since this is just an temporary fix to make the code snippets work. It feels like a fair trade off.