### PR TITLE
Fix icons-react version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,7 +252,7 @@ importers:
   packages/react:
     dependencies:
       '@obosbbl/grunnmuren-icons-react':
-        specifier: workspace:^2.0.0-canary.4
+        specifier: workspace:^2.0.0-canary.5
         version: link:../icons-react
       '@react-aria/utils':
         specifier: ^3.25.1


### PR DESCRIPTION
## Fix broken CI pipeline

Release of the package is currently failing due lockfile out of sync.

Seems like `pnpm-lock` is out of sync, with the version of `icons-react` being one step behind the current version (after [this](https://github.com/code-obos/grunnmuren/pull/1134) was merged). Seems like it somehow got the wrong version in the [changeset](https://github.com/code-obos/grunnmuren/pull/1134/files#diff-882ee4e1622e2f899e9cab54225ec983ea25a9aae0359abdbae3c4dd5804d72cR3).

