### PR TITLE
docs: run typecheck

### DIFF
--- a/apps/docs/app.config.ts
+++ b/apps/docs/app.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         }),
         enforce: 'pre',
       },
+      // @ts-expect-error errors due to transitive type only deps
       tsConfigPaths({
         projects: ['./tsconfig.json'],
       }),

--- a/apps/docs/app/routes/_docs/ikoner.tsx
+++ b/apps/docs/app/routes/_docs/ikoner.tsx
@@ -88,8 +88,9 @@ function IconCard({ iconName, Icon }) {
       <span className="block text-center text-sm">{iconName}</span>
       <Button
         variant="tertiary"
+        // @ts-expect-error how can we make this work when we've augmented grunnmuren with tanstack's router?
+        // In that case we don't want TSR's typesafty, because it's an external link. See https://github.com/adobe/react-spectrum/issues/6397
         href={downloadSvgLink}
-        // @ts-expect-error fix in Grunnmuren so we're allowed to pass download when href is set
         download
         className="ml-auto w-[44px]"
       >

--- a/apps/docs/app/routes/_docs/komponenter/index.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/index.tsx
@@ -29,7 +29,7 @@ function Page() {
         {components.map((component) => (
           <Card key={component._id} variant="outlined">
             <Heading level={2}>
-              {/* @ts-expect-error figure out how to make this typesafe. Seems like routerOptions doesn't accept params */}
+              {/* @ts-expect-error figure out how to make this typesafe. Seems like routerOptions doesn't accept params. See https://github.com/adobe/react-spectrum/issues/6587 */}
               <CardLink href={`/komponenter/${component.slug}`}>
                 {component.name}
               </CardLink>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm build:tsc && pnpm build:assets && pnpm build:docgen && pnpm build:app",
+    "build": "pnpm build:docgen && pnpm build:tsc && pnpm build:assets && pnpm build:app",
     "build:app": "vinxi build",
     "build:assets": "mkdir -p public/resources/icons && cp -r node_modules/@obosbbl/grunnmuren-icons-svg/src/ public/resources/icons",
     "build:docgen": "node build-docs.js && prettier --write docgen.ts --ignore-path",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,10 +6,11 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm build:assets && pnpm build:docgen && pnpm build:app",
+    "build": "pnpm build:tsc && pnpm build:assets && pnpm build:docgen && pnpm build:app",
     "build:app": "vinxi build",
     "build:assets": "mkdir -p public/resources/icons && cp -r node_modules/@obosbbl/grunnmuren-icons-svg/src/ public/resources/icons",
     "build:docgen": "node build-docs.js && prettier --write docgen.ts --ignore-path",
+    "build:tsc": "tsc",
     "dev": "vinxi dev",
     "start": "vinxi start",
     "typegen:extract": "sanity schema extract",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "strictNullChecks": true,
     "baseUrl": "./",
+    "noEmit": true,
     "paths": {
       "@/*": ["app/*"]
     }


### PR DESCRIPTION
TanStack Start kjører ikke TSC som en del av build, slik Next gjør.

Legger dermed inn dette selv. Dette hjelper oss også å sikre at vi ikke knekker ting i Grunnmuren, ref href på CardLink.

Måtte legge til noen ignores for å få dette til å funke. Og kunne fjerne en annen ignore etter https://github.com/code-obos/grunnmuren/pull/1082