### PR TITLE
Make it easier to style cards

### DIFF
--- a/.changeset/two-moles-watch.md
+++ b/.changeset/two-moles-watch.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Change layout from grid to flex on `<Card>`, as this makes styling easier. Handy if you have Card content of variable size but need to display a set of Cards with the same height.

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -279,36 +279,71 @@ export const ClickableWithBackgroundAndCTA = () => (
 );
 
 export const ClickableWithOtherClickableElements = () => (
-  <Card variant="outlined" className="w-72">
-    <Media>
-      <img
-        alt=""
-        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
-      />
-    </Media>
-    <Content>
-      <div className="grid gap-1">
-        <Heading level={3}>
-          <CardLink href="#card">Rødbergvn 88C</CardLink>
-        </Heading>
-        <small className="description">Bjerke - Oslo</small>
-      </div>
-      <small className="description -order-1">
-        Forhåndsvarsling - Saksnr. F0347565
-      </small>
-      <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
-      <p className="flex gap-x-1">
-        <House /> Rekkehus/småhus
-      </p>
-      <p className="flex gap-x-1">
-        <Bed /> 3 soverom
-      </p>
-      <p className="flex gap-x-1">
-        <PiggyBank /> Totalpris 9 989 838
-      </p>
-      <Badge size="small" color="mint">
-        Visning 13. oktober
-      </Badge>
+  <div className="flex gap-10">
+    <Card variant="outlined" className="w-72">
+      <Media>
+        <img
+          alt=""
+          src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
+        />
+      </Media>
+      <Content className="flex-grow">
+        <div className="grid gap-1">
+          <Heading level={3}>
+            <CardLink href="#card">Rødbergvn 88C</CardLink>
+          </Heading>
+          <small className="description">Bjerke - Oslo</small>
+        </div>
+        <small className="description -order-1">
+          Forhåndsvarsling - Saksnr. F0347565
+        </small>
+        <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
+        <p className="flex gap-x-1">
+          <House /> Rekkehus/småhus
+        </p>
+        <p className="flex gap-x-1">
+          <Bed /> 3 soverom
+        </p>
+        <p className="flex gap-x-1">
+          <PiggyBank /> Totalpris 9 989 838
+        </p>
+        <Badge size="small" color="mint">
+          Visning 13. oktober
+        </Badge>
+        <Footer className="relative grid gap-y-2">
+          <hr className="border-t border-t-current" />
+          <Button href="#other-link" variant="tertiary">
+            Se prospekt
+            <Documents />
+          </Button>
+        </Footer>
+      </Content>
+    </Card>
+    <Card variant="outlined" className="w-72">
+      <Media>
+        <img
+          alt=""
+          src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
+        />
+      </Media>
+      <Content className="flex-grow">
+        <div className="grid gap-1">
+          <Heading level={3}>
+            <CardLink href="#card">Rødbergvn 88C</CardLink>
+          </Heading>
+          <small className="description">Bjerke - Oslo</small>
+        </div>
+        <small className="description -order-1">
+          Forhåndsvarsling - Saksnr. F0347565
+        </small>
+        <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
+        <p className="flex gap-x-1">
+          <House /> Rekkehus/småhus
+        </p>
+        <Badge size="small" color="mint">
+          Visning 13. oktober
+        </Badge>
+      </Content>
       <Footer className="relative grid gap-y-2">
         <hr className="border-t border-t-current" />
         <Button href="#other-link" variant="tertiary">
@@ -316,8 +351,8 @@ export const ClickableWithOtherClickableElements = () => (
           <Documents />
         </Button>
       </Footer>
-    </Content>
-  </Card>
+    </Card>
+  </div>
 );
 
 export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
@@ -351,17 +386,17 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
       <Badge size="small" color="mint" className="text-black">
         Visning 13. oktober
       </Badge>
-      <Footer className="relative grid gap-y-2">
-        <hr className="border-t border-t-current" />
-        <Button
-          href="#other-link"
-          variant="tertiary"
-          className="focus-visible:outline-current"
-        >
-          Se prospekt
-          <Documents />
-        </Button>
-      </Footer>
     </Content>
+    <Footer className="relative grid gap-y-2">
+      <hr className="border-t border-t-current" />
+      <Button
+        href="#other-link"
+        variant="tertiary"
+        className="focus-visible:outline-current"
+      >
+        Se prospekt
+        <Documents />
+      </Button>
+    </Footer>
   </Card>
 );

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -319,39 +319,6 @@ export const ClickableWithOtherClickableElements = () => (
         </Footer>
       </Content>
     </Card>
-    <Card variant="outlined" className="w-72">
-      <Media>
-        <img
-          alt=""
-          src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
-        />
-      </Media>
-      <Content className="flex-grow">
-        <div className="grid gap-1">
-          <Heading level={3}>
-            <CardLink href="#card">Rødbergvn 88C</CardLink>
-          </Heading>
-          <small className="description">Bjerke - Oslo</small>
-        </div>
-        <small className="description -order-1">
-          Forhåndsvarsling - Saksnr. F0347565
-        </small>
-        <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
-        <p className="flex gap-x-1">
-          <House /> Rekkehus/småhus
-        </p>
-        <Badge size="small" color="mint">
-          Visning 13. oktober
-        </Badge>
-      </Content>
-      <Footer className="relative grid gap-y-2">
-        <hr className="border-t border-t-current" />
-        <Button href="#other-link" variant="tertiary">
-          Se prospekt
-          <Documents />
-        </Button>
-      </Footer>
-    </Card>
   </div>
 );
 

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -10,7 +10,7 @@ const cardVariants = cva({
   base: [
     'group/card',
     'rounded-2xl border p-3',
-    'grid auto-rows-max gap-y-4',
+    'flex flex-col gap-y-4',
     'relative', // Needed for positiong of the clickable pseudo-element (and can also be used for other absolute positioned elements the consumer might add)
 
     // **** Heading ****
@@ -23,7 +23,7 @@ const cardVariants = cva({
     '[&_[data-slot="heading"]]:[word-break:break-word]', // necessary to make hyphens work in grid containers in Safari
 
     // **** Content ****
-    '[&_[data-slot="content"]]:grid [&_[data-slot="content"]]:auto-rows-max [&_[data-slot="content"]]:gap-y-4',
+    '[&_[data-slot="content"]]:flex [&_[data-slot="content"]]:flex-col [&_[data-slot="content"]]:gap-y-4',
 
     // **** Media ****
     '[&_[data-slot="media"]]:overflow-hidden', // Prevent content from overflowing the rounded corners


### PR DESCRIPTION
## Make it easier to style Card

Changes from grid to flex layout on the `<Card>` component. As this makes styling easier. Let's say for example if you have multiple Cards side by side, where you want them to have equal height. But the size of the content varies:

<img width="672" alt="Screenshot 2025-01-13 at 15 32 06" src="https://github.com/user-attachments/assets/af3057bc-2d12-449d-a049-646d6fd7888b" />

Also making a small adjustment on the examples with a footer, which makes more sense (if a layout like shown above is desired)

Without this change, you would typically end up dealing with this issue:

<img width="658" alt="Screenshot 2025-01-13 at 15 37 45" src="https://github.com/user-attachments/assets/1e62295f-9116-4b37-8683-6fb67a5a1f7c" />