### PR TITLE
Horizontal card layout

### DIFF
--- a/.changeset/polite-candies-draw.md
+++ b/.changeset/polite-candies-draw.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+New `layout` prop in `<Card>` to support for responsive horizontal layout.

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -469,7 +469,7 @@ export const ClickableWithBadgeRight = () => (
   </Card>
 );
 
-export const Horizontal = () => (
+export const HorizontalLeft = () => (
   <Card layout="horizontal" variant="outlined">
     <Media>
       <img
@@ -487,6 +487,27 @@ export const Horizontal = () => (
         </Button>
       </CardLink>
     </Content>
+  </Card>
+);
+
+export const HorizontalRight = () => (
+  <Card layout="horizontal" variant="outlined">
+    <Content>
+      <Heading level={3}>Med bilde og CTA</Heading>
+      <p>Dette kortet har bilde og er klikkbart mot en CTA-lenke</p>
+      <CardLink className="group/cta">
+        <Button href="#cta" variant="tertiary">
+          Les mer
+          <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
+        </Button>
+      </CardLink>
+    </Content>
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/obos-logo-socialmeta.jpg"
+      />
+    </Media>
   </Card>
 );
 

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -518,7 +518,7 @@ export const HorizontalRight = () => (
 );
 
 export const HorizontalWithIconLeft = () => (
-  <Card layout="horizontal">
+  <Card layout="horizontal" variant="outlined">
     <PiggyBank />
     <Content>
       <Heading level={3}>Med ikon til venstre</Heading>

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -468,3 +468,62 @@ export const ClickableWithBadgeRight = () => (
     </Footer>
   </Card>
 );
+
+export const Horizontal = () => (
+  <Card layout="horizontal" variant="outlined">
+    <Media>
+      <img
+        alt=""
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/obos-logo-socialmeta.jpg"
+      />
+    </Media>
+    <Content>
+      <Heading level={3}>Med bilde og CTA</Heading>
+      <p>Dette kortet har bilde og er klikkbart mot en CTA-lenke</p>
+      <CardLink className="group/cta">
+        <Button href="#cta" variant="tertiary">
+          Les mer
+          <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
+        </Button>
+      </CardLink>
+    </Content>
+  </Card>
+);
+
+export const HorizontalWithIconLeft = () => (
+  <Card layout="horizontal" variant="outlined">
+    <PiggyBank />
+    <Content>
+      <Heading level={3}>Med ikon til venstre</Heading>
+      <p>
+        Dette kortet er liggende, har et ikon til venstre og er klikkbart mot en
+        CTA-lenke
+      </p>
+      <CardLink className="group/cta">
+        <Button href="#cta" variant="tertiary">
+          Les mer
+          <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
+        </Button>
+      </CardLink>
+    </Content>
+  </Card>
+);
+
+export const HorizontalWithIconRight = () => (
+  <Card layout="horizontal" variant="outlined">
+    <Content>
+      <Heading level={3}>Med ikon til høyre</Heading>
+      <p>
+        Dette kortet er liggende, har et ikon til høyre og er klikkbart mot en
+        CTA-lenke
+      </p>
+      <CardLink className="group/cta">
+        <Button href="#cta" variant="tertiary">
+          Les mer
+          <ArrowRight className="transition-transform group-hover/cta:motion-safe:translate-x-1" />
+        </Button>
+      </CardLink>
+    </Content>
+    <PiggyBank />
+  </Card>
+);

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -470,7 +470,7 @@ export const ClickableWithBadgeRight = () => (
 );
 
 export const HorizontalLeft = () => (
-  <Card layout="horizontal" variant="outlined">
+  <Card layout="horizontal">
     <Media>
       <img
         alt=""
@@ -478,8 +478,11 @@ export const HorizontalLeft = () => (
       />
     </Media>
     <Content>
-      <Heading level={3}>Med bilde og CTA</Heading>
-      <p>Dette kortet har bilde og er klikkbart mot en CTA-lenke</p>
+      <Heading level={3}>Med bilde til venstre</Heading>
+      <p>
+        Dette kortet har bilde til venstre på større skjermer og er klikkbart
+        mot en CTA-lenke
+      </p>
       <CardLink className="group/cta">
         <Button href="#cta" variant="tertiary">
           Les mer
@@ -491,10 +494,13 @@ export const HorizontalLeft = () => (
 );
 
 export const HorizontalRight = () => (
-  <Card layout="horizontal" variant="outlined">
+  <Card layout="horizontal">
     <Content>
-      <Heading level={3}>Med bilde og CTA</Heading>
-      <p>Dette kortet har bilde og er klikkbart mot en CTA-lenke</p>
+      <Heading level={3}>Med bilde til høyre</Heading>
+      <p>
+        Dette kortet har bilde til høyre på større skjermer og er klikkbart mot
+        en CTA-lenke
+      </p>
       <CardLink className="group/cta">
         <Button href="#cta" variant="tertiary">
           Les mer
@@ -512,7 +518,7 @@ export const HorizontalRight = () => (
 );
 
 export const HorizontalWithIconLeft = () => (
-  <Card layout="horizontal" variant="outlined">
+  <Card layout="horizontal">
     <PiggyBank />
     <Content>
       <Heading level={3}>Med ikon til venstre</Heading>

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -117,12 +117,10 @@ const cardVariants = cva({
 
         // **** Without Media ****
         '[&:not(:has(>[data-slot="media"]))]:flex-row',
-        // Make the layout responsive: when the Content reaches a minimum width of 18rem, the layout switches to vertical
+        // Make the layout responsive: when the Content reaches a minimum width of 18rem, the layout switches to vertical. Also makes sure Content takes up the remaining space available.
         '[&:not(:has(>[data-slot="media"]))]:flex-wrap [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:grow [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:basis-[18rem]',
         // Make sure svg's etc. are not shrinkable
         '[&>:not([data-slot="content"],[data-slot="media"])]:shrink-0',
-        // TODO
-        '[&:has(>svg:last-child)]:justify-between', // Fixes icon alignment when icon is right aligned
       ],
     },
   },

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -141,9 +141,15 @@ const cardVariants = cva({
       variant: 'outlined',
       layout: 'horizontal',
       className: [
+        // **** Media ****
+        // Some rounded corners are removed when the card is outlined
         '[&_[data-slot="media"]]:rounded-t-2xl', // On small screens, the top corners are rounded
         '[&_[data-slot="media"]:first-child]:md:rounded-tr-none [&_[data-slot="media"]:first-child]:md:rounded-bl-2xl', // Both left corners are rounded when media is on the left side
         '[&_[data-slot="media"]:last-child]:md:rounded-tl-none [&_[data-slot="media"]:last-child]:md:rounded-br-2xl', // Both right corners are rounded when media is on the right side
+        // **** Badge ****
+        // Override default corner radius of the badge to match the media border radius
+        '[&_[data-slot="media"]:first-child_[data-slot="badge"]:last-child]:md:rounded-tr-none',
+        '[&_[data-slot="media"]:last-child_[data-slot="badge"]:first-child]:md:rounded-tl-none',
       ],
     },
   ],

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -28,9 +28,9 @@ const cardVariants = cva({
     // **** Media ****
     '[&_[data-slot="media"]]:overflow-hidden', // Prevent content from overflowing the rounded corners
     '[&_[data-slot="media"]]:relative', // Needed for positioning the <Badge> component (if present)
-    '[&_[data-slot="media"]]:rounded-t-2xl', // Top corners are always rounded
     // Position media at the edges of the card (because of these negative margins the media-element must be a wrapper around the actual image or other media content)
     '[&_[data-slot="media"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] [&_[data-slot="media"]]:mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
+
     // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work in FF)
     '[&_[data-slot="media"]>*:not([data-slot="badge"])]:aspect-[3/2] [&_[data-slot="media"]>*:not([data-slot="badge"])]:w-full [&_[data-slot="media"]_img]:object-cover',
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
@@ -91,26 +91,63 @@ const cardVariants = cva({
     variant: {
       subtle: [
         'border-transparent',
-        // Media styles:
-        '[&_[data-slot="media"]]:rounded-b-2xl',
+        // **** Media styles ****
+        '[&_[data-slot="media"]]:rounded-2xl', // All corners are rounded
       ],
       outlined: 'border border-black',
+    },
+    /**
+     * The layout of the card
+     * @default vertical
+     */
+    layout: {
+      vertical: [
+        // **** Media ****
+        '[&_[data-slot="media"]]:rounded-t-2xl', // Both Top corners are rounded
+      ],
+      horizontal: [
+        // **** With Media ****
+        '[&:has(>[data-slot="media"])]:md:flex-row [&:has(>[data-slot="media"])]:md:gap-x-4',
+        '[&_[data-slot="media"]]:md:basis-1/2',
+        '[&_[data-slot="media"]]:md:mb-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
+        '[&_[data-slot="media"]:first-child]:md:mr-0',
+        '[&_[data-slot="media"]:last-child]:md:ml-0',
+        // **** With Icon ****
+        '[&:has(>svg)]:flex-row [&:has(>svg)]:gap-x-4',
+        '[&:has(>svg)]:flex-wrap [&:has(>svg)_[data-slot="content"]]:grow [&:has(>svg)_[data-slot="content"]]:basis-[18rem]',
+
+        '[&:has(>svg:last-child)]:justify-between', // Fixes icon alignment when icon is right aligned
+        '[&_svg]:shrink-0',
+      ],
     },
   },
   defaultVariants: {
     variant: 'subtle',
+    layout: 'vertical',
   },
+  compoundVariants: [
+    {
+      variant: 'outlined',
+      layout: 'horizontal',
+      className: [
+        '[&_[data-slot="media"]:first-child]:md:rounded-l-2xl', // Both left corners are rounded when media is on the left side
+        '[&_[data-slot="media"]:last-child]:md:rounded-r-2xl', // Both right corners are rounded when media is on the right side
+      ],
+    },
+  ],
 });
 
 const Card = ({
   children,
   className: _className,
   variant,
+  layout,
   ...restProps
 }: CardProps) => {
   const className = cardVariants({
     className: _className,
     variant,
+    layout,
   });
   return (
     <div className={className} {...restProps}>

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -119,6 +119,10 @@ const cardVariants = cva({
         '[&_[data-slot="media"]:first-child]:md:mr-0',
         '[&_[data-slot="media"]:last-child]:md:ml-0',
 
+        // Make sure the card link is clickable when the media is on the right side
+        // This i necessary because the media content is positioned after the card link in the DOM
+        '[&:has(>[data-slot="media"]:last-child)_[data-slot="card-link"]]:z-[1]',
+
         // **** Without Media ****
         '[&:not(:has(>[data-slot="media"]))]:flex-row',
         // Make the layout responsive: when the Content reaches a minimum width of 18rem, the layout switches to vertical. Also makes sure Content takes up the remaining space available.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -109,8 +109,12 @@ const cardVariants = cva({
       horizontal: [
         'gap-x-4', // Since this does not affect the layout before the flex direction is set (at breakpoint md for Card with Media), we can set it here
         // **** With Media ****
-        '[&:has(>[data-slot="media"])]:flex-col [&:has(>[data-slot="media"])]:md:flex-row',
-        '[&_[data-slot="media"]]:md:basis-1/2',
+        '[&:has(>[data-slot="media"]:first-child)]:flex-col',
+        '[&:has(>[data-slot="media"]:last-child)]:flex-col-reverse', // Always display the media at the top of the card
+        '[&:has(>[data-slot="media"])]:md:!flex-row', // When need !important to override the specificity (first-/last-child) of the flex-col-reverse and flex-col classes
+
+        '[&:has(>[data-slot="media"])>*]:md:basis-1/2', // Ensures a 50/50 split of the media and content on medium screens
+        // Position media at the edges of the card
         '[&_[data-slot="media"]]:md:mb-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
         '[&_[data-slot="media"]:first-child]:md:mr-0',
         '[&_[data-slot="media"]:last-child]:md:ml-0',
@@ -133,8 +137,9 @@ const cardVariants = cva({
       variant: 'outlined',
       layout: 'horizontal',
       className: [
-        '[&_[data-slot="media"]:first-child]:md:rounded-l-2xl', // Both left corners are rounded when media is on the left side
-        '[&_[data-slot="media"]:last-child]:md:rounded-r-2xl', // Both right corners are rounded when media is on the right side
+        '[&_[data-slot="media"]]:rounded-t-2xl', // On small screens, the top corners are rounded
+        '[&_[data-slot="media"]:first-child]:md:rounded-tr-none [&_[data-slot="media"]:first-child]:md:rounded-bl-2xl', // Both left corners are rounded when media is on the left side
+        '[&_[data-slot="media"]:last-child]:md:rounded-tl-none [&_[data-slot="media"]:last-child]:md:rounded-br-2xl', // Both right corners are rounded when media is on the right side
       ],
     },
   ],

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -10,7 +10,7 @@ const cardVariants = cva({
   base: [
     'group/card',
     'rounded-2xl border p-3',
-    'flex flex-col gap-y-4',
+    'flex gap-y-4', // y-gap ensures a vertical spacing for both verical layout and responsive horizontal layout
     'relative', // Needed for positiong of the clickable pseudo-element (and can also be used for other absolute positioned elements the consumer might add)
 
     // **** Heading ****
@@ -102,22 +102,27 @@ const cardVariants = cva({
      */
     layout: {
       vertical: [
+        'flex-col',
         // **** Media ****
         '[&_[data-slot="media"]]:rounded-t-2xl', // Both Top corners are rounded
       ],
       horizontal: [
+        'gap-x-4', // Since this does not affect the layout before the flex direction is set (at breakpoint md for Card with Media), we can set it here
         // **** With Media ****
-        '[&:has(>[data-slot="media"])]:md:flex-row [&:has(>[data-slot="media"])]:md:gap-x-4',
+        '[&:has(>[data-slot="media"])]:flex-col [&:has(>[data-slot="media"])]:md:flex-row',
         '[&_[data-slot="media"]]:md:basis-1/2',
         '[&_[data-slot="media"]]:md:mb-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
         '[&_[data-slot="media"]:first-child]:md:mr-0',
         '[&_[data-slot="media"]:last-child]:md:ml-0',
-        // **** With Icon ****
-        '[&:has(>svg)]:flex-row [&:has(>svg)]:gap-x-4',
-        '[&:has(>svg)]:flex-wrap [&:has(>svg)_[data-slot="content"]]:grow [&:has(>svg)_[data-slot="content"]]:basis-[18rem]',
 
+        // **** Without Media ****
+        '[&:not(:has(>[data-slot="media"]))]:flex-row',
+        // Make the layout responsive: when the Content reaches a minimum width of 18rem, the layout switches to vertical
+        '[&:not(:has(>[data-slot="media"]))]:flex-wrap [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:grow [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:basis-[18rem]',
+        // Make sure svg's etc. are not shrinkable
+        '[&>:not([data-slot="content"],[data-slot="media"])]:shrink-0',
+        // TODO
         '[&:has(>svg:last-child)]:justify-between', // Fixes icon alignment when icon is right aligned
-        '[&_svg]:shrink-0',
       ],
     },
   },


### PR DESCRIPTION
## Support for horizontal layout in `Card`

Adding support for horizontal layout in the `<Card>` component with a new `layout` prop.

This works for arbitrary compositions, where the combination of `<Content>` and `<Media>` as children renders a slightly different layout of the `<Card>` than if `<Content>` is combined with other types of children, such as an `svg` or `<Icon>`.

The exceptions for horizontal `<Card>` with `<Media>` as a child is that it renders a 50/50 split for the `Media` and `Content`. And that responsiveness is handled by a media query (for now, we will use a container query once we migrate to tailwind 4 and there is better support for container queries)

### Examples illustrating common use cases:

https://github.com/user-attachments/assets/f2afe771-35ec-4ed3-bf93-9b291a47e743

https://github.com/user-attachments/assets/cd18dd93-623d-456a-b728-4722d52fb5a4

