### PR TITLE
Fix disclosure panel spacing

### DIFF
--- a/.changeset/plenty-parts-mate.md
+++ b/.changeset/plenty-parts-mate.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": patch
 ---
 
-Fix the way spacing is managed in `<DisclosurePanel>`. Pseudo-elements were used to avoid an extra `<div>` wrapper around the content. But this caused some inherent spacing around the `Disclosure` which might not be desired in some cases.
+Fixes the way spacing is managed in `<DisclosurePanel>`. Pseudo-elements were used to avoid an extra `<div>` wrapper around the content. But this caused some inherent spacing around the `Disclosure` which might not be desired in some cases.

--- a/.changeset/plenty-parts-mate.md
+++ b/.changeset/plenty-parts-mate.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fix the way spacing is managed in `<DisclosurePanel>`. Previously pseudo-elements were used to avoid an extra `<div>` wrapper around the content. But this causes some inherent spacing around the `Disclosure` which might not be desired in some cases.

--- a/packages/react/src/disclosure/disclosure.stories.tsx
+++ b/packages/react/src/disclosure/disclosure.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof Disclosure> = {
           <DisclosureButton className="description" withChevron>
             Les mer
           </DisclosureButton>
-          <DisclosurePanel>
+          <DisclosurePanel className="pt-2">
             <p>Her finner du alle detaljer du måtte trenge.</p>
           </DisclosurePanel>
         </Disclosure>
@@ -40,7 +40,7 @@ export const DisclosureStory: Story = {
   args: {},
 };
 
-export const Dense: Story = {
+export const Hamburger: Story = {
   render: (props) => {
     return (
       <div className="p-4">
@@ -52,7 +52,7 @@ export const Dense: Story = {
           >
             <Menu />
           </DisclosureButton>
-          <DisclosurePanel>
+          <DisclosurePanel className="pt-2">
             <p>Her finner du alle detaljer du måtte trenge.</p>
           </DisclosurePanel>
         </Disclosure>
@@ -132,7 +132,7 @@ export const Grouped: Story = {
             </ul>
           )}
           {/* biome-ignore lint/a11y/useValidAriaRole: this is a custom component where role is a prop that defaults to 'group' */}
-          <DisclosurePanel className="px-4" role="none">
+          <DisclosurePanel className="p-12" role="none">
             <CheckboxGroup
               value={selectedOptions}
               onChange={setSelectedItems}
@@ -164,7 +164,7 @@ export const Grouped: Story = {
             </ul>
           )}
           {/* biome-ignore lint/a11y/useValidAriaRole: this is a custom component where role is a prop that defaults to 'group' */}
-          <DisclosurePanel className="px-4" role="none">
+          <DisclosurePanel className="p-4" role="none">
             <CheckboxGroup
               value={selectedOptions}
               onChange={setSelectedItems}

--- a/packages/react/src/disclosure/disclosure.stories.tsx
+++ b/packages/react/src/disclosure/disclosure.stories.tsx
@@ -88,7 +88,7 @@ export const WithCheckboxGroup: Story = {
             </ul>
           )}
           {/* biome-ignore lint/a11y/useValidAriaRole: this is a custom component where role is a prop that defaults to 'group' */}
-          <DisclosurePanel className="px-4" role="none">
+          <DisclosurePanel className="p-4" role="none">
             <CheckboxGroup
               value={selectedOptions}
               onChange={setSelectedItems}
@@ -132,7 +132,7 @@ export const Grouped: Story = {
             </ul>
           )}
           {/* biome-ignore lint/a11y/useValidAriaRole: this is a custom component where role is a prop that defaults to 'group' */}
-          <DisclosurePanel className="p-12" role="none">
+          <DisclosurePanel className="p-4" role="none">
             <CheckboxGroup
               value={selectedOptions}
               onChange={setSelectedItems}

--- a/packages/react/src/disclosure/disclosure.tsx
+++ b/packages/react/src/disclosure/disclosure.tsx
@@ -191,22 +191,19 @@ const DisclosurePanel = ({ ref: _ref, ..._props }: DisclosurePanelProps) => {
   return (
     <div
       className={cx(
-        'grid transition-all duration-300 after:relative after:block after:h-0 after:transition-all after:duration-300 motion-reduce:transition-none',
-        disclosureContext?.isExpanded
-          ? 'grid-rows-[1fr] after:h-3.5'
-          : 'grid-rows-[0fr]',
+        'grid transition-all duration-300 motion-reduce:transition-none',
+        disclosureContext?.isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
       )}
     >
-      <div
-        {...restProps}
-        ref={ref}
-        className={cx(
-          className,
-          'relative overflow-hidden [content-visibility:visible] before:relative before:block before:h-1.5 after:relative after:block after:h-1.5',
-        )}
-        role={role}
-        aria-labelledby={isWithoutRole ? undefined : ariaLabelledby}
-      />
+      <div className="overflow-hidden">
+        <div
+          {...restProps}
+          className={cx(className, '[content-visibility:visible]')}
+          ref={ref}
+          role={role}
+          aria-labelledby={isWithoutRole ? undefined : ariaLabelledby}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Fix inherent spacing in DisclosurePanel

Change the way in which spacing in the `<DisclosurePanel>` is managed.

The previous implementation was based on the styles for [`<Accordion>`](https://github.com/code-obos/grunnmuren/blob/main/packages/react/src/accordion/accordion.tsx#L145-L156). This spacing is very specific to the `<Accordion>` component, and pseudo-elements are used there to avoid wrapping the content in yet another `<div>`.

The `<Disclosure>` component however, should be much more flexible. It should be possible for the consumer to set _any_ desired spacing (padding, margin etc.) in the `<DisclosurePanel>`. The only way to do this (while still keeping the grid transition animation for the expand/collapse effect) is to wrap the panel in one extra div.

![Screenshot 2025-02-28 at 08 53 46](https://github.com/user-attachments/assets/4df8330f-13c9-4d9c-b27f-50c161a8b22d)

![Screenshot 2025-02-28 at 08 54 11](https://github.com/user-attachments/assets/912d9d64-f06a-4d97-98ce-f9189d02611b)

