### PR TITLE
Fix href types

### DIFF
--- a/.changeset/lazy-ducks-roll.md
+++ b/.changeset/lazy-ducks-roll.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Base `href` prop on `<Backlink>`, `<Breadcrumb>` and `<Button>` to enable type safe routes.

--- a/packages/react/src/backlink/backlink.tsx
+++ b/packages/react/src/backlink/backlink.tsx
@@ -1,14 +1,19 @@
 import { ChevronLeft } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { type Ref, forwardRef } from 'react';
-import { Button, type ButtonProps, Link } from 'react-aria-components';
+import {
+  Button,
+  type ButtonProps,
+  Link,
+  type LinkProps as RACLinkProps,
+} from 'react-aria-components';
 
 type ButtonOrLinkProps = {
   children?: React.ReactNode;
   /** Additional CSS className for the element. */
   className?: string;
   /** Determines whether to use an anchor or a button for the Backlink */
-  href?: string;
+  href?: RACLinkProps['href'];
   /** To add a permanent underline on the link (not only on hover)
    * @default false
    */

--- a/packages/react/src/breadcrumbs/breadcrumb.tsx
+++ b/packages/react/src/breadcrumbs/breadcrumb.tsx
@@ -5,6 +5,7 @@ import {
   Link,
   Breadcrumb as RACBreadcrumb,
   type BreadcrumbProps as RACBreadcrumbProps,
+  type LinkProps as RACLinkProps,
 } from 'react-aria-components';
 
 type BreadcrumbProps = {
@@ -16,7 +17,7 @@ type BreadcrumbProps = {
   style?: React.CSSProperties;
 
   /** The URL to navigate to when clicking the breadcrumb. */
-  href?: string;
+  href?: RACLinkProps['href'];
 } & Omit<RACBreadcrumbProps, 'className' | 'style'>;
 
 function Breadcrumb(props: BreadcrumbProps, ref: Ref<HTMLLIElement>) {

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -115,7 +115,7 @@ const buttonVariants = cva({
 
 type ButtonOrLinkProps = VariantProps<typeof buttonVariants> & {
   children?: React.ReactNode;
-  href?: string;
+  href?: RACLinkProps['href'];
   /**
    * Display the button in a loading state
    * @deprecated Use isPending instead.


### PR DESCRIPTION
## Type safe routes on href prop

Adds support for type safe routes as values for the `href` prop on `<Backlink>`, `<Breadcrumb>` and `<Button>`.

By basing the `href` prop on the RAC `LinkProps` `href` property, we ensure that type safety works on routes:

<img width="228" alt="Screenshot 2025-01-08 at 18 37 39" src="https://github.com/user-attachments/assets/a693779f-2d0f-4432-abda-e1fda0cb83eb" />
<br/>
<img width="231" alt="Screenshot 2025-01-08 at 18 37 56" src="https://github.com/user-attachments/assets/613df2b6-1d50-4577-93e7-744198ea1141" />
<br/>
<img width="225" alt="Screenshot 2025-01-08 at 18 38 35" src="https://github.com/user-attachments/assets/0b8e9595-f35b-4116-8eef-135ec671768c" />
<br/>
<img width="306" alt="Screenshot 2025-01-08 at 18 38 57" src="https://github.com/user-attachments/assets/0de45e3a-5e7d-4fb0-9b91-b3ddba46ef35" />
<br/>
<img width="450" alt="Screenshot 2025-01-08 at 18 40 19" src="https://github.com/user-attachments/assets/8d80cb59-8369-493c-9787-394c745a361c" />
<br/>
<img width="372" alt="Screenshot 2025-01-08 at 18 41 03" src="https://github.com/user-attachments/assets/7b1363e0-e7f8-4900-89ef-0785e0a3ab3a" />