### PR TITLE
WIP examples from sanity data

### DIFF
--- a/apps/docs/app/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/$slug.tsx
@@ -1,7 +1,6 @@
 import * as badgeExamples from '@/examples/badge';
 import * as buttonExamples from '@/examples/button';
 import { sanityFetch } from '@/lib/sanity';
-import { ComponentPreview } from '@/ui/component-preview';
 import { Content } from '@/ui/content';
 import { PropsTable } from '@/ui/props-table';
 import { createFileRoute, notFound } from '@tanstack/react-router';
@@ -45,10 +44,6 @@ function Page() {
       <h1 className="heading-l mb-12 mt-9">{data.name}</h1>
 
       <Content content={data.content ?? []} />
-
-      {examples.map(({ title, code }) => (
-        <ComponentPreview scope={scope} key={title} title={title} code={code} />
-      ))}
 
       <PropsTable props={componentProps} />
     </>

--- a/apps/docs/app/ui/component-preview.tsx
+++ b/apps/docs/app/ui/component-preview.tsx
@@ -7,25 +7,26 @@ import reactElementToJSXString from 'react-element-to-jsx-string';
 import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
 
 type ComponentPreviewProps = {
-  title: string;
+  caption: string;
   /** @alpha - Passing a React.ReactNode is currently not compatible with React 19, pass a string to make it work with React 19 until react-element-to-jsx-string supports React 19  */
   code: React.ReactNode | string;
 };
 
-export const ComponentPreview = ({ title, code }: ComponentPreviewProps) => {
+export const ComponentPreview = ({ caption, code }: ComponentPreviewProps) => {
   // Keep of the code string in state to be able to copy it
   const [codeString, setCodeString] = useState(
     typeof code === 'string' ? code : reactElementToJSXString(code),
   );
 
   const [hasCopied, setHasCopied] = useState(false);
+
   return (
     <LiveProvider
       code={codeString}
       scope={{ ...GrunnmurenIconsScope, ...GrunnmurenScope }}
       theme={themes.vsDark}
     >
-      <h3 className="heading-xs">{title}</h3>
+      <p>{caption}</p>
       <LivePreview className="my-4 flex gap-x-4" />
       <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
         <LiveEditor

--- a/apps/docs/app/ui/component-preview.tsx
+++ b/apps/docs/app/ui/component-preview.tsx
@@ -10,15 +10,9 @@ type ComponentPreviewProps = {
   title: string;
   /** @alpha - Passing a React.ReactNode is currently not compatible with React 19, pass a string to make it work with React 19 until react-element-to-jsx-string supports React 19  */
   code: React.ReactNode | string;
-  /** All custom components that are rendered must be present in the scope */
-  scope: Partial<typeof GrunnmurenIconsScope & typeof GrunnmurenScope>;
 };
 
-export const ComponentPreview = ({
-  title,
-  code,
-  scope,
-}: ComponentPreviewProps) => {
+export const ComponentPreview = ({ title, code }: ComponentPreviewProps) => {
   // Keep of the code string in state to be able to copy it
   const [codeString, setCodeString] = useState(
     typeof code === 'string' ? code : reactElementToJSXString(code),
@@ -26,41 +20,42 @@ export const ComponentPreview = ({
 
   const [hasCopied, setHasCopied] = useState(false);
   return (
-    <LiveProvider code={codeString} scope={scope} theme={themes.vsDark}>
-      <div className="my-8 grid gap-y-4">
-        <h2 className="heading-m">{title}</h2>
-        <hr />
-        <LivePreview className="flex gap-x-4" />
-        <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
-          <LiveEditor
-            tabMode="focus"
-            // Use the same black color as the background on the editor
-            className="row-span-2 font-mono"
-            onChange={(newCode) => setCodeString(newCode)}
-          />
-          <div className="relative text-mint">
-            <GrunnmurenScope.Button
-              onPress={() =>
-                navigator.clipboard.writeText(codeString).then(() => {
-                  setHasCopied(true);
-                  setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
-                })
-              }
-              variant="tertiary"
-            >
-              <GrunnmurenIconsScope.Documents />
-            </GrunnmurenScope.Button>
-            <span
-              className={cx(
-                'absolute right-2 top-full transition-opacity duration-100',
-                hasCopied ? 'opacity-100' : 'opacity-0',
-              )}
-              aria-hidden={!hasCopied}
-              role="alert"
-            >
-              Kopiert!
-            </span>
-          </div>
+    <LiveProvider
+      code={codeString}
+      scope={{ GrunnmurenIconsScope, GrunnmurenScope }}
+      theme={themes.vsDark}
+    >
+      <h3 className="heading-xs">{title}</h3>
+      <LivePreview className="flex gap-x-4" />
+      <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
+        <LiveEditor
+          tabMode="focus"
+          // Use the same black color as the background on the editor
+          className="row-span-2 font-mono"
+          onChange={(newCode) => setCodeString(newCode)}
+        />
+        <div className="relative text-mint">
+          <GrunnmurenScope.Button
+            onPress={() =>
+              navigator.clipboard.writeText(codeString).then(() => {
+                setHasCopied(true);
+                setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
+              })
+            }
+            variant="tertiary"
+          >
+            <GrunnmurenIconsScope.Documents />
+          </GrunnmurenScope.Button>
+          <span
+            className={cx(
+              'absolute right-2 top-full transition-opacity duration-100',
+              hasCopied ? 'opacity-100' : 'opacity-0',
+            )}
+            aria-hidden={!hasCopied}
+            role="alert"
+          >
+            Kopiert!
+          </span>
         </div>
       </div>
     </LiveProvider>

--- a/apps/docs/app/ui/component-preview.tsx
+++ b/apps/docs/app/ui/component-preview.tsx
@@ -22,11 +22,11 @@ export const ComponentPreview = ({ title, code }: ComponentPreviewProps) => {
   return (
     <LiveProvider
       code={codeString}
-      scope={{ GrunnmurenIconsScope, GrunnmurenScope }}
+      scope={{ ...GrunnmurenIconsScope, ...GrunnmurenScope }}
       theme={themes.vsDark}
     >
       <h3 className="heading-xs">{title}</h3>
-      <LivePreview className="flex gap-x-4" />
+      <LivePreview className="my-4 flex gap-x-4" />
       <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
         <LiveEditor
           tabMode="focus"

--- a/apps/docs/app/ui/content.tsx
+++ b/apps/docs/app/ui/content.tsx
@@ -1,5 +1,3 @@
-import { Edit, PaintRoller, Search } from '@obosbbl/grunnmuren-icons-react';
-import { Badge, Button } from '@obosbbl/grunnmuren-react';
 import { PortableText } from '@portabletext/react';
 import type { Content as IContent } from 'sanity.types';
 import { ComponentPreview } from './component-preview';
@@ -7,18 +5,14 @@ import { ComponentPreview } from './component-preview';
 const components = {
   types: {
     'live-code-block': ({ value }) => (
-      <ComponentPreview
-        scope={{ Badge, PaintRoller, Button, Edit, Search }}
-        title={value.caption}
-        code={value.code.code}
-      />
+      <ComponentPreview title={value.caption} code={value.code.code} />
     ),
   },
 };
 
 export function Content({ content }: { content: IContent }) {
   return (
-    <div>
+    <div className="prose">
       <PortableText value={content} components={components} />
     </div>
   );

--- a/apps/docs/app/ui/content.tsx
+++ b/apps/docs/app/ui/content.tsx
@@ -1,8 +1,8 @@
+import { Edit, PaintRoller, Search } from '@obosbbl/grunnmuren-icons-react';
+import { Badge, Button } from '@obosbbl/grunnmuren-react';
 import { PortableText } from '@portabletext/react';
 import type { Content as IContent } from 'sanity.types';
 import { ComponentPreview } from './component-preview';
-import { Badge, Button } from '@obosbbl/grunnmuren-react';
-import { PaintRoller, Edit, Search } from '@obosbbl/grunnmuren-icons-react';
 
 const components = {
   types: {

--- a/apps/docs/app/ui/content.tsx
+++ b/apps/docs/app/ui/content.tsx
@@ -5,7 +5,7 @@ import { ComponentPreview } from './component-preview';
 const components = {
   types: {
     'live-code-block': ({ value }) => (
-      <ComponentPreview title={value.caption} code={value.code.code} />
+      <ComponentPreview caption={value.caption} code={value.code.code} />
     ),
   },
 };

--- a/apps/docs/app/ui/content.tsx
+++ b/apps/docs/app/ui/content.tsx
@@ -1,11 +1,24 @@
 import { PortableText } from '@portabletext/react';
 import type { Content as IContent } from 'sanity.types';
+import { ComponentPreview } from './component-preview';
+import { Badge, Button } from '@obosbbl/grunnmuren-react';
+import { PaintRoller, Edit, Search } from '@obosbbl/grunnmuren-icons-react';
 
-const components = {};
+const components = {
+  types: {
+    'live-code-block': ({ value }) => (
+      <ComponentPreview
+        scope={{ Badge, PaintRoller, Button, Edit, Search }}
+        title={value.caption}
+        code={value.code.code}
+      />
+    ),
+  },
+};
 
 export function Content({ content }: { content: IContent }) {
   return (
-    <div className="prose">
+    <div>
       <PortableText value={content} components={components} />
     </div>
   );

--- a/apps/docs/app/ui/props-table.tsx
+++ b/apps/docs/app/ui/props-table.tsx
@@ -12,7 +12,7 @@ interface PropsTableProps {
 }
 
 export const PropsTable = ({ props }: PropsTableProps) => (
-  <table className="w-full">
+  <table className="my-12 w-full">
     <caption className="heading-m mb-2 text-left">Props</caption>
     <thead>
       <tr className="bg-sky-lightest text-left align-baseline *:px-3 *:py-2">


### PR DESCRIPTION
## Render code examples from Sanity data

Renders code examples for all components based on Sanity data.

A bit unsure if this is the path we want to go down.
By making the code "block content" we need to deal with it as portable text. This means we have define our own component type for the `PortableText` component. Since we also need to pass context to the `ComponentPreview`, we have agreed to just include all the Grunnmuren components in the `ComponentPreview` as a default. This way we can render any component, even as new components are added or some even deleted over time.

With this change we also affect the Button component, since they share the same render page (`$slug`). So this PR changes both those component docs to only render code examples from Santiy, and removes the hard coded ones.