### PR TITLE
Fix card img styles

### DIFF
--- a/.changeset/ready-shoes-spend.md
+++ b/.changeset/ready-shoes-spend.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+More specific CSS selectors to target `<img>` inside `<Media>` in `<Card>`. This fixes issues with unwnated styles being applied to other nested `<img>` elements.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -32,7 +32,7 @@ const cardVariants = cva({
     '[&_[data-slot="media"]]:mx-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))] [&_[data-slot="media"]]:mt-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
 
     // Sets the aspect ratio of the media content (width: 100% is necessary to make aspect ratio work on images in FF)
-    '[&_[data-slot="media"]>*:not([data-slot="badge"])]:aspect-[3/2] [&_[data-slot="media"]_img]:w-full [&_[data-slot="media"]_img]:object-cover',
+    '[&_[data-slot="media"]>*:not([data-slot="badge"])]:aspect-[3/2] [&_[data-slot="media"]>img]:w-full [&_[data-slot="media"]>img]:object-cover',
     // Prepare zoom animation for hover effects. The hover effect can also be enabled by classes on the parent component, so it is always prepared here.
     '[&_[data-slot="media"]>*]:duration-300 [&_[data-slot="media"]>*]:ease-in-out [&_[data-slot="media"]>*]:motion-safe:transition-transform',
 


### PR DESCRIPTION
## More specific img styles for Card

Prevents `Card` `img` styles from cascading further than necessary. Otherwise this can cause issues with custom `<img>` content in `<Media>` in `<Card>`. 

![image (10)](https://github.com/user-attachments/assets/f244b7a1-0e37-4425-bc1f-4867e67aae2e)
![image (11)](https://github.com/user-attachments/assets/e8e3120d-f883-4367-8291-97305cd2f984)
