### PR TITLE
Failsafe for image radius in horizontal Card

### DIFF
--- a/.changeset/mean-boxes-sort.md
+++ b/.changeset/mean-boxes-sort.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fix issue with image border-radius for `<Card layout="horizontal">` that can occur in some cases where the `<Card>` has very little horizontal space.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -113,6 +113,7 @@ const cardVariants = cva({
         '[&:has(>[data-slot="media"]:last-child)]:flex-col-reverse', // Always display the media at the top of the card
         '[&:has(>[data-slot="media"])]:md:!flex-row', // When need !important to override the specificity (first-/last-child) of the flex-col-reverse and flex-col classes
 
+        '[&_[data-slot="media"]]:md:h-fit', // Fail-safe for rounded corners on media content until we can use container queries for the breakpoints
         '[&:has(>[data-slot="media"])>*]:md:basis-1/2', // Ensures a 50/50 split of the media and content on medium screens
         // Position media at the edges of the card
         '[&_[data-slot="media"]]:md:mb-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',


### PR DESCRIPTION
## Failsafe for border-radius in horizontal Card

Adding a failsafe until we start using container queries as breakpoints for the horizontal `<Card>` layout.

<img width="719" alt="Screenshot 2025-02-27 at 14 26 47" src="https://github.com/user-attachments/assets/c31f4ec5-4fc9-4ebb-8771-6e4b530c9b58" />
