### PR TITLE
Add component for static code snippets

### DIFF
--- a/apps/docs/app/ui/code.tsx
+++ b/apps/docs/app/ui/code.tsx
@@ -1,0 +1,76 @@
+import * as GrunnmurenIconsScope from '@obosbbl/grunnmuren-icons-react';
+import * as GrunnmurenScope from '@obosbbl/grunnmuren-react';
+import { cx } from 'cva';
+import { themes } from 'prism-react-renderer';
+import { useState } from 'react';
+import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
+
+export type CodeProps = {
+  value: string;
+  setValue?: (newCode: string) => void;
+  caption?: string;
+  /** @default false - Renders the code as a React component that is live editable */
+  withLivePreview?: boolean;
+  /** @default false - Makes the code editable */
+  isEditable?: boolean;
+};
+
+export const Code = ({
+  value,
+  setValue,
+  caption,
+  withLivePreview,
+  isEditable,
+}: CodeProps) => {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  const scope = withLivePreview
+    ? // Scope is only needed when rendering the live preview
+      { ...GrunnmurenIconsScope, ...GrunnmurenScope }
+    : undefined;
+
+  return (
+    <LiveProvider
+      code={value}
+      scope={scope}
+      theme={themes.vsDark}
+      disabled={!isEditable}
+    >
+      <p>{caption}</p>
+      {withLivePreview && (
+        <LivePreview className="not-prose my-4 flex gap-x-4" />
+      )}
+      {/* Use the same black color as the background on the editor (#1e1e1e)  */}
+      <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
+        <LiveEditor
+          tabMode="focus"
+          className="row-span-2 font-mono"
+          onChange={setValue}
+        />
+        <div className="relative text-mint">
+          <GrunnmurenScope.Button
+            onPress={() =>
+              navigator.clipboard.writeText(value).then(() => {
+                setHasCopied(true);
+                setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
+              })
+            }
+            variant="tertiary"
+          >
+            <GrunnmurenIconsScope.Documents />
+          </GrunnmurenScope.Button>
+          <span
+            className={cx(
+              'absolute right-2 top-full transition-opacity duration-100',
+              hasCopied ? 'opacity-100' : 'opacity-0',
+            )}
+            aria-hidden={!hasCopied}
+            role="alert"
+          >
+            Kopiert!
+          </span>
+        </div>
+      </div>
+    </LiveProvider>
+  );
+};

--- a/apps/docs/app/ui/component-preview.tsx
+++ b/apps/docs/app/ui/component-preview.tsx
@@ -1,64 +1,26 @@
-import * as GrunnmurenIconsScope from '@obosbbl/grunnmuren-icons-react';
-import * as GrunnmurenScope from '@obosbbl/grunnmuren-react';
-import { cx } from 'cva';
-import { themes } from 'prism-react-renderer';
 import { useState } from 'react';
 import reactElementToJSXString from 'react-element-to-jsx-string';
-import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
+import { Code } from './code';
 
 type ComponentPreviewProps = {
-  caption: string;
   /** @alpha - Passing a React.ReactNode is currently not compatible with React 19, pass a string to make it work with React 19 until react-element-to-jsx-string supports React 19  */
   code: React.ReactNode | string;
+  caption: string;
 };
 
-export const ComponentPreview = ({ caption, code }: ComponentPreviewProps) => {
-  // Keep of the code string in state to be able to copy it
+export const ComponentPreview = ({ code, caption }: ComponentPreviewProps) => {
+  // Keep of the code string in state to sync editing, copying and render preview
   const [codeString, setCodeString] = useState(
     typeof code === 'string' ? code : reactElementToJSXString(code),
   );
 
-  const [hasCopied, setHasCopied] = useState(false);
-
   return (
-    <LiveProvider
-      code={codeString}
-      scope={{ ...GrunnmurenIconsScope, ...GrunnmurenScope }}
-      theme={themes.vsDark}
-    >
-      <p>{caption}</p>
-      <LivePreview className="not-prose my-4 flex gap-x-4" />
-      <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
-        <LiveEditor
-          tabMode="focus"
-          // Use the same black color as the background on the editor
-          className="row-span-2 font-mono"
-          onChange={(newCode) => setCodeString(newCode)}
-        />
-        <div className="relative text-mint">
-          <GrunnmurenScope.Button
-            onPress={() =>
-              navigator.clipboard.writeText(codeString).then(() => {
-                setHasCopied(true);
-                setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
-              })
-            }
-            variant="tertiary"
-          >
-            <GrunnmurenIconsScope.Documents />
-          </GrunnmurenScope.Button>
-          <span
-            className={cx(
-              'absolute right-2 top-full transition-opacity duration-100',
-              hasCopied ? 'opacity-100' : 'opacity-0',
-            )}
-            aria-hidden={!hasCopied}
-            role="alert"
-          >
-            Kopiert!
-          </span>
-        </div>
-      </div>
-    </LiveProvider>
+    <Code
+      value={codeString}
+      setValue={setCodeString}
+      caption={caption}
+      withLivePreview
+      isEditable
+    />
   );
 };

--- a/apps/docs/app/ui/content.tsx
+++ b/apps/docs/app/ui/content.tsx
@@ -1,11 +1,11 @@
 import { PortableText } from '@portabletext/react';
 import { cx } from 'cva';
+import { themes } from 'prism-react-renderer';
+import { LiveEditor, LiveProvider } from 'react-live';
 import type { Content as IContent } from 'sanity.types';
 import { AnchorHeading } from './anchor-heading';
-import { ComponentPreview } from './component-preview';
-import { LiveEditor, LiveProvider } from 'react-live';
-import { themes } from 'prism-react-renderer';
 import { Code } from './code';
+import { ComponentPreview } from './component-preview';
 
 export type ContentProps = {
   content: IContent;

--- a/apps/docs/app/ui/content.tsx
+++ b/apps/docs/app/ui/content.tsx
@@ -3,6 +3,9 @@ import { cx } from 'cva';
 import type { Content as IContent } from 'sanity.types';
 import { AnchorHeading } from './anchor-heading';
 import { ComponentPreview } from './component-preview';
+import { LiveEditor, LiveProvider } from 'react-live';
+import { themes } from 'prism-react-renderer';
+import { Code } from './code';
 
 export type ContentProps = {
   content: IContent;
@@ -21,6 +24,9 @@ export function Content({ content, className }: ContentProps) {
                 caption={value.caption}
                 code={value.code.code}
               />
+            ),
+            'static-code-block': ({ value }) => (
+              <Code value={value.code.code as string} />
             ),
           },
           block: {


### PR DESCRIPTION
## Static code snippets

Extract code snippet into a new `<Code/>` component that can be used for both editable code snippets with live preview, and static code snippets.

Not completely happy with the API of `<Code/>`, as it sort of "magically" requires the value to be controlled when enabling live edit with preview (this is to keep the code value in sync if a user edits it, and then wants to copy it). Maybe it would be better to just move that state into the `<Code/>` component itself (removing it from `<ComponentPreivew/>`). But then again for static code examples would end up being set up with a state that never updates, which also feels wrong.

https://github.com/user-attachments/assets/4e8e17c3-158f-45de-9599-2eb1ce61a03b

