### PR TITLE
Do not render caption

### DIFF
--- a/apps/docs/app/ui/code.tsx
+++ b/apps/docs/app/ui/code.tsx
@@ -66,7 +66,6 @@ const CodeSnippet = ({ value, setValue }: CodeSnippetProps) => {
 export const Code = ({
   value,
   setValue,
-  caption,
   withLivePreview,
   isEditable,
 }: CodeProps) => {
@@ -111,7 +110,6 @@ export const Code = ({
           )}
         </LiveProvider>
       </div>
-      <p>{caption}</p>
     </>
   );
 };


### PR DESCRIPTION
Removes the rendering of `caption` in code examples