### PR TITLE
fix props for backlink

### DIFF
--- a/.changeset/cool-kings-hunt.md
+++ b/.changeset/cool-kings-hunt.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Change types for backlink in order to display props correctly in the grunnmuren docs

--- a/packages/react/src/backlink/backlink.tsx
+++ b/packages/react/src/backlink/backlink.tsx
@@ -20,15 +20,12 @@ type ButtonOrLinkProps = {
   withUnderline?: boolean;
 };
 
-type BacklinkProps = (
-  | ButtonProps
-  | React.ComponentPropsWithoutRef<typeof Link>
-) &
-  ButtonOrLinkProps;
+type BacklinkProps = ( ButtonProps | RACLinkProps) & ButtonOrLinkProps;
+  
 
 function isLinkProps(
   props: BacklinkProps,
-): props is ButtonOrLinkProps & React.ComponentPropsWithoutRef<typeof Link> {
+): props is ButtonOrLinkProps & RACLinkProps {
   return !!props.href;
 }
 

--- a/packages/react/src/backlink/backlink.tsx
+++ b/packages/react/src/backlink/backlink.tsx
@@ -20,8 +20,7 @@ type ButtonOrLinkProps = {
   withUnderline?: boolean;
 };
 
-type BacklinkProps = ( ButtonProps | RACLinkProps) & ButtonOrLinkProps;
-  
+type BacklinkProps = (ButtonProps | RACLinkProps) & ButtonOrLinkProps;
 
 function isLinkProps(
   props: BacklinkProps,


### PR DESCRIPTION
Propsen syntes ikke på backlink! Det berodde nog på att typen till React.ComponentPropsWithoutRef<typeof Link> verkade vara problematisk. Samma skedde på button, och löstes med å bruke RACLinkProps istället!

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/e37f0b36-f5ea-464e-9a94-f24173536c82" />
