### PR TITLE
Reduce font size to 14px

### DIFF
--- a/apps/docs/app/ui/props-table.tsx
+++ b/apps/docs/app/ui/props-table.tsx
@@ -5,7 +5,7 @@ interface PropsTableProps {
 }
 
 export const PropsTable = ({ componentName }: PropsTableProps) => (
-  <table className="my-8 w-full">
+  <table className="my-8 w-full text-sm">
     <caption className="heading-s mb-2 text-left">{componentName}</caption>
     <thead>
       <tr className="bg-sky-lightest text-left align-baseline *:px-3 *:py-2">


### PR DESCRIPTION
## Reduce font size on props table

Reduces font size for the props table to the same as the font size of the code example (`14px`/`0.875rem`)