### PR TITLE
Support both static and dynamic code snippets

### DIFF
--- a/apps/docs/schema.json
+++ b/apps/docs/schema.json
@@ -663,7 +663,7 @@
     }
   },
   {
-    "name": "code-block",
+    "name": "live-code-block",
     "type": "type",
     "value": {
       "type": "object",
@@ -672,7 +672,38 @@
           "type": "objectAttribute",
           "value": {
             "type": "string",
-            "value": "code-block"
+            "value": "live-code-block"
+          }
+        },
+        "code": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "code"
+          },
+          "optional": true
+        },
+        "caption": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "static-code-block",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "static-code-block"
           }
         },
         "code": {
@@ -877,7 +908,22 @@
             },
             "rest": {
               "type": "inline",
-              "name": "code-block"
+              "name": "live-code-block"
+            }
+          },
+          {
+            "type": "object",
+            "attributes": {
+              "_key": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "rest": {
+              "type": "inline",
+              "name": "static-code-block"
             }
           }
         ]

--- a/apps/docs/studio/objects/content.ts
+++ b/apps/docs/studio/objects/content.ts
@@ -16,7 +16,8 @@ const content = defineType({
         { title: 'Quote', value: 'blockquote' },
       ],
     },
-    { type: 'code-block' },
+    { type: 'live-code-block' },
+    { type: 'static-code-block' },
   ],
 });
 

--- a/apps/docs/studio/objects/live-code-block.ts
+++ b/apps/docs/studio/objects/live-code-block.ts
@@ -1,10 +1,10 @@
 import { defineField, defineType } from 'sanity';
 
 const codeBlock = defineType({
-  name: 'code-block',
-  title: 'Code Block',
+  name: 'live-code-block',
+  title: 'Live Code Block',
   description:
-    "Great for simple code snippets that doesn't vary based on the language selected",
+    "For editable code snippets that also can control rendering. Use 'Static Code Block' for static, non editable code snippets.",
   type: 'object',
   fields: [
     defineField({
@@ -13,11 +13,9 @@ const codeBlock = defineType({
       type: 'code',
       options: {
         language: 'tsx',
-        languageAlternatives: [
-          { title: 'TypeScript / React', value: 'tsx' },
-          { title: 'Bash', value: 'bash' },
-        ],
+        languageAlternatives: [{ title: 'TypeScript / React', value: 'tsx' }],
       },
+      validation: (rule) => rule.required(),
     }),
     defineField({
       name: 'caption',

--- a/apps/docs/studio/objects/static-code-block.ts
+++ b/apps/docs/studio/objects/static-code-block.ts
@@ -1,0 +1,37 @@
+import { defineField, defineType } from 'sanity';
+
+const codeBlock = defineType({
+  name: 'static-code-block',
+  title: 'Static Code Block',
+  description:
+    "Great for simple code snippets that doesn't vary based on the language selected",
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'code',
+      title: 'Code',
+      type: 'code',
+      options: {
+        language: 'tsx',
+        languageAlternatives: [
+          { title: 'TypeScript / React', value: 'tsx' },
+          { title: 'Bash', value: 'bash' },
+        ],
+      },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'caption',
+      title: 'Caption',
+      description: 'A description or summary of the code',
+      type: 'string',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'caption',
+    },
+  },
+});
+
+export { codeBlock as default };

--- a/apps/docs/studio/schema-types.ts
+++ b/apps/docs/studio/schema-types.ts
@@ -1,6 +1,7 @@
 import component from './documents/component';
-import codeBlock from './objects/code-block';
+import staticCodeBlock from './objects/static-code-block';
+import liveCodeBlock from './objects/live-code-block';
 import content from './objects/content';
 
 // Export an array of all the schema types.  This is used in the Sanity Studio configuration. https://www.sanity.io/docs/schema-types
-export const schemaTypes = [component, content, codeBlock];
+export const schemaTypes = [component, content, staticCodeBlock, liveCodeBlock];

--- a/apps/docs/studio/schema-types.ts
+++ b/apps/docs/studio/schema-types.ts
@@ -1,7 +1,7 @@
 import component from './documents/component';
-import staticCodeBlock from './objects/static-code-block';
-import liveCodeBlock from './objects/live-code-block';
 import content from './objects/content';
+import liveCodeBlock from './objects/live-code-block';
+import staticCodeBlock from './objects/static-code-block';
 
 // Export an array of all the schema types.  This is used in the Sanity Studio configuration. https://www.sanity.io/docs/schema-types
 export const schemaTypes = [component, content, staticCodeBlock, liveCodeBlock];


### PR DESCRIPTION
## Static and dynamic code snippets

Adds two separate implementations of the code-block field: _static_ and _dynamic_.

### Static
Static code blocks renders as simple code snippets that don't control rendering or allows for live editing.
This is handy for simple getting started scripts like:

``` bash
pnpm i @obosbbl/grunnmuren-react
```

### Dynamic
Dynamic code blocks renders as code snippets that can control rendering and allows for live editing/live updates.
This is handy for demo examples where you want to render a component based on the code snippet:

``` tsx
  <Badge color="blue" size="large">
    large
  </Badge>
```