### PR TITLE
Adjust breakpoint

### DIFF
--- a/.changeset/public-hounds-leave.md
+++ b/.changeset/public-hounds-leave.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Decreases breakpoint for `Card` with horizontal layout, without `<Media>`

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -126,8 +126,8 @@ const cardVariants = cva({
 
         // **** Without Media ****
         '[&:not(:has(>[data-slot="media"]))]:flex-row',
-        // Make the layout responsive: when the Content reaches a minimum width of 18rem, the layout switches to vertical. Also makes sure Content takes up the remaining space available.
-        '[&:not(:has(>[data-slot="media"]))]:flex-wrap [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:grow [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:basis-[18rem]',
+        // Make the layout responsive: when the Content reaches a minimum width of 12rem, the layout switches to vertical. Also makes sure Content takes up the remaining space available.
+        '[&:not(:has(>[data-slot="media"]))]:flex-wrap [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:grow [&:not(:has(>[data-slot="media"]))_[data-slot="content"]]:basis-[12rem]',
         // Make sure svg's etc. are not shrinkable
         '[&>:not([data-slot="content"],[data-slot="media"])]:shrink-0',
       ],


### PR DESCRIPTION
Decrease break point in horizontal `<Card>` without `<Media>`

<img width="271" alt="Screenshot 2025-03-04 at 12 36 54" src="https://github.com/user-attachments/assets/7ef550b7-edc2-431a-9b8a-55f472f194c4" />

This should be more appropriate for current known use cases.