### PR TITLE
Add VideoLoop component

### DIFF
--- a/.changeset/mighty-candles-press.md
+++ b/.changeset/mighty-candles-press.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting. It ensures further accessiblity by requiering a visible or invisible description (`alt` or `caption`) of the video content.

--- a/.changeset/mighty-candles-press.md
+++ b/.changeset/mighty-candles-press.md
@@ -3,3 +3,21 @@
 ---
 
 Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting enabled. It ensures further accessibility by requiring a visible or invisible description (`alt` or `caption`) of the video content.
+
+Usage:
+
+``` tsx
+<VideoLoop
+    src="https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4"
+    format="mp4"
+    alt="Frysjaparken er moderne nabolag med flotte uteområder og en nydelig kafé"
+/>
+
+<Media>
+    <VideoLoop
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4"
+        format="mp4"
+    />
+    <Caption>Frysjaparken er moderne nabolag med flotte uteområder og en nydelig kafé</Caption>
+</Media>
+```

--- a/.changeset/mighty-candles-press.md
+++ b/.changeset/mighty-candles-press.md
@@ -2,4 +2,4 @@
 '@obosbbl/grunnmuren-react': minor
 ---
 
-Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting. It ensures further accessibility by requiring a visible or invisible description (`alt` or `caption`) of the video content.
+Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting enabled. It ensures further accessibility by requiring a visible or invisible description (`alt` or `caption`) of the video content.

--- a/.changeset/mighty-candles-press.md
+++ b/.changeset/mighty-candles-press.md
@@ -2,4 +2,4 @@
 '@obosbbl/grunnmuren-react': minor
 ---
 
-Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting. It ensures further accessibility by requiering a visible or invisible description (`alt` or `caption`) of the video content.
+Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting. It ensures further accessibility by requiring a visible or invisible description (`alt` or `caption`) of the video content.

--- a/.changeset/mighty-candles-press.md
+++ b/.changeset/mighty-candles-press.md
@@ -2,4 +2,4 @@
 '@obosbbl/grunnmuren-react': minor
 ---
 
-Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting. It ensures further accessiblity by requiering a visible or invisible description (`alt` or `caption`) of the video content.
+Adding a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting. It ensures further accessibility by requiering a visible or invisible description (`alt` or `caption`) of the video content.

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,3 +1,4 @@
+import { cx } from 'cva';
 import { type HTMLProps, type Ref, createContext, forwardRef } from 'react';
 import { type ContextValue, useContextProps } from 'react-aria-components';
 
@@ -64,20 +65,34 @@ type FooterProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
 };
 
+type CaptionProps = HTMLProps<HTMLDivElement> & {
+  children: React.ReactNode;
+};
+
+const Caption = ({ className, ...restProps }: CaptionProps) => (
+  <div
+    {...restProps}
+    className={cx('description', className)}
+    data-slot="caption"
+  />
+);
+
 const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
 const _Heading = forwardRef(Heading);
 const _Content = forwardRef(Content);
 
 export {
-  type HeadingProps,
-  _Heading as Heading,
-  HeadingContext,
-  type ContentProps,
+  Caption,
   _Content as Content,
   ContentContext,
-  type MediaProps,
-  Media,
-  type FooterProps,
   Footer,
+  _Heading as Heading,
+  HeadingContext,
+  Media,
+  type CaptionProps,
+  type ContentProps,
+  type FooterProps,
+  type HeadingProps,
+  type MediaProps,
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,3 +19,4 @@ export * from './breadcrumbs';
 export * from './backlink';
 export * from './card';
 export * from './date-formatter';
+export * from './video-loop';

--- a/packages/react/src/video-loop/index.ts
+++ b/packages/react/src/video-loop/index.ts
@@ -1,0 +1,1 @@
+export * from './video-loop';

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -1,0 +1,121 @@
+import { useLayoutEffect } from '@react-aria/utils';
+import { cx } from 'cva';
+import { useEffect, useRef, useState } from 'react';
+
+type VideoLoopPropsCommon = {
+  src: string;
+  format: string;
+  /** You may specify a visible caption, but if it is very similar to the alt text. Just a caption is sufficent.  */
+  caption?: string;
+  /** You may pass an alternative text, complimentary to the caption. Make sure it doesn't repeat too much of the caption text, if so just a caption is sufficent. Think of this just as an alt text, but for a muted video - this text will not be visible, but read by screen readers. */
+  alt?: string;
+  className?: string;
+  rounded?: boolean;
+};
+
+type VideoLoopPropsWithAlt = VideoLoopPropsCommon & {
+  alt: string;
+};
+
+type VideoLoopPropsWithCaption = VideoLoopPropsCommon & {
+  caption: string;
+};
+
+export type VideoLoopProps = VideoLoopPropsWithAlt | VideoLoopPropsWithCaption; // Either alt or caption is required
+
+export const VideoLoop = ({
+  src,
+  format,
+  caption,
+  alt,
+  className,
+  rounded,
+}: VideoLoopProps) => {
+  // We need to check if the user prefers reduced motion, so that we can prevent the video from autoplaying if so
+  const [userPrefersReducedMotion, setUserPrefersReducedMotion] = useState<
+    null | boolean
+  >(null);
+
+  useLayoutEffect(() => {
+    const { matches: userPrefersReducedMotion } = matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    );
+    setUserPrefersReducedMotion(userPrefersReducedMotion);
+    // Autoplay the video if the user does not prefer reduced motion
+    setShouldPlay(!userPrefersReducedMotion);
+  }, []);
+
+  // Control the video playback state, so that the user can pause and play the video at will
+  const [shouldPlay, setShouldPlay] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+
+    if (shouldPlay) {
+      // Follow google's autoplay policy: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
+      // "Don't assume a video will play, and don't show a pause button when the video is not actually playing."
+      // "You should always look at the Promise returned by the play function to see if it was rejected:"
+      // This is why we use the promise returned by the play function, and an extra state variable to determine if the video is actually playing or not
+      videoRef.current
+        .play()
+        .then(() => setIsPlaying(true))
+        .catch(() => setIsPlaying(false));
+    } else {
+      videoRef.current.pause();
+      setIsPlaying(false);
+    }
+  }, [shouldPlay]);
+
+  return (
+    <div className={className}>
+      <div className="relative aspect-video" aria-hidden>
+        {/* Don't render the video until we have determined if the user prefers reduced motion */}
+        {userPrefersReducedMotion !== null && (
+          <>
+            <video
+              ref={videoRef}
+              // cursor-pointer is not working on the button below, so we add it here for the same effect
+              className={cx('cursor-pointer', rounded && 'rounded-3xl')}
+              autoPlay={isPlaying}
+              loop={isPlaying}
+              playsInline={isPlaying}
+              muted
+            >
+              <source src={src} type={`video/${format}`} />
+            </video>
+            <button
+              type="button"
+              onClick={() => setShouldPlay((prevState) => !prevState)}
+              className={cx(
+                rounded && 'rounded-3xl', // Mirror the rounded prop from the parent div to align focus outline
+                'absolute bottom-0 left-0 right-0 top-0 m-auto grid place-items-center',
+                'focus-visible:outline-focus focus-visible:outline-focus-offset',
+                // Only show the pause button when the video is hovered or focused
+                isPlaying && [
+                  'opacity-0',
+                  'focus-visible:opacity-100',
+                  'transition-opacity duration-200',
+                  'hover:opacity-100',
+                ],
+              )}
+            >
+              <span
+                className={cx(
+                  'grid h-12 w-12 place-items-center rounded-full bg-white',
+                  'outline-none',
+                  isPlaying
+                    ? 'after:text-2xl after:content-["⏸"]'
+                    : 'after:absolute after:ml-0.5 after:h-0 after:w-0 after:border-b-8 after:border-l-[16px] after:border-t-8 after:border-transparent after:border-l-black',
+                )}
+              />
+            </button>
+          </>
+        )}
+      </div>
+      {caption && <p className="descrption mt-4">{caption}</p>}
+      {alt && <p className="sr-only">{alt}</p>}
+    </div>
+  );
+};

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -58,58 +58,57 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
   }, [shouldPlay]);
 
   return (
-    <>
-      <div
-        className={cx(
-          className,
-          'relative',
-          userPrefersReducedMotion === null && 'opacity-0',
-        )}
+    <div
+      className={cx(
+        className,
+        'relative',
+        userPrefersReducedMotion === null && 'opacity-0',
+      )}
+    >
+      <video
         aria-hidden
+        ref={videoRef}
+        // cursor-pointer is not working on the button below, so we add it here for the same effect
+        className="h-full w-full cursor-pointer object-cover"
+        playsInline
+        loop={userPrefersReducedMotion === false}
+        autoPlay={userPrefersReducedMotion === false}
+        muted
+        onEnded={(event) => {
+          if (userPrefersReducedMotion) {
+            // Reset the video to the beginning if the user prefers reduced motion, since the video will not loop
+            event.currentTarget.currentTime = 0;
+            setShouldPlay(false);
+            setIsPlaying(false);
+          }
+        }}
       >
-        <video
-          ref={videoRef}
-          // cursor-pointer is not working on the button below, so we add it here for the same effect
-          className="h-full w-full cursor-pointer object-cover"
-          playsInline
-          loop={userPrefersReducedMotion === false}
-          autoPlay={userPrefersReducedMotion === false}
-          muted
-          onEnded={(event) => {
-            if (userPrefersReducedMotion) {
-              // Reset the video to the beginning if the user prefers reduced motion, since the video will not loop
-              event.currentTarget.currentTime = 0;
-              setShouldPlay(false);
-              setIsPlaying(false);
-            }
-          }}
+        <source src={src} type={`video/${format}`} />
+      </video>
+      {userPrefersReducedMotion !== null && (
+        <button
+          aria-hidden
+          type="button"
+          onClick={() => setShouldPlay((prevState) => !prevState)}
+          className={cx(
+            'absolute bottom-0 left-0 right-0 top-0 m-auto grid place-items-center',
+            'focus-visible:outline-focus focus-visible:outline-focus-offset',
+            // Setting the opacity to 0 before applying the transition below will ensure the button only fades in after the video has started playing
+            shouldPlay && 'opacity-0',
+            isPlaying && [
+              'transition-opacity duration-200',
+              // Only show the pause button when the video is hovered or focused
+              'focus-visible:opacity-100',
+              'hover:opacity-100',
+            ],
+          )}
         >
-          <source src={src} type={`video/${format}`} />
-        </video>
-        {userPrefersReducedMotion !== null && (
-          <button
-            type="button"
-            onClick={() => setShouldPlay((prevState) => !prevState)}
-            className={cx(
-              'absolute bottom-0 left-0 right-0 top-0 m-auto grid place-items-center',
-              'focus-visible:outline-focus focus-visible:outline-focus-offset',
-              // Setting the opacity to 0 before applying the transition below will ensure the button only fades in after the video has started playing
-              shouldPlay && 'opacity-0',
-              isPlaying && [
-                'transition-opacity duration-200',
-                // Only show the pause button when the video is hovered or focused
-                'focus-visible:opacity-100',
-                'hover:opacity-100',
-              ],
-            )}
-          >
-            <span className="grid h-12 w-12 place-items-center rounded-full bg-white outline-none">
-              {isPlaying ? <PlayerPause /> : <PlayerPlay />}
-            </span>
-          </button>
-        )}
-      </div>
+          <span className="grid h-12 w-12 place-items-center rounded-full bg-white outline-none">
+            {isPlaying ? <PlayerPause /> : <PlayerPlay />}
+          </span>
+        </button>
+      )}
       {alt && <p className="sr-only">{alt}</p>}
-    </>
+    </div>
   );
 };

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -14,21 +14,10 @@ type VideoLoopProps = {
    * Think of this just as an alt text, but for a muted video - this text will not be visible, but read by screen readers.
    * */
   alt?: string;
-  /**
-   * Use this to provide a visible caption of the video content.
-   * It can be used as a brief summary of the video content. If using this, you might not need to provide an alt text.
-   * */
-  children?: React.ReactNode;
   className?: string;
 };
 
-export const VideoLoop = ({
-  src,
-  format,
-  alt,
-  children,
-  className,
-}: VideoLoopProps) => {
+export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
   // Control the video playback state, so that the user can pause and play the video at will, also control the video autoplay
   const [shouldPlay, setShouldPlay] = useState(false);
   // Needed to show the pause button when the video is actually playing (refer to google's autoplay policy: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes)
@@ -120,7 +109,6 @@ export const VideoLoop = ({
           </button>
         )}
       </div>
-      {children}
       {alt && <p className="sr-only">{alt}</p>}
     </>
   );

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -19,7 +19,6 @@ type VideoLoopProps = {
    * It can be used as a brief summary of the video content. If using this, you might not need to provide an alt text.
    * */
   children?: React.ReactNode;
-  /** @default aspect-video */
   className?: string;
 };
 
@@ -28,7 +27,7 @@ export const VideoLoop = ({
   format,
   alt,
   children,
-  className = 'aspect-video',
+  className,
 }: VideoLoopProps) => {
   // Control the video playback state, so that the user can pause and play the video at will, also control the video autoplay
   const [shouldPlay, setShouldPlay] = useState(false);
@@ -82,7 +81,7 @@ export const VideoLoop = ({
         <video
           ref={videoRef}
           // cursor-pointer is not working on the button below, so we add it here for the same effect
-          className="cursor-pointer h-full w-full object-cover"
+          className="h-full w-full cursor-pointer object-cover"
           playsInline
           loop={userPrefersReducedMotion === false}
           autoPlay={userPrefersReducedMotion === false}

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -82,7 +82,7 @@ export const VideoLoop = ({
         <video
           ref={videoRef}
           // cursor-pointer is not working on the button below, so we add it here for the same effect
-          className={cx('cursor-pointer', 'h-full w-full object-cover')}
+          className="cursor-pointer h-full w-full object-cover"
           playsInline
           loop={userPrefersReducedMotion === false}
           autoPlay={userPrefersReducedMotion === false}

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -81,7 +81,7 @@ export const VideoLoop = ({
               className={cx('cursor-pointer', rounded && 'rounded-3xl')}
               autoPlay={isPlaying}
               loop={isPlaying}
-              playsInline={isPlaying}
+              playsInline
               muted
             >
               <source src={src} type={`video/${format}`} />

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -1,3 +1,4 @@
+import { PlayerPause, PlayerPlay } from '@obosbbl/grunnmuren-icons-react';
 import { useLayoutEffect } from '@react-aria/utils';
 import { cx } from 'cva';
 import { useEffect, useRef, useState } from 'react';
@@ -101,15 +102,9 @@ export const VideoLoop = ({
                 ],
               )}
             >
-              <span
-                className={cx(
-                  'grid h-12 w-12 place-items-center rounded-full bg-white',
-                  'outline-none',
-                  isPlaying
-                    ? 'after:text-2xl after:content-["⏸"]'
-                    : 'after:absolute after:ml-0.5 after:h-0 after:w-0 after:border-b-8 after:border-l-[16px] after:border-t-8 after:border-transparent after:border-l-black',
-                )}
-              />
+              <span className="grid h-12 w-12 place-items-center rounded-full bg-white outline-none">
+                {isPlaying ? <PlayerPause /> : <PlayerPlay />}
+              </span>
             </button>
           </>
         )}

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -83,10 +83,10 @@ export const VideoLoop = ({
               playsInline
               muted
               loop={userPrefersReducedMotion === false}
-              onEnded={() => {
-                if (userPrefersReducedMotion && videoRef.current) {
-                  // Reset the video to the beginning if the user prefers reduced motion
-                  videoRef.current.currentTime = 0;
+              onEnded={(event) => {
+                if (userPrefersReducedMotion) {
+                  // Reset the video to the beginning if the user prefers reduced motion, since the video will not loop
+                  event.currentTarget.currentTime = 0;
                   setShouldPlay(false);
                   setIsPlaying(false);
                 }

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -1,6 +1,6 @@
 import { PlayerPause, PlayerPlay } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { useEffect, useRef, useState, useLayoutEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type VideoLoopProps = {
   /** The video url */
@@ -14,17 +14,21 @@ type VideoLoopProps = {
    * Think of this just as an alt text, but for a muted video - this text will not be visible, but read by screen readers.
    * */
   alt?: string;
+  /**
+   * Use this to provide a visible caption of the video content.
+   * It can be used as a brief summary of the video content. If using this, you might not need to provide an alt text.
+   * */
+  children?: React.ReactNode;
   /** @default aspect-video */
   className?: string;
-  rounded?: boolean;
 };
 
 export const VideoLoop = ({
   src,
   format,
   alt,
+  children,
   className = 'aspect-video',
-  rounded,
 }: VideoLoopProps) => {
   // Control the video playback state, so that the user can pause and play the video at will, also control the video autoplay
   const [shouldPlay, setShouldPlay] = useState(false);
@@ -78,11 +82,7 @@ export const VideoLoop = ({
         <video
           ref={videoRef}
           // cursor-pointer is not working on the button below, so we add it here for the same effect
-          className={cx(
-            'cursor-pointer',
-            rounded && 'rounded-3xl',
-            'h-full w-full object-cover',
-          )}
+          className={cx('cursor-pointer', 'h-full w-full object-cover')}
           playsInline
           loop={userPrefersReducedMotion === false}
           autoPlay={userPrefersReducedMotion === false}
@@ -103,7 +103,6 @@ export const VideoLoop = ({
             type="button"
             onClick={() => setShouldPlay((prevState) => !prevState)}
             className={cx(
-              rounded && 'rounded-3xl', // Mirror the rounded prop from the parent div to align focus outline
               'absolute bottom-0 left-0 right-0 top-0 m-auto grid place-items-center',
               'focus-visible:outline-focus focus-visible:outline-focus-offset',
               // Setting the opacity to 0 before applying the transition below will ensure the button only fades in after the video has started playing
@@ -122,6 +121,7 @@ export const VideoLoop = ({
           </button>
         )}
       </div>
+      {children}
       {alt && <p className="sr-only">{alt}</p>}
     </>
   );

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -1,5 +1,4 @@
 import { PlayerPause, PlayerPlay } from '@obosbbl/grunnmuren-icons-react';
-import { useLayoutEffect } from '@react-aria/utils';
 import { cx } from 'cva';
 import { useEffect, useRef, useState } from 'react';
 
@@ -8,7 +7,11 @@ type VideoLoopPropsCommon = {
   format: string;
   /** You may specify a visible caption, but if it is very similar to the alt text. Just a caption is sufficent.  */
   caption?: string;
-  /** You may pass an alternative text, complimentary to the caption. Make sure it doesn't repeat too much of the caption text, if so just a caption is sufficent. Think of this just as an alt text, but for a muted video - this text will not be visible, but read by screen readers. */
+  /**
+   * You may pass an alternative text, complimentary to the caption.
+   * Make sure it doesn't repeat too much of the caption text, if so just a caption is sufficent.
+   * Think of this just as an alt text, but for a muted video - this text will not be visible, but read by screen readers.
+   * */
   alt?: string;
   className?: string;
   rounded?: boolean;
@@ -32,12 +35,17 @@ export const VideoLoop = ({
   className,
   rounded,
 }: VideoLoopProps) => {
+  // Control the video playback state, so that the user can pause and play the video at will, also control the video autoplay
+  const [shouldPlay, setShouldPlay] = useState(false);
+  // Needed to show the pause button when the video is actually playing (refer to google's autoplay policy: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes)
+  const [isPlaying, setIsPlaying] = useState(false);
+
   // We need to check if the user prefers reduced motion, so that we can prevent the video from autoplaying if so
   const [userPrefersReducedMotion, setUserPrefersReducedMotion] = useState<
     null | boolean
   >(null);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const { matches: userPrefersReducedMotion } = matchMedia(
       '(prefers-reduced-motion: reduce)',
     );
@@ -46,19 +54,16 @@ export const VideoLoop = ({
     setShouldPlay(!userPrefersReducedMotion);
   }, []);
 
-  // Control the video playback state, so that the user can pause and play the video at will
-  const [shouldPlay, setShouldPlay] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
+  // Follow google's autoplay policy: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
+  // "Don't assume a video will play, and don't show a pause button when the video is not actually playing."
+  // "You should always look at the Promise returned by the play function to see if it was rejected:"
+  // This is why we use the promise returned by the play function, and an extra state variable to determine if the video is actually playing or not
   useEffect(() => {
     if (!videoRef.current) return;
 
     if (shouldPlay) {
-      // Follow google's autoplay policy: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
-      // "Don't assume a video will play, and don't show a pause button when the video is not actually playing."
-      // "You should always look at the Promise returned by the play function to see if it was rejected:"
-      // This is why we use the promise returned by the play function, and an extra state variable to determine if the video is actually playing or not
       videoRef.current
         .play()
         .then(() => setIsPlaying(true))
@@ -72,52 +77,47 @@ export const VideoLoop = ({
   return (
     <div className={className}>
       <div className="relative aspect-video" aria-hidden>
-        {/* Don't render the video until we have determined if the user prefers reduced motion */}
-        {userPrefersReducedMotion !== null && (
-          <>
-            <video
-              ref={videoRef}
-              // cursor-pointer is not working on the button below, so we add it here for the same effect
-              className={cx('cursor-pointer', rounded && 'rounded-3xl')}
-              autoPlay={isPlaying}
-              playsInline
-              muted
-              loop={userPrefersReducedMotion === false}
-              onEnded={(event) => {
-                if (userPrefersReducedMotion) {
-                  // Reset the video to the beginning if the user prefers reduced motion, since the video will not loop
-                  event.currentTarget.currentTime = 0;
-                  setShouldPlay(false);
-                  setIsPlaying(false);
-                }
-              }}
-            >
-              <source src={src} type={`video/${format}`} />
-            </video>
-            <button
-              type="button"
-              onClick={() => setShouldPlay((prevState) => !prevState)}
-              className={cx(
-                rounded && 'rounded-3xl', // Mirror the rounded prop from the parent div to align focus outline
-                'absolute bottom-0 left-0 right-0 top-0 m-auto grid place-items-center',
-                'focus-visible:outline-focus focus-visible:outline-focus-offset',
-                // Only show the pause button when the video is hovered or focused
-                isPlaying && [
-                  'opacity-0',
-                  'focus-visible:opacity-100',
-                  'transition-opacity duration-200',
-                  'hover:opacity-100',
-                ],
-              )}
-            >
-              <span className="grid h-12 w-12 place-items-center rounded-full bg-white outline-none">
-                {isPlaying ? <PlayerPause /> : <PlayerPlay />}
-              </span>
-            </button>
-          </>
-        )}
+        <video
+          ref={videoRef}
+          // cursor-pointer is not working on the button below, so we add it here for the same effect
+          className={cx('cursor-pointer', rounded && 'rounded-3xl')}
+          playsInline
+          muted
+          autoPlay={userPrefersReducedMotion === false}
+          loop={userPrefersReducedMotion === false}
+          onEnded={(event) => {
+            if (userPrefersReducedMotion) {
+              // Reset the video to the beginning if the user prefers reduced motion, since the video will not loop
+              event.currentTarget.currentTime = 0;
+              setShouldPlay(false);
+              setIsPlaying(false);
+            }
+          }}
+        >
+          <source src={src} type={`video/${format}`} />
+        </video>
+        <button
+          type="button"
+          onClick={() => setShouldPlay((prevState) => !prevState)}
+          className={cx(
+            rounded && 'rounded-3xl', // Mirror the rounded prop from the parent div to align focus outline
+            'absolute bottom-0 left-0 right-0 top-0 m-auto grid place-items-center',
+            'focus-visible:outline-focus focus-visible:outline-focus-offset',
+            // Only show the pause button when the video is hovered or focused
+            isPlaying && [
+              'opacity-0',
+              'focus-visible:opacity-100',
+              'transition-opacity duration-200',
+              'hover:opacity-100',
+            ],
+          )}
+        >
+          <span className="grid h-12 w-12 place-items-center rounded-full bg-white outline-none">
+            {isPlaying ? <PlayerPause /> : <PlayerPlay />}
+          </span>
+        </button>
       </div>
-      {caption && <p className="descrption mt-4">{caption}</p>}
+      {caption && <p className="description mt-4">{caption}</p>}
       {alt && <p className="sr-only">{alt}</p>}
     </div>
   );

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -80,9 +80,17 @@ export const VideoLoop = ({
               // cursor-pointer is not working on the button below, so we add it here for the same effect
               className={cx('cursor-pointer', rounded && 'rounded-3xl')}
               autoPlay={isPlaying}
-              loop={isPlaying}
               playsInline
               muted
+              loop={userPrefersReducedMotion === false}
+              onEnded={() => {
+                if (userPrefersReducedMotion && videoRef.current) {
+                  // Reset the video to the beginning if the user prefers reduced motion
+                  videoRef.current.currentTime = 0;
+                  setShouldPlay(false);
+                  setIsPlaying(false);
+                }
+              }}
             >
               <source src={src} type={`video/${format}`} />
             </video>


### PR DESCRIPTION
## VideoLoop

Adds a new `<VideoLoop/>` component that can play a muted video that loops (similar to a gif). The component respects reduced motion settings for users that have this setting enabled (typically users with vestibular motion disorders). And will not autoplay for these users. It ensures further accessibility by requiring a visible or invisible description (`alt` or `caption`) of the video content. Play/pause button is of course keyboard accessible with a click area corresponding to the entire video size. The video itself is hidden from screen readers, but the texts passed to the `alt` and `caption` props are read by screen readers. Only `caption` is visible.

The pause button only shows when hovering or focusing the video. But the play button will always show, as long as the video is paused.

This implementation should follow googles autoplay policy:

- Autoplay is allowed for muted videos (this is also required for accessibility)  
- Don't assume a video will play, and don't show a pause button when the video is not actually playing.


https://github.com/user-attachments/assets/a33f39ab-ce21-43b2-be1a-e7f88e547eb3

