### PR TITLE
docs: add props tables to ToC

### DIFF
--- a/apps/docs/app/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/$slug.tsx
@@ -69,6 +69,7 @@ function Page() {
         <TableOfContentsNav
           className="w-56 lg:sticky lg:top-9 lg:order-1 lg:shrink-0"
           content={data.content}
+          propsTables={data.propsComponents}
         />
         <div>
           {data.componentState === 'new' && (

--- a/apps/docs/app/ui/table-of-contents-nav.tsx
+++ b/apps/docs/app/ui/table-of-contents-nav.tsx
@@ -5,11 +5,13 @@ import type { COMPONENT_QUERYResult } from 'sanity.types';
 type TableOfContentsNavProps = {
   className?: string;
   content: NonNullable<COMPONENT_QUERYResult>['content'];
+  propsTables: string[] | null;
 };
 
 const TableOfContentsNav = ({
   className,
   content,
+  propsTables,
 }: TableOfContentsNavProps) => {
   const sections = (
     content?.filter(
@@ -25,6 +27,20 @@ const TableOfContentsNav = ({
     href: `#${_key}`,
     text: children[0].text,
   }));
+
+  if (propsTables && propsTables.length > 0) {
+    sections.push({
+      href: '#props',
+      text: 'Props',
+    });
+
+    for (const componentName of propsTables) {
+      sections.push({
+        href: `#${componentName.toLowerCase()}-props`,
+        text: componentName,
+      });
+    }
+  }
 
   return (
     // @ts-expect-error: the role prop is passed to the Card component, even though it is not valid TS


### PR DESCRIPTION
Legger til Props-tabellene til ToC.

<img width="277" alt="Screenshot 2025-03-24 at 12 32 05" src="https://github.com/user-attachments/assets/1b372438-85c1-4bda-952d-4e716e4c50bb" />
