### PR TITLE
Quick fix for ComboboxItem

### DIFF
--- a/apps/docs/build-docs.js
+++ b/apps/docs/build-docs.js
@@ -21,6 +21,12 @@ try {
     Object.values(docs)
       .map((prop) => {
         const prettifiedName = prop.displayName.replace('_', '');
+        if (prettifiedName === 'ListBoxItem') {
+          // Quick fix to expose ListBoxItem as both ComboboxItem and ListBoxItem
+          return `export const ${prettifiedName} = ${JSON.stringify({ ...prop, displayName: prettifiedName }, null, 2)}
+          export const ComboboxItem = ${JSON.stringify({ ...prop, displayName: prettifiedName }, null, 2)}
+          `;
+        }
         return `export const ${prettifiedName} = ${JSON.stringify({ ...prop, displayName: prettifiedName }, null, 2)}`;
       })
       .join('\n'),


### PR DESCRIPTION
## Fix ComboboxItem docgen

A quick and drity fix to expose `ComboboxItem` in the docgen types. This makes it possible to select `ComboboxItem` in the "Components to display props for" section in the sanity studio