### PR TITLE
Make media css more predictable

### DIFF
--- a/.changeset/tender-melons-lose.md
+++ b/.changeset/tender-melons-lose.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Makes styling custom content in the `<Media>` component easier. This fixes width issues on content other than `<img/>`, `<video/>`.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -31,8 +31,8 @@ const cardVariants = cva({
     // Position media at the edges of the card (because of these negative margins the media-element must be a wrapper around the actual image or other media content)
     '[&_[data-slot="media"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] [&_[data-slot="media"]]:mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
 
-    // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work in FF)
-    '[&_[data-slot="media"]>*:not([data-slot="badge"])]:aspect-[3/2] [&_[data-slot="media"]>*:not([data-slot="badge"])]:w-full [&_[data-slot="media"]_img]:object-cover',
+    // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work on images in FF)
+    '[&_[data-slot="media"]>*:not([data-slot="badge"])]:aspect-[3/2] [&_[data-slot="media"]_img]:w-full [&_[data-slot="media"]_img]:object-cover',
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
     '[&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out [&_[data-slot="media"]>*]:motion-safe:transition-transform',
 


### PR DESCRIPTION
## More flexible layout in Card Media

This enables more flexible layouts in the `<Media>` component in `<Card>`.

![Screenshot 2025-03-04 at 10 44 52](https://github.com/user-attachments/assets/3aacd73c-46e9-4755-97d6-6c694636ffd8)

This was not possible before, due to a work-around for Firefox: setting `w-full` on _every_ child in the `<Media>` component.
<img width="410" alt="Screenshot 2025-03-04 at 10 57 43" src="https://github.com/user-attachments/assets/e6c7a73e-5041-4bc4-932c-95ace736c46f" />

This is now solved by only targeting any immediate `img` child of `<Media>`, which is the only case where it is necessary for Firefox to respect the `aspect-ratio`.
