### PR TITLE
Override default prose code styles

### DIFF
--- a/.changeset/funny-pillows-listen.md
+++ b/.changeset/funny-pillows-listen.md
@@ -1,5 +1,5 @@
 ---
-"@obosbbl/grunnmuren-tailwind": major
+"@obosbbl/grunnmuren-tailwind": patch
 ---
 
 Add custom styling to `<code>` in prose content

--- a/.changeset/funny-pillows-listen.md
+++ b/.changeset/funny-pillows-listen.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": major
+---
+
+Add custom styling to `<code>` in prose content

--- a/packages/tailwind/tailwind-base.cjs
+++ b/packages/tailwind/tailwind-base.cjs
@@ -534,6 +534,20 @@ module.exports = (options = {}) => {
               strong: {
                 fontWeight: theme('fontWeight.medium'),
               },
+              code: {
+                padding: `${theme('spacing[0.5]')} ${theme('spacing.2')}`,
+                borderRadius: theme('borderRadius.DEFAULT'),
+                borderWidth: theme('borderWidth.DEFAULT'),
+                borderColor: theme('colors.gray.DEFAULT'),
+                backgroundColor: theme('colors.gray.lightest'),
+                whiteSpace: 'nowrap',
+              },
+              'code::before': {
+                content: '""',
+              },
+              'code::after': {
+                content: '""',
+              },
               blockquote: {
                 // Reset defaults:
                 marginBottom: 'unset',


### PR DESCRIPTION
## Style for inline code

Add custom styling for inline `<code>` in prose:

<img width="709" alt="Screenshot 2025-02-19 at 14 46 42" src="https://github.com/user-attachments/assets/6b48a6dd-00c4-4c43-a124-19b22cb83ed1" />

As designed by Kristian.