### PR TITLE
docs: add nesting to ToC

### DIFF
--- a/apps/docs/app/ui/table-of-contents-nav.tsx
+++ b/apps/docs/app/ui/table-of-contents-nav.tsx
@@ -13,33 +13,44 @@ const TableOfContentsNav = ({
   content,
   propsTables,
 }: TableOfContentsNavProps) => {
-  const sections = (
-    content?.filter(
-      (c) =>
-        c._type === 'block' &&
-        // Only include headings (h1, h2, h3 etc.)
-        c.style?.startsWith('h'),
-    ) as {
-      _key: string;
-      children: { text: string }[];
-    }[]
-  ).map(({ _key, children }) => ({
-    href: `#${_key}`,
-    text: children[0].text,
-  }));
+  const sections: Array<{
+    href: string;
+    text: string;
+    subSections: Array<{ href: string; text: string }>;
+  }> = [];
+
+  for (const block of content ?? []) {
+    // a h2 marks the start of a new section
+    if (block._type === 'block' && block.style === 'h2') {
+      const section = {
+        href: `#${block._key}`,
+        text: block.children?.[0].text ?? '',
+        subSections: [],
+      };
+
+      sections.push(section);
+    }
+
+    // every h3 we discover is added to the latest section, as that is the section we are currently in
+    if (block._type === 'block' && block.style === 'h3') {
+      const latestSection = sections.at(-1);
+
+      latestSection?.subSections.push({
+        href: `#${block._key}`,
+        text: block.children?.[0].text ?? '',
+      });
+    }
+  }
 
   if (propsTables && propsTables.length > 0) {
     sections.push({
       href: '#props',
       text: 'Props',
-    });
-
-    for (const componentName of propsTables) {
-      sections.push({
+      subSections: propsTables.map((componentName) => ({
         href: `#${componentName.toLowerCase()}-props`,
         text: componentName,
-      });
-    }
+      })),
+    });
   }
 
   return (
@@ -47,10 +58,20 @@ const TableOfContentsNav = ({
     // biome-ignore lint/a11y/useSemanticElements: this is a navigation component styled as a card
     <Card role="navigation" className={cx(className, 'h-fit min-h-96 bg-mint')}>
       <Heading level={2}>Innhold</Heading>
-      <ul className="grid gap-y-[inherit]">
-        {sections?.map(({ href, text }) => (
+      <ul className="grid gap-y-4">
+        {sections?.map(({ href, text, subSections = [] }) => (
           <li key={href}>
             <a href={href}>{text}</a>
+
+            {subSections.length > 0 && (
+              <ul className="description mt-4 ml-4 grid gap-y-4">
+                {subSections.map(({ href, text }) => (
+                  <li key={href}>
+                    <a href={href}>{text}</a>
+                  </li>
+                ))}
+              </ul>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
Denne PRen legger til nesting av ToC i Grunnmuren dokumentasjonen.

Dette gjør det enklere å scanne innholdsfortegnelsen. Har lagt inn støtte for h2 og h3. Eventuelle mindre heading ignoreres fra innholdsfortegnelsen.

<img width="374" alt="Screenshot 2025-03-24 at 14 51 09" src="https://github.com/user-attachments/assets/8c0761f2-2b38-413e-bcd1-789cf0670a8c" />
