### PR TITLE
Add role prop

### DIFF
--- a/.changeset/gentle-toys-dance.md
+++ b/.changeset/gentle-toys-dance.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Add a `role` prop to the `<Card>` component. This is handy if you can not, or don't want to add an extra semantic HTML tag to your `Card` content, or as a wrapper for your `Card`. The prop is optional, and supports both `'complementary'` and `'listitem'`.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -4,6 +4,11 @@ import { Link, type LinkProps as RACLinkProps } from 'react-aria-components';
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
   className?: string;
+  /**
+   * ARIA role for the `Card`.
+   * This is handy if you can not, or don't want to add an extra semantic HTML tag to your `Card` content, or as a wrapper for your `Card`
+   * */
+  role?: 'complementary' | 'listitem';
 };
 
 const cardVariants = cva({


### PR DESCRIPTION
## Add role prop to the Card component

Adding a `role` prop to the `<Card>` component, this can be necessary to make Card work as an `<aside>`/`complimentary`, as some screen readers (like VoiceOver) can struggle to announce the `complimentary` role correctly if `<Card>` is composed with `<aside>` as a child:

```
  <Card className="bg-mint-lightest">
    <aside>
      <h2 className="heading-m">{title}</h2>
      <div className="prose">
        <PortableText value={content ?? []} />
      </div>
    </aside>
  </Card>
```

Or alternatively:

```
<aside>
  <Card className="bg-mint-lightest">
      <h2 className="heading-m">{title}</h2>
      <div className="prose">
        <PortableText value={content ?? []} />
      </div>
  </Card>
</aside>
```

Both these fails with VoiceOver on `macOS Sequoia 15.1.1`.

It is generally advised to use semantic HTML over ARIA, but when screen readers fails to support it. That argument no longer makes sense.

Adding this, we also enable consumers to set `role="listitem"` instead of wrapping the `<Card>` in a `<li>` item when listed in a `<ul>`. Giving the consumers more flexibility to compose components in an accessible way.