### PR TITLE
Support all RAC link props on CardLink

### DIFF
--- a/.changeset/grumpy-ducks-turn.md
+++ b/.changeset/grumpy-ducks-turn.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Adding support for all RAC Link props on the CardLink component. This makes it possible to pass props like `onPress` and other events, which again enables tracking and so on.

--- a/.changeset/grumpy-ducks-turn.md
+++ b/.changeset/grumpy-ducks-turn.md
@@ -1,5 +1,5 @@
 ---
-'@obosbbl/grunnmuren-react': minor
+'@obosbbl/grunnmuren-react': patch
 ---
 
 Adding support for all RAC Link props on the CardLink component. This makes it possible to pass props like `onPress` and other events, which again enables tracking and so on.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -1,5 +1,5 @@
 import { type VariantProps, cva } from 'cva';
-import { Link, type LinkProps } from 'react-aria-components';
+import { Link, type LinkProps as RACLinkProps } from 'react-aria-components';
 
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
@@ -101,16 +101,16 @@ const Card = ({
   );
 };
 
-type RACLinkProps = Pick<LinkProps, 'href' | 'routerOptions' | 'children'>;
-
-type CardLinkWrapperProps = RACLinkProps & {
-  // Override children type of LinkProps as it also allows a callback which is not allowed in HTMLProps
-  children: React.ReactNode;
+type CardLinkWrapperProps = {
+  children?: React.ReactNode;
+  className?: string;
+} & {
+  [K in keyof Omit<RACLinkProps, 'className' | 'children'>]?: never;
 };
 
-type CardLinkProps = {
-  className?: string;
-} & (RACLinkProps | CardLinkWrapperProps);
+type CardLinkProps =
+  | (Omit<RACLinkProps, 'href'> & { href: string })
+  | CardLinkWrapperProps;
 
 const cardLinkVariants = cva({
   base: 'w-fit max-w-full',
@@ -168,7 +168,7 @@ const CardLink = ({
   return href ? (
     <Link
       data-slot="card-link"
-      {...restProps}
+      {...(restProps as RACLinkProps)}
       href={href}
       className={className}
     />
@@ -177,9 +177,9 @@ const CardLink = ({
     // because it still renders with role="link" and tabindex="0" which makes it focusable.
     // So we need to render a div instead.
     <div
+      {...(restProps as CardLinkWrapperProps)}
       data-slot="card-link"
       className={className}
-      {...(restProps as CardLinkWrapperProps)}
     />
   );
 };

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -108,8 +108,10 @@ type CardLinkWrapperProps = {
   [K in keyof Omit<RACLinkProps, 'className' | 'children'>]?: never;
 };
 
+type S = Pick<RACLinkProps, 'href'>;
+
 type CardLinkProps =
-  | (Omit<RACLinkProps, 'href'> & { href: string })
+  | (Omit<RACLinkProps, 'href'> & Required<Pick<RACLinkProps, 'href'>>)
   | CardLinkWrapperProps;
 
 const cardLinkVariants = cva({


### PR DESCRIPTION
## Support all RAC link props on CardLink

Adds support for all RAC `<Link>` props on the `<CardLink>` component. This enables passing events such as `onPress` for tracking.

The type has been modified to allow either a `href` prop in combination with any other RAC Link prop, or no `href` with just `className` or `children` props. Thie ensures that the type safety matches the implementation: if a `href` is passed it renders as a `<Link>`, if not it renders as a `<div>`. Note that we we can't utilize that the `<Link>` component from react-aria-components renders as a `<span>` if it doesn't have a `href`, because it still renders with `role="link"` and `tabindex="0"` which makes it focusable and announced as a link by screen readers.