### PR TITLE
docs: add borders for the examples

### DIFF
--- a/apps/docs/app/ui/code.tsx
+++ b/apps/docs/app/ui/code.tsx
@@ -39,58 +39,69 @@ export const Code = ({
   const [isCodeExpanded, setIsCodeExpanded] = useState(false);
 
   return (
-    <LiveProvider
-      code={value}
-      scope={scope}
-      theme={themes.vsDark}
-      disabled={!isEditable}
-    >
-      <p>{caption}</p>
-      {withLivePreview && (
-        <LivePreview className="not-prose my-4 flex gap-x-4" />
-      )}
-      <Disclosure
-        isExpanded={isCodeExpanded}
-        onExpandedChange={setIsCodeExpanded}
-        className="grid grid-cols-1"
-      >
-        <DisclosureButton withChevron className="w-fit justify-self-end">
-          {isCodeExpanded ? 'Skjul' : 'Vis'} kode
-        </DisclosureButton>
-        <DisclosurePanel>
-          {/* Use the same black color as the background on the editor (#1e1e1e)  */}
-          <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden rounded-lg bg-[#1e1e1e]">
-            <LiveEditor
-              tabMode="focus"
-              className="row-span-2 font-mono"
-              onChange={setValue}
-            />
-            <div className="relative text-mint">
-              <Button
-                onPress={() =>
-                  navigator.clipboard.writeText(value).then(() => {
-                    setHasCopied(true);
-                    setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
-                  })
-                }
-                variant="tertiary"
-              >
-                <GrunnmurenIconsScope.Documents />
-              </Button>
-              <span
-                className={cx(
-                  'absolute top-full right-2 transition-opacity duration-100',
-                  hasCopied ? 'opacity-100' : 'opacity-0',
-                )}
-                aria-hidden={!hasCopied}
-                role="alert"
-              >
-                Kopiert!
-              </span>
+    <>
+      <div className="rounded-lg border">
+        <LiveProvider
+          code={value}
+          scope={scope}
+          theme={themes.vsDark}
+          disabled={!isEditable}
+        >
+          {withLivePreview && (
+            <div className="grid place-items-center p-18">
+              <LivePreview className="not-prose" />
             </div>
-          </div>
-        </DisclosurePanel>
-      </Disclosure>
-    </LiveProvider>
+          )}
+          <Disclosure
+            isExpanded={isCodeExpanded}
+            onExpandedChange={setIsCodeExpanded}
+            className="grid grid-cols-1"
+          >
+            <Button
+              className="justify-self-end"
+              variant="tertiary"
+              slot="trigger"
+            >
+              {isCodeExpanded ? 'Skjul' : 'Vis'} kode
+            </Button>
+            <DisclosurePanel>
+              {/* Use the same black color as the background on the editor (#1e1e1e)  */}
+              <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden bg-[#1e1e1e]">
+                <LiveEditor
+                  tabMode="focus"
+                  className="row-span-2 font-mono"
+                  onChange={setValue}
+                />
+                <div className="relative text-mint">
+                  <button
+                    className="size-[44px]"
+                    onClick={() =>
+                      navigator.clipboard.writeText(value).then(() => {
+                        setHasCopied(true);
+                        setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
+                      })
+                    }
+                    type="button"
+                  >
+                    <GrunnmurenIconsScope.Documents />
+                  </button>
+                  <span
+                    className={cx(
+                      'absolute top-full right-2 transition-opacity duration-100',
+                      hasCopied ? 'opacity-100' : 'opacity-0',
+                    )}
+                    aria-hidden={!hasCopied}
+                    role="alert"
+                  >
+                    Kopiert!
+                  </span>
+                </div>
+              </div>
+            </DisclosurePanel>
+          </Disclosure>
+        </LiveProvider>
+      </div>
+      <p>{caption}</p>
+    </>
   );
 };

--- a/apps/docs/app/ui/code.tsx
+++ b/apps/docs/app/ui/code.tsx
@@ -88,9 +88,7 @@ export const Code = ({
         >
           {withLivePreview ? (
             <>
-              <div className="grid place-items-center p-18">
-                <LivePreview className="not-prose" />
-              </div>
+              <LivePreview className="not-prose grid place-items-center gap-y-2 p-18" />
               <Disclosure
                 isExpanded={isCodeExpanded}
                 onExpandedChange={setIsCodeExpanded}

--- a/apps/docs/app/ui/code.tsx
+++ b/apps/docs/app/ui/code.tsx
@@ -12,14 +12,55 @@ const {
   Button,
 } = GrunnmurenScope;
 
-export type CodeProps = {
-  value: string;
-  setValue?: (newCode: string) => void;
+export type CodeProps = CodeSnippetProps & {
   caption?: string;
   /** @default false - Renders the code as a React component that is live editable */
   withLivePreview?: boolean;
   /** @default false - Makes the code editable */
   isEditable?: boolean;
+};
+
+type CodeSnippetProps = {
+  value: string;
+  setValue?: (newCode: string) => void;
+};
+
+const CodeSnippet = ({ value, setValue }: CodeSnippetProps) => {
+  const [hasCopied, setHasCopied] = useState(false);
+  // Use the same black color as the background on the editor (#1e1e1e)
+  return (
+    <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] bg-[#1e1e1e]">
+      <LiveEditor
+        tabMode="focus"
+        className="row-span-2 font-mono"
+        onChange={setValue}
+      />
+      <div className="relative text-mint">
+        <button
+          className="size-[44px]"
+          onClick={() =>
+            navigator.clipboard.writeText(value).then(() => {
+              setHasCopied(true);
+              setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
+            })
+          }
+          type="button"
+        >
+          <GrunnmurenIconsScope.Documents />
+        </button>
+        <span
+          className={cx(
+            'absolute top-full right-2 transition-opacity duration-100',
+            hasCopied ? 'opacity-100' : 'opacity-0',
+          )}
+          aria-hidden={!hasCopied}
+          role="alert"
+        >
+          Kopiert!
+        </span>
+      </div>
+    </div>
+  );
 };
 
 export const Code = ({
@@ -29,8 +70,6 @@ export const Code = ({
   withLivePreview,
   isEditable,
 }: CodeProps) => {
-  const [hasCopied, setHasCopied] = useState(false);
-
   const scope = withLivePreview
     ? // Scope is only needed when rendering the live preview
       { ...GrunnmurenIconsScope, ...GrunnmurenScope }
@@ -40,65 +79,38 @@ export const Code = ({
 
   return (
     <>
-      <div className="rounded-lg border">
+      <div className="overflow-hidden rounded-lg border">
         <LiveProvider
           code={value}
           scope={scope}
           theme={themes.vsDark}
           disabled={!isEditable}
         >
-          {withLivePreview && (
-            <div className="grid place-items-center p-18">
-              <LivePreview className="not-prose" />
-            </div>
-          )}
-          <Disclosure
-            isExpanded={isCodeExpanded}
-            onExpandedChange={setIsCodeExpanded}
-            className="grid grid-cols-1"
-          >
-            <Button
-              className="justify-self-end"
-              variant="tertiary"
-              slot="trigger"
-            >
-              {isCodeExpanded ? 'Skjul' : 'Vis'} kode
-            </Button>
-            <DisclosurePanel>
-              {/* Use the same black color as the background on the editor (#1e1e1e)  */}
-              <div className="grid grid-cols-[1fr,auto] grid-rows-[auto,1fr] overflow-hidden bg-[#1e1e1e]">
-                <LiveEditor
-                  tabMode="focus"
-                  className="row-span-2 font-mono"
-                  onChange={setValue}
-                />
-                <div className="relative text-mint">
-                  <button
-                    className="size-[44px]"
-                    onClick={() =>
-                      navigator.clipboard.writeText(value).then(() => {
-                        setHasCopied(true);
-                        setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
-                      })
-                    }
-                    type="button"
-                  >
-                    <GrunnmurenIconsScope.Documents />
-                  </button>
-                  <span
-                    className={cx(
-                      'absolute top-full right-2 transition-opacity duration-100',
-                      hasCopied ? 'opacity-100' : 'opacity-0',
-                    )}
-                    aria-hidden={!hasCopied}
-                    role="alert"
-                  >
-                    Kopiert!
-                  </span>
-                </div>
+          {withLivePreview ? (
+            <>
+              <div className="grid place-items-center p-18">
+                <LivePreview className="not-prose" />
               </div>
-            </DisclosurePanel>
-          </Disclosure>
+              <Disclosure
+                isExpanded={isCodeExpanded}
+                onExpandedChange={setIsCodeExpanded}
+                className="grid grid-cols-1"
+              >
+                <Button
+                  className="justify-self-end"
+                  variant="tertiary"
+                  slot="trigger"
+                >
+                  {isCodeExpanded ? 'Skjul' : 'Vis'} kode
+                </Button>
+                <DisclosurePanel>
+                  <CodeSnippet value={value} setValue={setValue} />
+                </DisclosurePanel>
+              </Disclosure>
+            </>
+          ) : (
+            <CodeSnippet value={value} />
+          )}
         </LiveProvider>
       </div>
       <p>{caption}</p>


### PR DESCRIPTION
First step in making the examples stand out more in the docs.

Components are consistently horizontally centered in a bordered "frame", with a vertical spacing.
<img width="712" alt="Screenshot 2025-02-27 at 13 16 27" src="https://github.com/user-attachments/assets/5c204c77-7437-4b33-b789-cbe1c5e74f4e" />

The "view code" button is rendered inside this "frame":
<img width="722" alt="Screenshot 2025-02-27 at 13 16 58" src="https://github.com/user-attachments/assets/1e3030ef-0517-478b-a8db-52144247f21e" />


There are some things that needs to be fixed in the `Discolsure` komponent before this looks good enough. But that is out of scope for this PR.