### PR TITLE
Modal

### DIFF
--- a/.changeset/lemon-hairs-know.md
+++ b/.changeset/lemon-hairs-know.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+New `<Modal>` component that can be used for modal dialogs.

--- a/packages/react/src/alertbox/alertbox.tsx
+++ b/packages/react/src/alertbox/alertbox.tsx
@@ -10,7 +10,8 @@ import {
   Warning,
 } from '@obosbbl/grunnmuren-icons-react';
 import { useState } from 'react';
-import { type Locale, useLocale } from '../use-locale';
+import { useLocale } from '../use-locale';
+import { translations } from '../translations';
 
 const iconMap = {
   info: InfoCircle,
@@ -77,32 +78,6 @@ type Props = VariantProps<typeof alertVariants> & {
    * This is used to control the open/closed state of the component; make the component "controlled".
    */
   onDismiss?: () => void;
-};
-
-type Translation = {
-  [key in Locale]: string;
-};
-
-type Translations = {
-  [x: string]: Translation;
-};
-
-const translations: Translations = {
-  close: {
-    nb: 'Lukk',
-    sv: 'Stäng',
-    en: 'Close',
-  },
-  showMore: {
-    nb: 'Les mer',
-    sv: 'Läs mer',
-    en: 'Read more',
-  },
-  showLess: {
-    nb: 'Vis mindre',
-    sv: 'Dölj',
-    en: 'Show less',
-  },
 };
 
 const Alertbox = ({

--- a/packages/react/src/alertbox/alertbox.tsx
+++ b/packages/react/src/alertbox/alertbox.tsx
@@ -10,8 +10,8 @@ import {
   Warning,
 } from '@obosbbl/grunnmuren-icons-react';
 import { useState } from 'react';
-import { useLocale } from '../use-locale';
 import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 const iconMap = {
   info: InfoCircle,

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -8,7 +8,8 @@ import {
   Link as RACLink,
   type LinkProps as RACLinkProps,
 } from 'react-aria-components';
-import { type Locale, useLocale } from '../use-locale';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 /**
  * Figma: https://www.figma.com/file/9OvSg0ZXI5E1eQYi7AWiWn/Grunnmuren-2.0-%E2%94%82-Designsystem?node-id=30%3A2574&mode=dev
@@ -133,22 +134,6 @@ function isLinkProps(
 ): props is ButtonOrLinkProps & RACLinkProps {
   return !!props.href;
 }
-
-type Translation = {
-  [key in Locale]: string;
-};
-
-type Translations = {
-  [x: string]: Translation;
-};
-
-const translations: Translations = {
-  pending: {
-    nb: 'venter',
-    sv: 'väntar',
-    en: 'pending',
-  },
-};
 
 function Button(
   props: ButtonProps,

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -8,6 +8,8 @@ type HeadingProps = HTMLProps<HTMLHeadingElement> & {
   level: 1 | 2 | 3 | 4 | 5 | 6;
   /** @private Used internally for slotted components */
   _innerWrapper?: (children: React.ReactNode) => React.ReactNode;
+  /** @private Used internally for slotted components */
+  _outerWrapper?: (children: React.ReactNode) => React.ReactNode;
 };
 
 const HeadingContext = createContext<
@@ -23,16 +25,19 @@ const Heading = (props: HeadingProps, ref: Ref<HTMLHeadingElement>) => {
     level,
     className,
     _innerWrapper: innerWrapper,
+    _outerWrapper: outerWrapper,
     ...restProps
   } = props;
 
   const Element = `h${level}` as const;
 
-  return (
+  const content = (
     <Element {...restProps} className={className} data-slot="heading">
       {innerWrapper ? innerWrapper(children) : children}
     </Element>
   );
+
+  return outerWrapper ? outerWrapper(content) : content;
 };
 
 const ContentContext = createContext<

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -29,6 +29,21 @@ const meta: Meta<typeof Modal> = {
                 vaskemaskin, tørketrommel, oppvaskmaskin eller å avstå dette
                 tilbudet.
               </p>
+              <Heading level={3} className="heading-xs">
+                Andre tilvalg
+              </Heading>
+              <p>
+                Vi er opptatt av at du skal bli fornøyd og kan skape ditt
+                drømmehjem med tilvalg. Det er viktig å huske at når vi gjør
+                endringer i standarden på boligen, kommer blant annet montering,
+                tilpasninger og transport som en tilleggskostnad. Vi bestiller
+                varer i store kvanta, og å fjerne varer fra totalleveransen gjør
+                prisen på resten av varene høyere, som betyr at vi ikke alltid
+                har mulighet til å gi deg fradrag på varene du velger bort. Når
+                du bestiller tilvalg hos oss gir vi deg en totalpris på
+                oppgraderingen som inkluderer alt dette, hvilket gjør det litt
+                vanskeligere å sammenligne priser på lignende varer i butikk.
+              </p>
               <Button slot="close">Lukk</Button>
             </Dialog>
           </Modal>

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -59,8 +59,10 @@ export const MultipleActions: Story = {
             tilbudet.
           </p>
           <Footer>
-            <Button slot="close">Lagre</Button>
-            <Button slot="close" variant="tertiary">
+            <Button onPress={() => console.log('SAVED!')} slot="close">
+              Lagre
+            </Button>
+            <Button variant="tertiary" slot="close">
               Avbryt
             </Button>
           </Footer>
@@ -73,23 +75,24 @@ export const MultipleActions: Story = {
 export const Controlled: Story = {
   render: (props) => {
     const [isOpen, setIsOpen] = useState(false);
+    console.log('isOpen', isOpen);
     return (
-      <>
-        <Button onPress={() => setIsOpen(true)}>Open Modal</Button>
-        {isOpen && (
-          <DialogTrigger>
-            <Modal {...props} isOpen={isOpen} onOpenChange={setIsOpen}>
-              <Dialog>
-                <Heading slot="title" level={2}>
-                  Tittel
-                </Heading>
-                <p>Denne modalen er controlled.</p>
-                <Button onPress={() => setIsOpen(false)}>Lukk</Button>
-              </Dialog>
-            </Modal>
-          </DialogTrigger>
-        )}
-      </>
+      <div>
+        <DialogTrigger>
+          <Button onPress={() => setIsOpen(true)}>Open Modal</Button>
+          <Modal {...props} isOpen={isOpen} onOpenChange={setIsOpen}>
+            <Dialog>
+              <Heading slot="title" level={2}>
+                Tittel
+              </Heading>
+              <p>Denne modalen er controlled.</p>
+              <Button onPress={() => setIsOpen(false)} slot="close">
+                Lukk
+              </Button>
+            </Dialog>
+          </Modal>
+        </DialogTrigger>
+      </div>
     );
   },
 };

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import {
-  UNSAFE_DialogTrigger as DialogTrigger,
-  UNSAFE_Modal as Modal,
-  UNSAFE_Dialog as Dialog,
-} from './modal';
 import { Button } from '../button';
 import { Footer, Heading } from '../content';
+import {
+  UNSAFE_Dialog as Dialog,
+  UNSAFE_DialogTrigger as DialogTrigger,
+  UNSAFE_Modal as Modal,
+} from './modal';
 
 const meta: Meta<typeof Modal> = {
   title: 'Modal',

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import {
+  UNSAFE_DialogTrigger as DialogTrigger,
+  UNSAFE_Modal as Modal,
+  UNSAFE_Dialog as Dialog,
+} from './modal';
+import { Button } from '../button';
+import { Footer, Heading } from '../content';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Modal',
+  component: Modal,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (props) => {
+    return (
+      <DialogTrigger>
+        <Button>Åpne</Button>
+        <Modal {...props}>
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Hvitevarer
+            </Heading>
+            <p>
+              Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for
+              vaskemaskin, tørketrommel, oppvaskmaskin eller å avstå dette
+              tilbudet.
+            </p>
+            <Button slot="close">Lukk</Button>
+          </Dialog>
+        </Modal>
+      </DialogTrigger>
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const ModalStory: Story = {
+  args: {},
+};
+
+export const MultipleActions: Story = {
+  render: (props) => (
+    <DialogTrigger>
+      <Button>Åpne</Button>
+      <Modal {...props}>
+        <Dialog>
+          <Heading slot="title" level={2}>
+            Hvitevarer
+          </Heading>
+          <p>
+            Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for
+            vaskemaskin, tørketrommel, oppvaskmaskin eller å avstå dette
+            tilbudet.
+          </p>
+          <Footer>
+            <Button slot="close">Lagre</Button>
+            <Button slot="close" variant="tertiary">
+              Avbryt
+            </Button>
+          </Footer>
+        </Dialog>
+      </Modal>
+    </DialogTrigger>
+  ),
+};
+
+export const Controlled: Story = {
+  render: (props) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onPress={() => setIsOpen(true)}>Open Modal</Button>
+        {isOpen && (
+          <DialogTrigger>
+            <Modal {...props} isOpen={isOpen} onOpenChange={setIsOpen}>
+              <Dialog>
+                <Heading slot="title" level={2}>
+                  Tittel
+                </Heading>
+                <p>Denne modalen er controlled.</p>
+                <Button onPress={() => setIsOpen(false)}>Lukk</Button>
+              </Dialog>
+            </Modal>
+          </DialogTrigger>
+        )}
+      </>
+    );
+  },
+};

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -16,22 +16,24 @@ const meta: Meta<typeof Modal> = {
   },
   render: (props) => {
     return (
-      <DialogTrigger>
-        <Button>Åpne</Button>
-        <Modal {...props}>
-          <Dialog>
-            <Heading slot="title" level={2}>
-              Hvitevarer
-            </Heading>
-            <p>
-              Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for
-              vaskemaskin, tørketrommel, oppvaskmaskin eller å avstå dette
-              tilbudet.
-            </p>
-            <Button slot="close">Lukk</Button>
-          </Dialog>
-        </Modal>
-      </DialogTrigger>
+      <div className="p-4">
+        <DialogTrigger>
+          <Button>Åpne</Button>
+          <Modal {...props}>
+            <Dialog>
+              <Heading slot="title" level={2}>
+                Hvitevarer
+              </Heading>
+              <p>
+                Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for
+                vaskemaskin, tørketrommel, oppvaskmaskin eller å avstå dette
+                tilbudet.
+              </p>
+              <Button slot="close">Lukk</Button>
+            </Dialog>
+          </Modal>
+        </DialogTrigger>
+      </div>
     );
   },
 };
@@ -46,38 +48,39 @@ export const ModalStory: Story = {
 
 export const MultipleActions: Story = {
   render: (props) => (
-    <DialogTrigger>
-      <Button>Åpne</Button>
-      <Modal {...props}>
-        <Dialog>
-          <Heading slot="title" level={2}>
-            Hvitevarer
-          </Heading>
-          <p>
-            Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for
-            vaskemaskin, tørketrommel, oppvaskmaskin eller å avstå dette
-            tilbudet.
-          </p>
-          <Footer>
-            <Button onPress={() => console.log('SAVED!')} slot="close">
-              Lagre
-            </Button>
-            <Button variant="tertiary" slot="close">
-              Avbryt
-            </Button>
-          </Footer>
-        </Dialog>
-      </Modal>
-    </DialogTrigger>
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne</Button>
+        <Modal {...props}>
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Hvitevarer
+            </Heading>
+            <p>
+              Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for
+              vaskemaskin, tørketrommel, oppvaskmaskin eller å avstå dette
+              tilbudet.
+            </p>
+            <Footer>
+              <Button onPress={() => console.log('SAVED!')} slot="close">
+                Lagre
+              </Button>
+              <Button variant="tertiary" slot="close">
+                Avbryt
+              </Button>
+            </Footer>
+          </Dialog>
+        </Modal>
+      </DialogTrigger>
+    </div>
   ),
 };
 
 export const Controlled: Story = {
   render: (props) => {
     const [isOpen, setIsOpen] = useState(false);
-    console.log('isOpen', isOpen);
     return (
-      <div>
+      <div className="p-4">
         <DialogTrigger>
           <Button onPress={() => setIsOpen(true)}>Open Modal</Button>
           <Modal {...props} isOpen={isOpen} onOpenChange={setIsOpen}>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,0 +1,91 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
+import { cx } from 'cva';
+import {
+  DialogTrigger as RACDialogTrigger,
+  ModalOverlay as RACModalOverlay,
+  type DialogTriggerProps as RACDialogTriggerProps,
+  Dialog as RACDialog,
+  type DialogProps as RACDialogProps,
+  Modal as RACModal,
+  type ModalOverlayProps as RACModalOverlayProps,
+  Provider,
+  ButtonContext,
+} from 'react-aria-components';
+import { Button } from '../button';
+
+type DialogTriggerProps = RACDialogTriggerProps;
+
+const DialogTrigger = (props: DialogTriggerProps) => (
+  <RACDialogTrigger {...props} />
+);
+
+type ModalOverlayProps = Omit<RACModalOverlayProps, 'isDismissable'>;
+
+const ModalOverlay = (props: ModalOverlayProps) => (
+  <RACModalOverlay
+    {...props}
+    isDismissable
+    className={({ isEntering, isExiting }) =>
+      cx(
+        'fixed inset-0 z-10 flex min-h-full items-center justify-center overflow-y-auto bg-black/25 p-4 text-center backdrop-blur',
+        isEntering && 'fade-in animate-in duration-300 ease-out',
+        isExiting && 'fade-out animate-out duration-200 ease-in',
+      )
+    }
+  />
+);
+
+type ModalProps = Omit<RACModalOverlayProps, 'isDismissable'>;
+
+const Modal = ({ className, ...restProps }: ModalProps) => (
+  <ModalOverlay>
+    <RACModal
+      {...restProps}
+      className={({ isEntering, isExiting }) =>
+        cx(
+          className,
+          'w-full max-w-md overflow-hidden rounded-2xl bg-white p-4 text-left align-middle shadow-xl',
+          isEntering && 'zoom-in-95 animate-in duration-300 ease-out',
+          isExiting && 'zoom-out-95 animate-out duration-200 ease-in',
+        )
+      }
+    />
+  </ModalOverlay>
+);
+
+type DialogProps = RACDialogProps & {
+  children: React.ReactNode;
+};
+
+const Dialog = ({ className, children, ...restProps }: DialogProps) => (
+  <RACDialog
+    {...restProps}
+    className={cx(
+      'relative grid gap-y-5 outline-none',
+      // Title
+      '[&_[slot="title"]]:heading-s [&_[slot="title"]]:pr-14',
+      // Footer
+      '[&_[data-slot="footer"]]:flex [&_[data-slot="footer"]]:gap-x-2',
+    )}
+  >
+    <Button
+      slot="close"
+      variant="tertiary"
+      className="-mt-3 !px-2.5 absolute top-0 right-0 data-[focus-visible]:outline-focus-inset"
+    >
+      <Close />
+    </Button>
+    <Provider values={[[ButtonContext, { className: 'w-fit' }]]}>
+      {children}
+    </Provider>
+  </RACDialog>
+);
+
+export {
+  type DialogTriggerProps as UNSAFE_DialogTriggerProps,
+  DialogTrigger as UNSAFE_DialogTrigger,
+  type ModalProps as UNSAFE_ModalProps,
+  Modal as UNSAFE_Modal,
+  type DialogProps as UNSAFE_DialogProps,
+  Dialog as UNSAFE_Dialog,
+};

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -89,7 +89,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
                         <Button
                           slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
                           variant="tertiary"
-                          className="-mt-3 !px-2.5 data-[focus-visible]:outline-focus-inset"
+                          className="!px-2.5 data-[focus-visible]:outline-focus-inset"
                         >
                           <Close />
                         </Button>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,16 +1,16 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import {
-  DialogTrigger as RACDialogTrigger,
-  ModalOverlay as RACModalOverlay,
-  type DialogTriggerProps as RACDialogTriggerProps,
+  ButtonContext,
+  DEFAULT_SLOT,
+  Provider,
   Dialog as RACDialog,
   type DialogProps as RACDialogProps,
+  DialogTrigger as RACDialogTrigger,
+  type DialogTriggerProps as RACDialogTriggerProps,
   Modal as RACModal,
-  DEFAULT_SLOT,
+  ModalOverlay as RACModalOverlay,
   type ModalOverlayProps as RACModalOverlayProps,
-  Provider,
-  ButtonContext,
 } from 'react-aria-components';
 import { Button } from '../button';
 

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -7,6 +7,7 @@ import {
   Dialog as RACDialog,
   type DialogProps as RACDialogProps,
   Modal as RACModal,
+  DEFAULT_SLOT,
   type ModalOverlayProps as RACModalOverlayProps,
   Provider,
   ButtonContext,
@@ -68,16 +69,39 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
       '[&_[data-slot="footer"]]:flex [&_[data-slot="footer"]]:gap-x-2',
     )}
   >
-    <Button
-      slot="close"
-      variant="tertiary"
-      className="-mt-3 !px-2.5 absolute top-0 right-0 data-[focus-visible]:outline-focus-inset"
-    >
-      <Close />
-    </Button>
-    <Provider values={[[ButtonContext, { className: 'w-fit' }]]}>
-      {children}
-    </Provider>
+    {({ close }) => (
+      <>
+        <Button
+          slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
+          variant="tertiary"
+          className="-mt-3 !px-2.5 absolute top-0 right-0 data-[focus-visible]:outline-focus-inset"
+        >
+          <Close />
+        </Button>
+        <Provider
+          values={[
+            [
+              ButtonContext,
+              {
+                // This is necessary to support multiple close buttons
+                slots: {
+                  // We need to define default slot in order to also support non-slotted buttons (i.e. buttons without slot prop)
+                  [DEFAULT_SLOT]: {
+                    className: 'w-fit',
+                  },
+                  close: {
+                    onPress: close,
+                    className: 'w-fit',
+                  },
+                },
+              },
+            ],
+          ]}
+        >
+          {children}
+        </Provider>
+      </>
+    )}
   </RACDialog>
 );
 

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -13,6 +13,7 @@ import {
   type ModalOverlayProps as RACModalOverlayProps,
 } from 'react-aria-components';
 import { Button } from '../button';
+import { HeadingContext } from '../content';
 
 type DialogTriggerProps = RACDialogTriggerProps;
 
@@ -67,8 +68,6 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
     {...restProps}
     className={cx(
       'relative grid gap-y-5 outline-none',
-      // Title
-      '[&_[slot="title"]]:heading-s [&_[slot="title"]]:pr-14',
       // Footer
       '[&_[data-slot="footer"]]:flex [&_[data-slot="footer"]]:gap-x-2',
     )}
@@ -77,6 +76,29 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
       <>
         <Provider
           values={[
+            [
+              HeadingContext,
+              {
+                slots: {
+                  [DEFAULT_SLOT]: {}, // RAC requires a default slot in order to support non-slotted components
+                  title: {
+                    className: 'heading-s pr-14',
+                    _outerWrapper: (children) => (
+                      <div className="flex items-center justify-between">
+                        {children}
+                        <Button
+                          slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
+                          variant="tertiary"
+                          className="-mt-3 !px-2.5 data-[focus-visible]:outline-focus-inset"
+                        >
+                          <Close />
+                        </Button>
+                      </div>
+                    ),
+                  },
+                },
+              },
+            ],
             [
               ButtonContext,
               {
@@ -97,13 +119,6 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
         >
           {children}
         </Provider>
-        <Button
-          slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
-          variant="tertiary"
-          className="-mt-3 !px-2.5 absolute top-0 right-0 data-[focus-visible]:outline-focus-inset"
-        >
-          <Close />
-        </Button>
       </>
     )}
   </RACDialog>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -89,7 +89,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => {
                     title: {
                       className: 'heading-s',
                       _outerWrapper: (children) => (
-                        <div className="flex items-center justify-between">
+                        <div className="flex items-center justify-between gap-x-2">
                           {children}
                           <Button
                             slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -14,6 +14,8 @@ import {
 } from 'react-aria-components';
 import { Button } from '../button';
 import { HeadingContext } from '../content';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 type DialogTriggerProps = RACDialogTriggerProps;
 
@@ -63,72 +65,77 @@ type DialogProps = RACDialogProps & {
   children: React.ReactNode;
 };
 
-const Dialog = ({ className, children, ...restProps }: DialogProps) => (
-  <RACDialog
-    {...restProps}
-    className={cx(
-      'relative grid gap-y-5 outline-none',
-      // Footer
-      '[&_[data-slot="footer"]]:flex [&_[data-slot="footer"]]:gap-x-2',
-    )}
-  >
-    {({ close }) => (
-      <>
-        <Provider
-          values={[
-            [
-              HeadingContext,
-              {
-                slots: {
-                  [DEFAULT_SLOT]: {}, // RAC requires a default slot in order to support non-slotted components
-                  title: {
-                    className: 'heading-s pr-14',
-                    _outerWrapper: (children) => (
-                      <div className="flex items-center justify-between">
-                        {children}
-                        <Button
-                          slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
-                          variant="tertiary"
-                          className="!px-2.5 data-[focus-visible]:outline-focus-inset"
-                        >
-                          <Close />
-                        </Button>
-                      </div>
-                    ),
+const Dialog = ({ className, children, ...restProps }: DialogProps) => {
+  const locale = useLocale();
+
+  return (
+    <RACDialog
+      {...restProps}
+      className={cx(
+        'relative grid gap-y-5 outline-none',
+        // Footer
+        '[&_[data-slot="footer"]]:flex [&_[data-slot="footer"]]:gap-x-2',
+      )}
+    >
+      {({ close }) => (
+        <>
+          <Provider
+            values={[
+              [
+                HeadingContext,
+                {
+                  slots: {
+                    [DEFAULT_SLOT]: {}, // RAC requires a default slot in order to support non-slotted components
+                    title: {
+                      className: 'heading-s pr-14',
+                      _outerWrapper: (children) => (
+                        <div className="flex items-center justify-between">
+                          {children}
+                          <Button
+                            slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
+                            variant="tertiary"
+                            className="!px-2.5 data-[focus-visible]:outline-focus-inset"
+                            aria-label={translations.close[locale]}
+                          >
+                            <Close />
+                          </Button>
+                        </div>
+                      ),
+                    },
                   },
                 },
-              },
-            ],
-            [
-              ButtonContext,
-              {
-                // This is necessary to support multiple close buttons
-                slots: {
-                  // We need to define default slot in order to also support non-slotted buttons (i.e. buttons without slot prop)
-                  [DEFAULT_SLOT]: {
-                    className: 'w-fit',
-                  },
-                  close: {
-                    onPress: close,
-                    className: 'w-fit',
+              ],
+              [
+                ButtonContext,
+                {
+                  // This is necessary to support multiple close buttons
+                  slots: {
+                    // We need to define default slot in order to also support non-slotted buttons (i.e. buttons without slot prop)
+                    [DEFAULT_SLOT]: {
+                      className: 'w-fit',
+                    },
+                    close: {
+                      onPress: close,
+                      className: 'w-fit',
+                    },
                   },
                 },
-              },
-            ],
-          ]}
-        >
-          {children}
-        </Provider>
-      </>
-    )}
-  </RACDialog>
-);
+              ],
+            ]}
+          >
+            {children}
+          </Provider>
+        </>
+      )}
+    </RACDialog>
+  );
+};
 
 export {
-  type DialogTriggerProps as UNSAFE_DialogTriggerProps,
+  Dialog as UNSAFE_Dialog,
   DialogTrigger as UNSAFE_DialogTrigger,
-  type ModalProps as UNSAFE_ModalProps,
   Modal as UNSAFE_Modal,
   type DialogProps as UNSAFE_DialogProps,
-  Dialog as UNSAFE_Dialog,
+  type DialogTriggerProps as UNSAFE_DialogTriggerProps,
+  type ModalProps as UNSAFE_ModalProps,
 };

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -87,7 +87,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => {
                   slots: {
                     [DEFAULT_SLOT]: {}, // RAC requires a default slot in order to support non-slotted components
                     title: {
-                      className: 'heading-s pr-14',
+                      className: 'heading-s',
                       _outerWrapper: (children) => (
                         <div className="flex items-center justify-between">
                           {children}

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -75,13 +75,6 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
   >
     {({ close }) => (
       <>
-        <Button
-          slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
-          variant="tertiary"
-          className="-mt-3 !px-2.5 absolute top-0 right-0 data-[focus-visible]:outline-focus-inset"
-        >
-          <Close />
-        </Button>
         <Provider
           values={[
             [
@@ -104,6 +97,13 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
         >
           {children}
         </Provider>
+        <Button
+          slot="close" // RAC Dialog suppors one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
+          variant="tertiary"
+          className="-mt-3 !px-2.5 absolute top-0 right-0 data-[focus-visible]:outline-focus-inset"
+        >
+          <Close />
+        </Button>
       </>
     )}
   </RACDialog>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -31,6 +31,8 @@ const ModalOverlay = (props: ModalOverlayProps) => (
         'fixed inset-0 z-10 flex min-h-full items-center justify-center overflow-y-auto bg-black/25 p-4 text-center backdrop-blur',
         isEntering && 'fade-in animate-in duration-300 ease-out',
         isExiting && 'fade-out animate-out duration-200 ease-in',
+        // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
+        'motion-reduce:animate-none',
       )
     }
   />
@@ -48,6 +50,8 @@ const Modal = ({ className, ...restProps }: ModalProps) => (
           'w-full max-w-md overflow-hidden rounded-2xl bg-white p-4 text-left align-middle shadow-xl',
           isEntering && 'zoom-in-95 animate-in duration-300 ease-out',
           isExiting && 'zoom-out-95 animate-out duration-200 ease-in',
+          // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
+          'motion-reduce:animate-none',
         )
       }
     />

--- a/packages/react/src/translations.ts
+++ b/packages/react/src/translations.ts
@@ -1,0 +1,34 @@
+import type { Locale } from './use-locale';
+
+type Translation = {
+  [key in Locale]: string;
+};
+
+type Translations = {
+  [x: string]: Translation;
+};
+
+const translations: Translations = {
+  close: {
+    nb: 'Lukk',
+    sv: 'Stäng',
+    en: 'Close',
+  },
+  pending: {
+    nb: 'venter',
+    sv: 'väntar',
+    en: 'pending',
+  },
+  showMore: {
+    nb: 'Les mer',
+    sv: 'Läs mer',
+    en: 'Read more',
+  },
+  showLess: {
+    nb: 'Vis mindre',
+    sv: 'Dölj',
+    en: 'Show less',
+  },
+};
+
+export { translations, type Translation, type Translations };


### PR DESCRIPTION
## Modal

New `<Modal>` component that can be used for modal dialogs. It is pretty much just a small wrapper around the [Modal](https://react-spectrum.adobe.com/react-aria/Modal.html) component from `react-aria-components`.

It is basically enhanced with styling and with `isDismissable` always set to `true`, so that the modal is always closed when a user clicks outside the dialog. This makes sense, since it is designed to always have a button with a `<Close>` (X) icon in the upper right corner.

### Closing 

The `<Modal>` from RAC supports one close button defined by the `slot="close"` prop. This behavior is utilized for the button with the `<Close>` icon (X), which is always present in the dialog. In order to support multiple buttons that can close the modal, we utilize the `close` callback provided through the RAC `<Dialog>` children API.

In to pass the [WCAG Success Criterion 2.4.3 Focus Order](https://www.w3.org/TR/WCAG22/#focus-order), we put the close (X) button right after the title. This could also be solved by having `title` as a prop instead of a slotted child.

https://github.com/user-attachments/assets/ea59406a-2c97-46a5-9aa2-11927101d8cf

