### PR TITLE
Avatar

### DIFF
--- a/.changeset/curly-schools-tap.md
+++ b/.changeset/curly-schools-tap.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+New `<Avatar>` component that can be used to create rounded images. It helps composing components like contact cards.

--- a/packages/react/src/avatar/avatar.stories.tsx
+++ b/packages/react/src/avatar/avatar.stories.tsx
@@ -1,0 +1,49 @@
+import { Menu } from '@obosbbl/grunnmuren-icons-react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { UNSAFE_Avatar as Avatar } from './avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Avatar',
+  component: Avatar,
+  parameters: {
+    // disable built in padding in story, because we provide our own
+    layout: 'fullscreen',
+  },
+  render: (props) => {
+    return (
+      <div className="p-4">
+        <Avatar {...props} />
+      </div>
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const DisclosureStory: Story = {
+  args: {
+    src: 'https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/v1578474487/Boligkonferansen/obosbk%202017/Daniel_Kj%C3%B8rberg_Siraj_1x1.jpg',
+  },
+};
+
+export const WithoutSrc: Story = {
+  render: () => {
+    return (
+      <div className="p-4">
+        <Avatar />
+      </div>
+    );
+  },
+};
+
+export const WithoutInvalidSrc: Story = {
+  render: () => {
+    return (
+      <div className="p-4">
+        <Avatar src="invalid" />
+      </div>
+    );
+  },
+};

--- a/packages/react/src/avatar/avatar.stories.tsx
+++ b/packages/react/src/avatar/avatar.stories.tsx
@@ -1,4 +1,3 @@
-import { Menu } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { UNSAFE_Avatar as Avatar } from './avatar';
 

--- a/packages/react/src/avatar/avatar.tsx
+++ b/packages/react/src/avatar/avatar.tsx
@@ -1,6 +1,6 @@
+import { User } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { type ComponentProps, useState } from 'react';
-import { User } from '@obosbbl/grunnmuren-icons-react';
 
 type AvatarProps = ComponentProps<'img'>;
 

--- a/packages/react/src/avatar/avatar.tsx
+++ b/packages/react/src/avatar/avatar.tsx
@@ -42,4 +42,4 @@ const Avatar = ({
   );
 };
 
-export { Avatar as UNSTABLE_Avatar, type AvatarProps as UNSTABLE_AvatarProps };
+export { Avatar as UNSAFE_Avatar, type AvatarProps as UNSAFE_AvatarProps };

--- a/packages/react/src/avatar/avatar.tsx
+++ b/packages/react/src/avatar/avatar.tsx
@@ -1,0 +1,13 @@
+type AvatarProps = {
+  src: string;
+};
+
+const Avatar = ({ src }: AvatarProps) => (
+  <img
+    src={src}
+    alt=""
+    className="h-20 w-20 flex-shrink-0 rounded-full object-cover"
+  />
+);
+
+export { Avatar as UNSTABLE_Avatar, type AvatarProps as UNSTABLE_AvatarProps };

--- a/packages/react/src/avatar/avatar.tsx
+++ b/packages/react/src/avatar/avatar.tsx
@@ -1,13 +1,45 @@
-type AvatarProps = {
-  src: string;
-};
+import { cx } from 'cva';
+import { type ComponentProps, useState } from 'react';
+import { User } from '@obosbbl/grunnmuren-icons-react';
 
-const Avatar = ({ src }: AvatarProps) => (
-  <img
-    src={src}
-    alt=""
-    className="h-20 w-20 flex-shrink-0 rounded-full object-cover"
-  />
-);
+type AvatarProps = ComponentProps<'img'>;
+
+const baseClassName = 'h-20 w-20 flex-shrink-0 rounded-full';
+
+const Avatar = ({
+  src,
+  alt = '',
+  className,
+  onError,
+  loading = 'lazy',
+  ...rest
+}: AvatarProps) => {
+  const [hasError, setHasError] = useState(false);
+  const hasValidImage = !hasError && src;
+
+  return hasValidImage ? (
+    <img
+      {...rest}
+      src={src}
+      alt={alt}
+      loading={loading}
+      className={cx(className, baseClassName, 'object-cover')}
+      onError={(event) => {
+        onError?.(event);
+        setHasError(true);
+      }}
+    />
+  ) : (
+    <div
+      className={cx(
+        className,
+        baseClassName,
+        'grid place-items-center bg-gray-light text-gray-dark',
+      )}
+    >
+      <User className="scale-[2.25]" />
+    </div>
+  );
+};
 
 export { Avatar as UNSTABLE_Avatar, type AvatarProps as UNSTABLE_AvatarProps };

--- a/packages/react/src/avatar/index.ts
+++ b/packages/react/src/avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './avatar';

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -8,12 +8,12 @@ import {
 } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta } from '@storybook/react';
 import { cx } from 'cva';
+import { UNSTABLE_Avatar as Avatar } from '../avatar';
 import { Badge } from '../badge';
 import { Button } from '../button';
 import { Content, Footer, Heading, Media } from '../content';
-import { Card, CardLink } from './card';
-import { UNSTABLE_Avatar as Avatar } from '../avatar';
 import { Description } from '../label';
+import { Card, CardLink } from './card';
 
 const meta: Meta<typeof Card> = {
   title: 'Card',

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -12,6 +12,8 @@ import { Badge } from '../badge';
 import { Button } from '../button';
 import { Content, Footer, Heading, Media } from '../content';
 import { Card, CardLink } from './card';
+import { UNSTABLE_Avatar as Avatar } from '../avatar';
+import { Description } from '../label';
 
 const meta: Meta<typeof Card> = {
   title: 'Card',
@@ -552,5 +554,18 @@ export const HorizontalWithIconRight = () => (
       </CardLink>
     </Content>
     <PiggyBank />
+  </Card>
+);
+
+export const WithAvatar = () => (
+  <Card layout="horizontal" variant="outlined" className="w-96 max-w-full">
+    <Avatar src="https://image.estatenyheter.no/199256.webp?imageId=199256&width=2116&height=1778&format=webp" />
+    <Content>
+      <div className="flex flex-col-reverse gap-2">
+        <Heading level={3}>Daniel Kjørberg Siraj</Heading>
+        <Description>Konsernsjef (CEO)</Description>
+      </div>
+      <p>Dette kortet er liggende, med et rundt bilde til høyre</p>
+    </Content>
   </Card>
 );

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -559,7 +559,7 @@ export const HorizontalWithIconRight = () => (
 
 export const WithAvatar = () => (
   <Card layout="horizontal" variant="outlined" className="w-96 max-w-full">
-    <Avatar src="https://image.estatenyheter.no/199256.webp?imageId=199256&width=2116&height=1778&format=webp" />
+    <Avatar src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/v1578474487/Boligkonferansen/obosbk%202017/Daniel_Kj%C3%B8rberg_Siraj_1x1.jpg" />
     <Content>
       <div className="flex flex-col-reverse gap-2">
         <Heading level={3}>Daniel Kjørberg Siraj</Heading>

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta } from '@storybook/react';
 import { cx } from 'cva';
-import { UNSTABLE_Avatar as Avatar } from '../avatar';
+import { UNSAFE_Avatar as Avatar } from '../avatar';
 import { Badge } from '../badge';
 import { Button } from '../button';
 import { Content, Footer, Heading, Media } from '../content';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -21,3 +21,4 @@ export * from './card';
 export * from './date-formatter';
 export * from './video-loop';
 export * from './disclosure';
+export * from './avatar';


### PR DESCRIPTION
## Avatar

Adding a new component called `Avatar`. It is  used to create circular images, which can be used to compose contact cards.

Seeing as we don't really have any other intended use case than contact cards at the moment, I have only added examples in context of the `Card` component: 

I figure we can add more later perhaps? We don't have docs for other supplementary components like `Heading`, `Media` `Label` etc.

### In Card

In a `<Card layout="horizontal">` these will be responsive to the container width, just like other horizontal cards:

<img width="420" alt="Screenshot 2025-03-17 at 13 28 30" src="https://github.com/user-attachments/assets/674899dd-225e-49e7-9556-90ac5e0cf4a0" />

<img width="293" alt="Screenshot 2025-03-17 at 13 28 45" src="https://github.com/user-attachments/assets/ae340654-0b02-4a2f-b62a-f673098e1db3" />
