### PR TITLE
Remove TS workaround on inert prop

### DIFF
--- a/.changeset/fuzzy-pillows-call.md
+++ b/.changeset/fuzzy-pillows-call.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Remove TS workaround on the `inert` prop in `<Accordion>`. This type has now been fixed in React 19: https://github.com/facebook/react/issues/17157#issuecomment-2003750544 (prior to React 19, `inert` was not accepted as boolean)

--- a/packages/react/src/accordion/accordion.tsx
+++ b/packages/react/src/accordion/accordion.tsx
@@ -146,8 +146,7 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
                 // Uses pseudo element for vertical padding, since that doesn't affect the height when the accordion is closed
                 'text-sm font-light leading-6 px-3.5 relative overflow-hidden border-mint border-l-[3px] before:relative before:block before:h-1.5 after:relative after:block after:h-1.5',
               role: 'region',
-              // @ts-expect-error TODO: remove this expect-error when we're on React 19 https://github.com/facebook/react/issues/17157#issuecomment-2003750544
-              inert: isOpen ? undefined : 'true',
+              inert: isOpen,
               'aria-labelledby': buttonId,
               _outerWrapper: (children) => (
                 <div


### PR DESCRIPTION
## Remove TS workaround on inert

Removes the TS workaround for the `inert` prop in the `<Accordion>` implementation. This has been fixed in React 19.

This PR can not be merged until we have dropped support for React 18.

- [x] We have dropped support for React 18 