### PR TITLE
Add id prop

### DIFF
--- a/.changeset/eighty-geckos-exist.md
+++ b/.changeset/eighty-geckos-exist.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Add optional `id` prop to the `<Card>` component

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -4,6 +4,7 @@ import { Link, type LinkProps as RACLinkProps } from 'react-aria-components';
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
   className?: string;
+  id?: string;
 };
 
 const cardVariants = cva({


### PR DESCRIPTION
## Add id prop to Card

Adds support for optional `id` prop on the `<Card>` component. @SondreKanstad requested this, to make it possible to create links to some fact boxes (which are built with the `<Card>` component)