### PR TITLE
alertbox: add icon prop to override the default icon

### DIFF
--- a/.changeset/silly-rings-mix.md
+++ b/.changeset/silly-rings-mix.md
@@ -1,0 +1,13 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Alertbox: add `icon` prop to override the default icon for the variant
+
+Example:
+
+```jsx
+import { Subscription } from '@obosbbl/grunnmuren-react/icons';
+
+<Alertbox variant="info" icon={Subscription}> ... </Alertbox>
+```

--- a/packages/react/src/alertbox/alertbox.stories.tsx
+++ b/packages/react/src/alertbox/alertbox.stories.tsx
@@ -1,3 +1,4 @@
+import { Subscription } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { Alertbox, type AlertboxProps } from '.';
@@ -112,4 +113,9 @@ export const ExpandableAlert: Story = {
 export const ExpandableDismissableAlert: Story = {
   render: Template,
   args: { ...defaultProps, isExpandable: true, isDismissable: true },
+};
+
+export const WithCustomIcon: Story = {
+  render: SmallTemplate,
+  args: {... defaultProps, variant:'success', icon: Subscription},
 };

--- a/packages/react/src/alertbox/alertbox.stories.tsx
+++ b/packages/react/src/alertbox/alertbox.stories.tsx
@@ -117,5 +117,5 @@ export const ExpandableDismissableAlert: Story = {
 
 export const WithCustomIcon: Story = {
   render: SmallTemplate,
-  args: {... defaultProps, variant:'success', icon: Subscription},
+  args: { ...defaultProps, variant: 'success', icon: Subscription },
 };

--- a/packages/react/src/alertbox/alertbox.tsx
+++ b/packages/react/src/alertbox/alertbox.tsx
@@ -54,6 +54,8 @@ type Props = VariantProps<typeof alertVariants> & {
   role: 'alert' | 'status' | 'none';
   /** Additional CSS className for the element. */
   className?: string;
+  /** Overrides the default icon for the alertbox variant. Should be used sparingly as the default icons are visually connected to the color of the variant. */
+  icon?: React.ComponentType;
   /**
    * Controls if the alert is expandable or not
    * @default false
@@ -107,13 +109,14 @@ const Alertbox = ({
   children,
   role,
   className,
+  icon,
   variant = 'info',
   isDismissable = false, // Assign default value to make cva variants apply correctly
   isDismissed,
   onDismiss,
   isExpandable,
 }: Props) => {
-  const Icon = iconMap[variant];
+  const Icon = icon ?? iconMap[variant];
 
   const locale = useLocale();
 


### PR DESCRIPTION
Denne PRen legger til mulighet for å overstyre default ikonet for en alertbox variant:

<img width="431" alt="Screenshot 2025-02-04 at 10 51 01" src="https://github.com/user-attachments/assets/9819f4df-9f6a-4b8e-a067-3f03fe2e1527" />

Merk at dette er funskjonalitet som skal brukes varsomt. Variantene har forskjellige farger knyttet til seg, men for folk med fargeblindhet kan det være ikonet som avgjør typen alert, eg warning eller info.