### PR TITLE
grunnmuren-react: don't pin cva version

### DIFF
--- a/.changeset/slimy-jobs-cough.md
+++ b/.changeset/slimy-jobs-cough.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+chore: don't pin to a specific beta version of the cva dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,7 @@
     "@obosbbl/grunnmuren-icons-react": "workspace:^2.0.0-canary.5",
     "@react-aria/utils": "^3.25.1",
     "@types/node": "^22.0.0",
-    "cva": "1.0.0-beta.2",
+    "cva": "^1.0.0-0",
     "react-aria": "^3.35.1",
     "react-aria-components": "^1.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
         specifier: ^22.0.0
         version: 22.10.5
       cva:
-        specifier: 1.0.0-beta.2
+        specifier: ^1.0.0-0
         version: 1.0.0-beta.2(typescript@5.7.3)
       react:
         specifier: ^18 || ^19


### PR DESCRIPTION
Denne PRen gjør at vi ikke pinner CVA til en spesifikk beta versjon, men heller tillater hvilken som helst av betaversjonene. Det er samme vi gjør her https://github.com/code-obos/grunnmuren-extended/blob/7d7a818a72ea651f3e4e2256f44685deea2cc23e/packages/map/package.json#L30

Dette for å forhindre at folk ender opp med flere versjoner av CVA i dependency treet sitt.