### PR TITLE
Table content in docs

### DIFF
--- a/apps/docs/app/ui/content.tsx
+++ b/apps/docs/app/ui/content.tsx
@@ -1,12 +1,12 @@
 import { PortableText } from '@portabletext/react';
 import { cx } from 'cva';
-import { themes } from 'prism-react-renderer';
-import { LiveEditor, LiveProvider } from 'react-live';
 import type { Content as IContent } from 'sanity.types';
 import { AnchorHeading } from './anchor-heading';
 import { Code } from './code';
 import { ComponentPreview } from './component-preview';
 import { ImageWithCaption } from './image-with-caption';
+import { Table, TableHead, TableRow, TableCell, TableBody } from './table';
+import {} from 'react-aria-components';
 
 export type ContentProps = {
   content: IContent;
@@ -36,6 +36,38 @@ export function Content({ content, className }: ContentProps) {
                 caption={value.caption ?? ''}
               />
             ),
+            table: ({ value: { rows } }) => {
+              const [firstRow, ...restRows] = rows;
+              return (
+                <Table>
+                  <TableHead>
+                    {/**
+                     * Due to limitations in the @sanity/table plugin,
+                     * we just have to assume that the first row is the thead:
+                     * https://www.sanity.io/answers/discussion-about-the-limitations-of-a-table-plugin-and-alternative-solutions-for-creating-tables-in-sanity-io-
+                     */}
+                    <TableRow key={firstRow._key}>
+                      {firstRow.cells.map((cell) => (
+                        <TableCell key={`${firstRow._key}-${cell}`}>
+                          {cell}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {restRows.map((row) => (
+                      <TableRow key={row._key}>
+                        {row.cells.map((cell) => (
+                          <TableCell key={`${row._key}-${cell}`}>
+                            {cell}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              );
+            },
           },
           block: {
             h2: ({ children, value }) => (

--- a/apps/docs/app/ui/props-table.tsx
+++ b/apps/docs/app/ui/props-table.tsx
@@ -1,5 +1,6 @@
 import * as props from 'docgen';
 import { AnchorHeading } from './anchor-heading';
+import { Table, TableHead, TableRow, TableCell, TableBody } from './table';
 
 interface PropsTableProps {
   componentName: keyof typeof props;
@@ -12,32 +13,29 @@ export const PropsTable = ({ componentName }: PropsTableProps) => {
       <AnchorHeading className="heading-s my-2" level={2} id={headingId}>
         {componentName}
       </AnchorHeading>
-      <table className="mb-8 w-full text-sm" aria-describedby={headingId}>
-        <thead>
-          <tr className="bg-sky-lightest text-left align-baseline *:px-3 *:py-2">
-            <th>Prop</th>
-            <th>Description</th>
-            <th>Default</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table className="mb-8 w-full text-sm" aria-describedby={headingId}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Prop</TableCell>
+            <TableCell>Description</TableCell>
+            <TableCell>Default</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
           {Object.values(props[componentName].props).map((prop) => (
-            <tr
-              key={prop.name}
-              className="border-t-gray-light align-baseline *:px-3 *:py-2 [&:not(:first-child)]:border-t-[1px]"
-            >
-              <td className="italic">
+            <TableRow key={prop.name}>
+              <TableCell className="italic">
                 <code className="font-mono">
                   {prop.name}
                   {prop.required ? '' : '?'}
                 </code>
-              </td>
-              <td>{prop.description}</td>
-              <td>{prop.defaultValue?.value ?? '-'}</td>
-            </tr>
+              </TableCell>
+              <TableCell>{prop.description}</TableCell>
+              <TableCell>{prop.defaultValue?.value ?? '-'}</TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </>
   );
 };

--- a/apps/docs/app/ui/table.tsx
+++ b/apps/docs/app/ui/table.tsx
@@ -1,0 +1,87 @@
+import { cx } from 'cva';
+import { createContext, useContext } from 'react';
+
+type TableProps = {
+  children: React.ReactNode;
+  className?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+};
+
+const Table = ({ children, className, ...restProps }: TableProps) => (
+  <table
+    className={cx(className, 'not-prose mb-8 w-full text-sm')}
+    {...restProps}
+  >
+    {children}
+  </table>
+);
+
+type TableHeadProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const TableSectionContext = createContext<'head' | 'body' | null>(null);
+
+const TableHead = ({ children, className }: TableHeadProps) => (
+  <TableSectionContext.Provider value="head">
+    <thead className={cx(className)}>{children}</thead>
+  </TableSectionContext.Provider>
+);
+
+type TableBodyProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const TableBody = ({ children, className }: TableBodyProps) => (
+  <TableSectionContext.Provider value="body">
+    <tbody className={cx(className)}>{children}</tbody>
+  </TableSectionContext.Provider>
+);
+
+type TableRowProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const TableRow = ({ children, className }: TableRowProps) => {
+  const section = useContext(TableSectionContext);
+  return (
+    <tr
+      className={cx(
+        className,
+        section === 'head'
+          ? 'bg-sky-lightest text-left align-baseline *:px-3 *:py-2'
+          : 'align-baseline *:px-3 *:py-2 [&:not(:first-child)]:border-t-[1px] [&:not(:first-child)]:border-t-gray-light',
+      )}
+    >
+      {children}
+    </tr>
+  );
+};
+
+type TableCellProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const TableCell = ({ children, className }: TableCellProps) => {
+  const section = useContext(TableSectionContext);
+  const Cell = section === 'head' ? 'th' : 'td';
+  return <Cell className={className}>{children}</Cell>;
+};
+
+export {
+  Table,
+  type TableProps,
+  TableHead,
+  type TableHeadProps,
+  TableBody,
+  type TableBodyProps,
+  TableRow,
+  type TableRowProps,
+  TableCell,
+  type TableCellProps,
+};

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,6 +25,7 @@
     "@react-aria/utils": "3.27.0",
     "@sanity/client": "6.24.1",
     "@sanity/code-input": "5.1.2",
+    "@sanity/table": "1.1.3",
     "@sanity/vision": "3.68.3",
     "@tanstack/react-router": "1.97.3",
     "@tanstack/start": "1.97.3",

--- a/apps/docs/sanity.config.ts
+++ b/apps/docs/sanity.config.ts
@@ -4,6 +4,7 @@ import { visionTool } from '@sanity/vision';
 import { defineConfig } from 'sanity';
 import { structureTool } from 'sanity/structure';
 import { schemaTypes } from './studio/schema-types';
+import { table } from '@sanity/table';
 
 const dataset = 'grunnmuren';
 
@@ -13,7 +14,7 @@ export default defineConfig({
   basePath: '/studio',
   title: 'Grunnmuren - Sanity Studio',
   auth: obosAuthStore({ dataset }),
-  plugins: [structureTool(), visionTool(), codeInput()],
+  plugins: [structureTool(), visionTool(), codeInput(), table()],
   schema: {
     types: schemaTypes,
   },

--- a/apps/docs/sanity.types.ts
+++ b/apps/docs/sanity.types.ts
@@ -39,22 +39,6 @@ export type SanityImageDimensions = {
   aspectRatio?: number;
 };
 
-export type SanityImageHotspot = {
-  _type: 'sanity.imageHotspot';
-  x?: number;
-  y?: number;
-  height?: number;
-  width?: number;
-};
-
-export type SanityImageCrop = {
-  _type: 'sanity.imageCrop';
-  top?: number;
-  bottom?: number;
-  left?: number;
-  right?: number;
-};
-
 export type SanityFileAsset = {
   _id: string;
   _type: 'sanity.fileAsset';
@@ -75,6 +59,43 @@ export type SanityFileAsset = {
   path?: string;
   url?: string;
   source?: SanityAssetSourceData;
+};
+
+export type Geopoint = {
+  _type: 'geopoint';
+  lat?: number;
+  lng?: number;
+  alt?: number;
+};
+
+export type ImageWithCaption = {
+  _type: 'image-with-caption';
+  asset?: {
+    _ref: string;
+    _type: 'reference';
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+  };
+  hotspot?: SanityImageHotspot;
+  crop?: SanityImageCrop;
+  alt?: string;
+  caption?: string;
+};
+
+export type SanityImageCrop = {
+  _type: 'sanity.imageCrop';
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+};
+
+export type SanityImageHotspot = {
+  _type: 'sanity.imageHotspot';
+  x?: number;
+  y?: number;
+  height?: number;
+  width?: number;
 };
 
 export type SanityImageAsset = {
@@ -100,6 +121,13 @@ export type SanityImageAsset = {
   source?: SanityAssetSourceData;
 };
 
+export type SanityAssetSourceData = {
+  _type: 'sanity.assetSourceData';
+  name?: string;
+  id?: string;
+  url?: string;
+};
+
 export type SanityImageMetadata = {
   _type: 'sanity.imageMetadata';
   location?: Geopoint;
@@ -109,20 +137,6 @@ export type SanityImageMetadata = {
   blurHash?: string;
   hasAlpha?: boolean;
   isOpaque?: boolean;
-};
-
-export type Geopoint = {
-  _type: 'geopoint';
-  lat?: number;
-  lng?: number;
-  alt?: number;
-};
-
-export type SanityAssetSourceData = {
-  _type: 'sanity.assetSourceData';
-  name?: string;
-  id?: string;
-  url?: string;
 };
 
 export type LiveCodeBlock = {
@@ -162,6 +176,12 @@ export type Content = Array<
   | ({
       _key: string;
     } & StaticCodeBlock)
+  | ({
+      _key: string;
+    } & ImageWithCaption)
+  | ({
+      _key: string;
+    } & Table)
 >;
 
 export type Component = {
@@ -188,6 +208,20 @@ export type Slug = {
   source?: string;
 };
 
+export type Table = {
+  _type: 'table';
+  rows?: Array<
+    {
+      _key: string;
+    } & TableRow
+  >;
+};
+
+export type TableRow = {
+  _type: 'tableRow';
+  cells?: Array<string>;
+};
+
 export type Code = {
   _type: 'code';
   language?: string;
@@ -200,18 +234,21 @@ export type AllSanitySchemaTypes =
   | SanityImagePaletteSwatch
   | SanityImagePalette
   | SanityImageDimensions
-  | SanityImageHotspot
-  | SanityImageCrop
   | SanityFileAsset
-  | SanityImageAsset
-  | SanityImageMetadata
   | Geopoint
+  | ImageWithCaption
+  | SanityImageCrop
+  | SanityImageHotspot
+  | SanityImageAsset
   | SanityAssetSourceData
+  | SanityImageMetadata
   | LiveCodeBlock
   | StaticCodeBlock
   | Content
   | Component
   | Slug
+  | Table
+  | TableRow
   | Code;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./app/routes/_docs.tsx
@@ -225,9 +262,79 @@ export type COMPONENTS_NAVIGATION_QUERYResult = Array<{
 
 // Source: ./app/routes/_docs/komponenter/$slug.tsx
 // Variable: COMPONENT_QUERY
-// Query: *[_type == "component" && slug.current == $slug][0]{ content, "name": coalesce(name, ''), propsComponents, resourceLinks }
+// Query: *[_type == "component" && slug.current == $slug][0]{ "content": content[] {..., _type == "image-with-caption" => {...,asset->}}, "name": coalesce(name, ''), propsComponents, resourceLinks }
 export type COMPONENT_QUERYResult = {
-  content: Content | null;
+  content: Array<
+    | {
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: 'span';
+          _key: string;
+        }>;
+        style?: 'blockquote' | 'h2' | 'h3' | 'h4' | 'h5' | 'normal';
+        listItem?: 'bullet' | 'number';
+        markDefs?: Array<{
+          href?: string;
+          _type: 'link';
+          _key: string;
+        }>;
+        level?: number;
+        _type: 'block';
+        _key: string;
+      }
+    | {
+        _key: string;
+        _type: 'image-with-caption';
+        asset: {
+          _id: string;
+          _type: 'sanity.imageAsset';
+          _createdAt: string;
+          _updatedAt: string;
+          _rev: string;
+          originalFilename?: string;
+          label?: string;
+          title?: string;
+          description?: string;
+          altText?: string;
+          sha1hash?: string;
+          extension?: string;
+          mimeType?: string;
+          size?: number;
+          assetId?: string;
+          uploadId?: string;
+          path?: string;
+          url?: string;
+          metadata?: SanityImageMetadata;
+          source?: SanityAssetSourceData;
+        } | null;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        alt?: string;
+        caption?: string;
+      }
+    | {
+        _key: string;
+        _type: 'live-code-block';
+        code?: Code;
+        caption?: string;
+      }
+    | {
+        _key: string;
+        _type: 'static-code-block';
+        code?: Code;
+        caption?: string;
+      }
+    | {
+        _key: string;
+        _type: 'table';
+        rows?: Array<
+          {
+            _key: string;
+          } & TableRow
+        >;
+      }
+  > | null;
   name: string | '';
   propsComponents: Array<string> | null;
   resourceLinks: Array<{
@@ -254,6 +361,6 @@ declare module '@sanity/client' {
     "*[_type == \"component\"]{ _id, name, 'slug': coalesce(slug.current, '')} | order(name asc)":
       | COMPONENTS_NAVIGATION_QUERYResult
       | COMPONENTS_INDEX_QUERYResult;
-    '*[_type == "component" && slug.current == $slug][0]{ content, "name": coalesce(name, \'\'), propsComponents, resourceLinks }': COMPONENT_QUERYResult;
+    '*[_type == "component" && slug.current == $slug][0]{ "content": content[] {..., _type == "image-with-caption" => {...,asset->}}, "name": coalesce(name, \'\'), propsComponents, resourceLinks }': COMPONENT_QUERYResult;
   }
 }

--- a/apps/docs/schema.json
+++ b/apps/docs/schema.json
@@ -153,94 +153,6 @@
     }
   },
   {
-    "name": "sanity.imageHotspot",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageHotspot"
-          }
-        },
-        "x": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "y": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "height": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "width": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageCrop",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageCrop"
-          }
-        },
-        "top": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "bottom": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "left": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "right": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
     "name": "sanity.fileAsset",
     "type": "document",
     "attributes": {
@@ -373,6 +285,207 @@
           "name": "sanity.assetSourceData"
         },
         "optional": true
+      }
+    }
+  },
+  {
+    "name": "geopoint",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "geopoint"
+          }
+        },
+        "lat": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "lng": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "alt": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "image-with-caption",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "image-with-caption"
+          }
+        },
+        "asset": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "sanity.imageAsset"
+          },
+          "optional": true
+        },
+        "hotspot": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "sanity.imageHotspot"
+          },
+          "optional": true
+        },
+        "crop": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "sanity.imageCrop"
+          },
+          "optional": true
+        },
+        "alt": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "caption": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageCrop",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageCrop"
+          }
+        },
+        "top": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "bottom": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "left": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "right": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageHotspot",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageHotspot"
+          }
+        },
+        "x": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "y": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "height": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "width": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        }
       }
     }
   },
@@ -521,6 +634,43 @@
     }
   },
   {
+    "name": "sanity.assetSourceData",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.assetSourceData"
+          }
+        },
+        "name": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "id": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "url": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "sanity.imageMetadata",
     "type": "type",
     "value": {
@@ -582,80 +732,6 @@
           "type": "objectAttribute",
           "value": {
             "type": "boolean"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "geopoint",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "geopoint"
-          }
-        },
-        "lat": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "lng": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "alt": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.assetSourceData",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.assetSourceData"
-          }
-        },
-        "name": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "id": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "url": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
           },
           "optional": true
         }
@@ -925,6 +1001,36 @@
               "type": "inline",
               "name": "static-code-block"
             }
+          },
+          {
+            "type": "object",
+            "attributes": {
+              "_key": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "rest": {
+              "type": "inline",
+              "name": "image-with-caption"
+            }
+          },
+          {
+            "type": "object",
+            "attributes": {
+              "_key": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "rest": {
+              "type": "inline",
+              "name": "table"
+            }
           }
         ]
       }
@@ -1078,6 +1184,70 @@
           "type": "objectAttribute",
           "value": {
             "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "table",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "table"
+          }
+        },
+        "rows": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "rest": {
+                "type": "inline",
+                "name": "tableRow"
+              }
+            }
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "tableRow",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "tableRow"
+          }
+        },
+        "cells": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "string"
+            }
           },
           "optional": true
         }

--- a/apps/docs/studio/objects/content.ts
+++ b/apps/docs/studio/objects/content.ts
@@ -19,6 +19,7 @@ const content = defineType({
     { type: 'live-code-block' },
     { type: 'static-code-block' },
     { type: 'image-with-caption' },
+    { type: 'table' },
   ],
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@sanity/code-input':
         specifier: 5.1.2
         version: 5.1.2(@babel/runtime@7.26.0)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.68.3(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@22.10.5)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@sanity/table':
+        specifier: 1.1.3
+        version: 1.1.3(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.68.3(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@22.10.5)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/vision':
         specifier: 3.68.3
         version: 3.68.3(@babel/runtime@7.26.0)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
@@ -3348,6 +3351,13 @@ packages:
 
   '@sanity/schema@3.68.3':
     resolution: {integrity: sha512-JMeenS3OOJPoFbFZm1dPc/IJgpnj5hRvLlj23ayhNHr0aGuMHUprlgBOijUuXKu9XYK1AveeMhB9XDuzqRqMEA==}
+
+  '@sanity/table@1.1.3':
+    resolution: {integrity: sha512-RVMjU+xWSGgVx2pbSKFCF51GtVn7k2gWFWPJXoQt3BwiJvqJowBl7QaWGaF9mq87UN8c4HIQg21fzuGBZ3pU0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19
+      sanity: ^3.0.0
 
   '@sanity/telemetry@0.7.9':
     resolution: {integrity: sha512-TBBRK2SUwiNND+ZJPwdWSu8tbEjdIz7UjagmCCBBWcfXtDKXXlWawC/DOEWuI4Q+WcA5OWLDjboxZT4ApWjVbw==}
@@ -12969,6 +12979,19 @@ snapshots:
       - '@types/react'
       - debug
       - supports-color
+
+  '@sanity/table@1.1.3(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.68.3(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@22.10.5)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+    dependencies:
+      '@sanity/icons': 3.5.7(react@19.0.0)
+      '@sanity/incompatible-plugin': 1.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@sanity/ui': 2.11.1(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      react: 19.0.0
+      sanity: 3.68.3(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@22.10.5)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react-dom
+      - react-is
+      - styled-components
 
   '@sanity/telemetry@0.7.9(react@19.0.0)':
     dependencies:


### PR DESCRIPTION
## Table in block content for docs

Make it possible to add tables to the block content in the docs studio. Using the [@sanity/table](https://www.sanity.io/plugins/sanity-table) plugin.

Due to limitations in the table plugin, as described [here](https://www.sanity.io/answers/discussion-about-the-limitations-of-a-table-plugin-and-alternative-solutions-for-creating-tables-in-sanity-io-), we need to assume that the first row is the table head row. Otherwise we would have to create our own custom field + component.

As part of this PR, the table for `<PropsTable>` has also been extracted into it a new, reusable `<Table>` component. This component is now also used to render the tables as `PortableText`.

<img width="750" alt="Screenshot 2025-01-23 at 13 35 27" src="https://github.com/user-attachments/assets/37d96d0b-562d-4c75-a6bb-66d623112284" />
<img width="1177" alt="Screenshot 2025-01-23 at 13 35 41" src="https://github.com/user-attachments/assets/1eea7284-0f08-4f14-a657-79ef67727de0" />
