### PR TITLE
Use correct font-weight on strong

### DIFF
--- a/.changeset/new-chefs-chew.md
+++ b/.changeset/new-chefs-chew.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": major
+---
+
+Fix font-weight on strong tags in prose content (use 500 instead of 600)

--- a/apps/docs/app/ui/sanity-content.tsx
+++ b/apps/docs/app/ui/sanity-content.tsx
@@ -92,6 +92,11 @@ export function SanityContent({ content, className }: SanityContentProps) {
               </AnchorHeading>
             ),
           },
+          marks: {
+            strong: ({ children }) => (
+              <strong className="font-medium">{children}</strong>
+            ),
+          },
         }}
       />
     </div>

--- a/apps/docs/app/ui/sanity-content.tsx
+++ b/apps/docs/app/ui/sanity-content.tsx
@@ -92,11 +92,6 @@ export function SanityContent({ content, className }: SanityContentProps) {
               </AnchorHeading>
             ),
           },
-          marks: {
-            strong: ({ children }) => (
-              <strong className="font-medium">{children}</strong>
-            ),
-          },
         }}
       />
     </div>

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -531,6 +531,9 @@ module.exports = (options = {}) => {
                   ...typography.paragraphText.large,
                 },
               },
+              strong: {
+                fontWeight: theme('fontWeight.medium'),
+              },
               blockquote: {
                 // Reset defaults:
                 marginBottom: 'unset',


### PR DESCRIPTION
## font-weight for strong tag

Set the font weight for all `<strong>` in Portable Text tags to `medium`:

<img width="544" alt="Screenshot 2025-02-19 at 10 45 48" src="https://github.com/user-attachments/assets/889f0f61-79c2-4377-aab8-30ae812e464b" />

### Before:
<img width="579" alt="Screenshot 2025-02-19 at 10 46 05" src="https://github.com/user-attachments/assets/4d31d103-2a05-4a23-90e0-94543e263274" />
