### PR TITLE
Add short cuts menu

### DIFF
--- a/apps/docs/app/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/$slug.tsx
@@ -64,20 +64,7 @@ function Page() {
       <div className="lg:relative lg:flex lg:gap-[var(--gm-container-gutter-width)] lg:px-[var(--gm-container-gutter-width)] lg:pt-9">
         <TableOfContentsNav
           className="w-56 lg:sticky lg:top-9 lg:order-1 lg:shrink-0"
-          sections={(
-            data.content?.filter(
-              (c) =>
-                c._type === 'block' &&
-                // Only include headings (h1, h2, h3 etc)
-                c.style?.startsWith('h'),
-            ) as {
-              _key: string;
-              children: { text: string }[];
-            }[]
-          ).map(({ _key, children }) => ({
-            href: `#${_key}`,
-            text: children[0].text,
-          }))}
+          content={data.content}
         />
         <div>
           {data.componentState === 'new' && (

--- a/apps/docs/app/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/$slug.tsx
@@ -3,6 +3,7 @@ import { AnchorHeading } from '@/ui/anchor-heading';
 import { PropsTable } from '@/ui/props-table';
 import { ResourceLink, ResourceLinks } from '@/ui/resource-links';
 import { SanityContent } from '@/ui/sanity-content';
+import { TableOfContentsNav } from '@/ui/table-of-contents-nav';
 import { Child, CircusTent } from '@obosbbl/grunnmuren-icons-react';
 import { Alertbox, Content } from '@obosbbl/grunnmuren-react';
 import { createFileRoute, notFound } from '@tanstack/react-router';
@@ -54,68 +55,93 @@ function Page() {
 
   return (
     <>
-      <h1 className="heading-l mt-9 mb-4">{data.name}</h1>
+      <h1 className="heading-l mb-4">{data.name}</h1>
 
       <ResourceLinks className="mb-12">
         {figmaLink && <ResourceLink type="figma" href={figmaLink} />}
         {ghLink && <ResourceLink type="github" href={ghLink} />}
       </ResourceLinks>
-
-      {data.componentState === 'new' && (
-        // biome-ignore lint/a11y/useValidAriaRole: <explanation>
-        <Alertbox
-          variant="success"
-          className="mb-12 w-fit"
-          icon={Child}
-          role="none"
-        >
-          <Content>
-            <p>
-              Denne komponenten er ny eller har nylig fått større endringer.
-            </p>
-            <p>
-              Ta den i bruk og kom gjerne med innspill til oss på{' '}
-              <a href="https://obos.slack.com/archives/C03FR05FJ9F">Slack</a>{' '}
-              hvordan du synes den fungerer.
-            </p>
-          </Content>
-        </Alertbox>
-      )}
-
-      {data.componentState === 'beta' && (
-        // biome-ignore lint/a11y/useValidAriaRole: <explanation>
-        <Alertbox
-          variant="warning"
-          className="mb-12 w-fit"
-          icon={CircusTent}
-          role="none"
-        >
-          <Content>
-            <p>
-              Denne komponenten er under aktiv utvikling, og vi trenger din
-              feedback!
-            </p>
-            <p>
-              Er du eventyrlysten, test den og kom med innspill til oss på{' '}
-              <a href="https://obos.slack.com/archives/C03FR05FJ9F">Slack</a>.
-            </p>
-          </Content>
-        </Alertbox>
-      )}
-
-      <SanityContent className="mb-12" content={data.content ?? []} />
-
-      {data.propsComponents?.length && (
-        <AnchorHeading className="heading-m" level={2} id="props">
-          Props
-        </AnchorHeading>
-      )}
-      {data.propsComponents?.map((componentName) => (
-        <PropsTable
-          key={componentName}
-          componentName={componentName as keyof typeof props}
+      <div className="lg:relative lg:flex lg:gap-[var(--gm-container-gutter-width)] lg:px-[var(--gm-container-gutter-width)] lg:pt-9">
+        <TableOfContentsNav
+          className="w-56 lg:sticky lg:top-9 lg:order-1 lg:shrink-0"
+          sections={(
+            data.content?.filter(
+              (c) =>
+                c._type === 'block' &&
+                // Only include headings (h1, h2, h3 etc)
+                c.style?.startsWith('h'),
+            ) as {
+              _key: string;
+              children: { text: string }[];
+            }[]
+          ).map(({ _key, children }) => ({
+            href: `#${_key}`,
+            text: children[0].text,
+          }))}
         />
-      ))}
+        <div>
+          {data.componentState === 'new' && (
+            // biome-ignore lint/a11y/useValidAriaRole: <explanation>
+            <Alertbox
+              variant="success"
+              className="mb-12 w-fit"
+              icon={Child}
+              role="none"
+            >
+              <Content>
+                <p>
+                  Denne komponenten er ny eller har nylig fått større endringer.
+                </p>
+                <p>
+                  Ta den i bruk og kom gjerne med innspill til oss på{' '}
+                  <a href="https://obos.slack.com/archives/C03FR05FJ9F">
+                    Slack
+                  </a>{' '}
+                  hvordan du synes den fungerer.
+                </p>
+              </Content>
+            </Alertbox>
+          )}
+
+          {data.componentState === 'beta' && (
+            // biome-ignore lint/a11y/useValidAriaRole: <explanation>
+            <Alertbox
+              variant="warning"
+              className="mb-12 w-fit"
+              icon={CircusTent}
+              role="none"
+            >
+              <Content>
+                <p>
+                  Denne komponenten er under aktiv utvikling, og vi trenger din
+                  feedback!
+                </p>
+                <p>
+                  Er du eventyrlysten, test den og kom med innspill til oss på{' '}
+                  <a href="https://obos.slack.com/archives/C03FR05FJ9F">
+                    Slack
+                  </a>
+                  .
+                </p>
+              </Content>
+            </Alertbox>
+          )}
+
+          <SanityContent className="mb-12" content={data.content ?? []} />
+
+          {data.propsComponents?.length && (
+            <AnchorHeading className="heading-m" level={2} id="props">
+              Props
+            </AnchorHeading>
+          )}
+          {data.propsComponents?.map((componentName) => (
+            <PropsTable
+              key={componentName}
+              componentName={componentName as keyof typeof props}
+            />
+          ))}
+        </div>
+      </div>
     </>
   );
 }

--- a/apps/docs/app/ui/table-of-contents-nav.tsx
+++ b/apps/docs/app/ui/table-of-contents-nav.tsx
@@ -1,0 +1,30 @@
+import { Card, Heading } from '@obosbbl/grunnmuren-react';
+import { cx } from 'cva';
+
+type TableOfContentsNavProps = {
+  className?: string;
+  sections?: Array<{
+    href: string;
+    text: string;
+  }>;
+};
+
+const TableOfContentsNav = ({
+  className,
+  sections,
+}: TableOfContentsNavProps) => (
+  // @ts-expect-error: the role prop is passed to the Card component, even though it is not valid TS
+  // biome-ignore lint/a11y/useSemanticElements: this is a navigation component styled as a card
+  <Card role="navigation" className={cx(className, 'h-fit min-h-96 bg-mint')}>
+    <Heading level={2}>Hopp til:</Heading>
+    <ul className="grid gap-y-[inherit]">
+      {sections?.map(({ href, text }) => (
+        <li key={href}>
+          <a href={href}>{text}</a>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+export { type TableOfContentsNavProps, TableOfContentsNav };

--- a/apps/docs/app/ui/table-of-contents-nav.tsx
+++ b/apps/docs/app/ui/table-of-contents-nav.tsx
@@ -1,30 +1,45 @@
 import { Card, Heading } from '@obosbbl/grunnmuren-react';
 import { cx } from 'cva';
+import type { COMPONENT_QUERYResult } from 'sanity.types';
 
 type TableOfContentsNavProps = {
   className?: string;
-  sections?: Array<{
-    href: string;
-    text: string;
-  }>;
+  content: NonNullable<COMPONENT_QUERYResult>['content'];
 };
 
 const TableOfContentsNav = ({
   className,
-  sections,
-}: TableOfContentsNavProps) => (
-  // @ts-expect-error: the role prop is passed to the Card component, even though it is not valid TS
-  // biome-ignore lint/a11y/useSemanticElements: this is a navigation component styled as a card
-  <Card role="navigation" className={cx(className, 'h-fit min-h-96 bg-mint')}>
-    <Heading level={2}>Innhold</Heading>
-    <ul className="grid gap-y-[inherit]">
-      {sections?.map(({ href, text }) => (
-        <li key={href}>
-          <a href={href}>{text}</a>
-        </li>
-      ))}
-    </ul>
-  </Card>
-);
+  content,
+}: TableOfContentsNavProps) => {
+  const sections = (
+    content?.filter(
+      (c) =>
+        c._type === 'block' &&
+        // Only include headings (h1, h2, h3 etc.)
+        c.style?.startsWith('h'),
+    ) as {
+      _key: string;
+      children: { text: string }[];
+    }[]
+  ).map(({ _key, children }) => ({
+    href: `#${_key}`,
+    text: children[0].text,
+  }));
+
+  return (
+    // @ts-expect-error: the role prop is passed to the Card component, even though it is not valid TS
+    // biome-ignore lint/a11y/useSemanticElements: this is a navigation component styled as a card
+    <Card role="navigation" className={cx(className, 'h-fit min-h-96 bg-mint')}>
+      <Heading level={2}>Innhold</Heading>
+      <ul className="grid gap-y-[inherit]">
+        {sections?.map(({ href, text }) => (
+          <li key={href}>
+            <a href={href}>{text}</a>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
 
 export { type TableOfContentsNavProps, TableOfContentsNav };

--- a/apps/docs/app/ui/table-of-contents-nav.tsx
+++ b/apps/docs/app/ui/table-of-contents-nav.tsx
@@ -16,7 +16,7 @@ const TableOfContentsNav = ({
   // @ts-expect-error: the role prop is passed to the Card component, even though it is not valid TS
   // biome-ignore lint/a11y/useSemanticElements: this is a navigation component styled as a card
   <Card role="navigation" className={cx(className, 'h-fit min-h-96 bg-mint')}>
-    <Heading level={2}>Hopp til:</Heading>
+    <Heading level={2}>Innhold</Heading>
     <ul className="grid gap-y-[inherit]">
       {sections?.map(({ href, text }) => (
         <li key={href}>


### PR DESCRIPTION
## Shortcuts

Adding shortcuts to the right hand side of the docs. This is a start, and something that we can continue to work on as we make the docs responsive. 

The navigation is sticky, using anchor tags that target each heading.

![Screenshot 2025-03-03 at 13 58 23](https://github.com/user-attachments/assets/24786f2d-0719-4d91-a3a1-61514e53920e)
