### PR TITLE
ci: attempt to fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:netlify": "pnpm --filter @obosbbl/grunnmuren-icons-react build && pnpm build:storybook",
     "build:storybook": "storybook build",
     "ci:publish": "pnpm build && changeset publish",
-    "ci:version": "changeset version && pnpm install --lockfile-only",
+    "ci:version": "changeset version",
     "dev": "storybook dev -p 6006 --ci",
     "lint": "pnpm lint:biome && pnpm lint:format",
     "lint:biome": "pnpm biome check .",


### PR DESCRIPTION
Usikker på hvorfor dette repoet har det, men ingen andre vi har changesets har `install` som en del av `version`. Kan hende det har noe med prereleases/canary å gjøre, men vi gjør et forsøk uten..