### PR TITLE
Add NPM_TOKEN var

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@code-obos:registry=https://npm.pkg.github.com
+@code-obos://registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Another attempt to fix the broken release pipeline. Using recommended auth setup from the npm docs: [https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file)