### PR TITLE
Overlay badge in Card Media

### DIFF
--- a/.changeset/early-clubs-peel.md
+++ b/.changeset/early-clubs-peel.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Render `<Badge>` as an overlay in `<Media>` in the `<Card>` component. This way `<Badge>` is placed on top of the other content in `<Media>` (image, illustration or video). It can be either left or right aligned, depending on it's child index of `<Media>`.

--- a/packages/react/src/badge/badge.tsx
+++ b/packages/react/src/badge/badge.tsx
@@ -39,7 +39,9 @@ function Badge(props: BadgeProps, ref: Ref<HTMLSpanElement>) {
     size,
   });
 
-  return <span className={className} {...restProps} ref={ref} />;
+  return (
+    <span className={className} {...restProps} ref={ref} data-slot="badge" />
+  );
 }
 
 const _Badge = forwardRef(Badge);

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -3,6 +3,7 @@ import {
   Bed,
   Documents,
   House,
+  InfoCircle,
   PiggyBank,
 } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta } from '@storybook/react';
@@ -329,6 +330,106 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
         alt=""
         src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
       />
+    </Media>
+    <Content>
+      <div className="grid gap-1">
+        <Heading level={3}>
+          <CardLink href="#card">Rødbergvn 88C</CardLink>
+        </Heading>
+        <small className="description">Bjerke - Oslo</small>
+      </div>
+      <small className="description -order-1">
+        Forhåndsvarsling - Saksnr. F0347565
+      </small>
+      <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
+      <p className="flex gap-x-1">
+        <House /> Rekkehus/småhus
+      </p>
+      <p className="flex gap-x-1">
+        <Bed /> 3 soverom
+      </p>
+      <p className="flex gap-x-1">
+        <PiggyBank /> Totalpris 9 989 838
+      </p>
+      <Badge size="small" color="mint" className="text-black">
+        Visning 13. oktober
+      </Badge>
+    </Content>
+    <Footer className="relative grid gap-y-2">
+      <hr className="border-t border-t-current" />
+      <Button
+        href="#other-link"
+        variant="tertiary"
+        className="focus-visible:outline-current"
+      >
+        Se prospekt
+        <Documents />
+      </Button>
+    </Footer>
+  </Card>
+);
+
+export const ClickableWithBadge = () => (
+  <Card variant="outlined" className="w-72 bg-blue-dark text-mint">
+    <Media>
+      <Badge color="blue-dark">
+        <InfoCircle />
+        Meldefrist
+      </Badge>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
+      />
+    </Media>
+    <Content>
+      <div className="grid gap-1">
+        <Heading level={3}>
+          <CardLink href="#card">Rødbergvn 88C</CardLink>
+        </Heading>
+        <small className="description">Bjerke - Oslo</small>
+      </div>
+      <small className="description -order-1">
+        Forhåndsvarsling - Saksnr. F0347565
+      </small>
+      <p className="font-semibold">100 m² | Prisantydning 9 600 000 kr</p>
+      <p className="flex gap-x-1">
+        <House /> Rekkehus/småhus
+      </p>
+      <p className="flex gap-x-1">
+        <Bed /> 3 soverom
+      </p>
+      <p className="flex gap-x-1">
+        <PiggyBank /> Totalpris 9 989 838
+      </p>
+      <Badge size="small" color="mint" className="text-black">
+        Visning 13. oktober
+      </Badge>
+    </Content>
+    <Footer className="relative grid gap-y-2">
+      <hr className="border-t border-t-current" />
+      <Button
+        href="#other-link"
+        variant="tertiary"
+        className="focus-visible:outline-current"
+      >
+        Se prospekt
+        <Documents />
+      </Button>
+    </Footer>
+  </Card>
+);
+
+export const ClickableWithBadgeRight = () => (
+  <Card variant="outlined" className="w-72 bg-blue-dark text-mint">
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
+      />
+      <Badge color="blue-dark">
+        <InfoCircle />
+        Meldefrist
+      </Badge>
     </Media>
     <Content>
       <div className="grid gap-1">

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -73,11 +73,11 @@ const cardVariants = cva({
     // Left aligned - override default corner radius of the badge
     '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tl-2xl',
     '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-br-2xl',
-    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tr-[0px]',
-    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-bl-[0px]',
+    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tr-none',
+    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-bl-none',
     // Right aligned - override default corner radius of the badge
-    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-tl-[0px]',
-    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-br-[0px]',
+    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-tl-none',
+    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-br-none',
     '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-tr-2xl',
     '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-bl-2xl',
     // ... and position the badge at the right edge of the media content

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -68,7 +68,7 @@ const cardVariants = cva({
 
     // **** Badge ****
     '[&_[data-slot="media"]_[data-slot="badge"]]:absolute [&_[data-slot="media"]_[data-slot="badge"]]:top-0',
-    // Increasing z-index Preserves badge position when media content is hovered
+    // Increasing z-index Preserves badge position when media content is hovered (the transform scale effect might otherwise move the badge behind the other media content)
     '[&_[data-slot="media"]_[data-slot="badge"]]:z-[1]',
     // Left aligned - override default corner radius of the badge
     '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tl-2xl',

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -27,20 +27,21 @@ const cardVariants = cva({
 
     // **** Media ****
     '[&_[data-slot="media"]]:overflow-hidden', // Prevent content from overflowing the rounded corners
+    '[&_[data-slot="media"]]:relative', // Needed for positioning the <Badge> component (if present)
     '[&_[data-slot="media"]]:rounded-t-2xl', // Top corners are always rounded
     // Position media at the edges of the card (because of these negative margins the media-element must be a wrapper around the actual image or other media content)
     '[&_[data-slot="media"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] [&_[data-slot="media"]]:mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
     // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work in FF)
-    '[&_[data-slot="media"]>*]:aspect-[3/2] [&_[data-slot="media"]>*]:w-full [&_[data-slot="media"]_img]:object-cover',
+    '[&_[data-slot="media"]>*:not([data-slot="badge"])]:aspect-[3/2] [&_[data-slot="media"]>*:not([data-slot="badge"])]:w-full [&_[data-slot="media"]_img]:object-cover',
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
     '[&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out [&_[data-slot="media"]>*]:motion-safe:transition-transform',
 
     // **** Card link ****
     // **** Hover ****
     // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
-    '[&:has([data-slot="card-link"]_a:hover)_[data-slot="media"]>*]:scale-110',
+    '[&:has([data-slot="card-link"]_a:hover)_[data-slot="media"]>*:not([data-slot="badge"])]:scale-110',
     // **** Card link in Heading ****
-    '[&:has([data-slot="heading"]_[data-slot="card-link"]:hover)_[data-slot="media"]>*]:scale-110',
+    '[&:has([data-slot="heading"]_[data-slot="card-link"]:hover)_[data-slot="media"]>*:not([data-slot="badge"])]:scale-110',
     // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
     // Border top is set to even out the border bottom used for the underline
     '[&_[data-slot="heading"]_[data-slot="card-link"]]:no-underline',
@@ -64,6 +65,23 @@ const cardVariants = cva({
     // Place other interactive on top of the pseudo-element that makes the entire card clickable
     // by setting a higher z-index than the pseudo-element (which implicitly z-index 0)
     '[&_a:not([data-slot="card-link"])]:z-[1] [&_button]:z-[1] [&_input]:z-[1]',
+
+    // **** Badge ****
+    '[&_[data-slot="media"]_[data-slot="badge"]]:absolute [&_[data-slot="media"]_[data-slot="badge"]]:top-0',
+    // Increasing z-index Preserves badge position when media content is hovered
+    '[&_[data-slot="media"]_[data-slot="badge"]]:z-[1]',
+    // Left aligned - override default corner radius of the badge
+    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tl-2xl',
+    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-br-2xl',
+    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tr-[0px]',
+    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-bl-[0px]',
+    // Right aligned - override default corner radius of the badge
+    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-tl-[0px]',
+    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-br-[0px]',
+    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-tr-2xl',
+    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-bl-2xl',
+    // ... and position the badge at the right edge of the media content
+    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:right-0',
   ],
   variants: {
     /**


### PR DESCRIPTION
## Overlay Badge in Card Media

Makes it possible to use the existing `<Badge>` component to create a badge that overlays the `<Media>` content of a `<Card>`.

It follows the border radius of the `Card` and can be either left or right aligned (based it's nth-child index):

- If it is the _first-child_ it will be **left aligned**
- If it is the _last-child_ it will be **right aligned** 

### Examples:

<img width="305" alt="Screenshot 2025-02-24 at 10 20 56" src="https://github.com/user-attachments/assets/62c69d5e-caab-4379-97f7-8d7565e56f47" />

<img width="304" alt="Screenshot 2025-02-24 at 10 22 18" src="https://github.com/user-attachments/assets/d4046fab-27d8-49a2-86e3-2c8eb8016d12" />

<img width="314" alt="Screenshot 2025-02-24 at 10 20 06" src="https://github.com/user-attachments/assets/50cfcc75-5798-406c-a7cb-cf8136287a91" />

<img width="310" alt="Screenshot 2025-02-24 at 10 20 32" src="https://github.com/user-attachments/assets/34ec3764-ff3e-43b5-ac2e-c6695a30527c" />