### PR TITLE
Add top spacing

### DIFF
--- a/apps/docs/app/routes/_docs/$slug.tsx
+++ b/apps/docs/app/routes/_docs/$slug.tsx
@@ -39,13 +39,6 @@ export const Route = createFileRoute('/_docs/$slug')({
 function Page() {
   const { data } = Route.useLoaderData();
 
-  const ghLink = data.resourceLinks?.find(
-    (link) => link.linkType === 'github',
-  )?.url;
-  const figmaLink = data.resourceLinks?.find(
-    (link) => link.linkType === 'figma',
-  )?.url;
-
   return (
     <>
       <h1 className="heading-l mb-4">{data.name}</h1>

--- a/apps/docs/app/routes/_docs/$slug.tsx
+++ b/apps/docs/app/routes/_docs/$slug.tsx
@@ -41,7 +41,7 @@ function Page() {
 
   return (
     <>
-      <h1 className="heading-l mb-4">{data.name}</h1>
+      <h1 className="heading-l my-12">{data.name}</h1>
       {data.resourceLinks && (
         <ResourceLinks className="mb-12">
           {data.resourceLinks?.map(

--- a/apps/docs/app/routes/_docs/index.tsx
+++ b/apps/docs/app/routes/_docs/index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/_docs/')({
 function Home() {
   return (
     <>
-      <h1 className="heading-l mb-12">Grunnmuren</h1>
+      <h1 className="heading-l my-12">Grunnmuren</h1>
       <div className="grid grid-cols-2 gap-4">
         <Card variant="outlined">
           <Heading level={2}>

--- a/apps/docs/app/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/$slug.tsx
@@ -55,7 +55,7 @@ function Page() {
 
   return (
     <>
-      <h1 className="heading-l mb-4">{data.name}</h1>
+      <h1 className="heading-l my-12">{data.name}</h1>
 
       <ResourceLinks className="mb-12">
         {data.resourceLinks?.map(

--- a/apps/docs/app/routes/_docs/komponenter/index.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/index.tsx
@@ -25,7 +25,7 @@ function Page() {
 
   return (
     <>
-      <h1 className="heading-l mt-9 mb-12">Komponenter</h1>
+      <h1 className="heading-l my-12">Komponenter</h1>
       <div className="grid grid-cols-2 gap-4">
         {components.map((component) => (
           <Card key={component._id} variant="outlined">

--- a/apps/docs/app/routes/_docs/profil/farger.tsx
+++ b/apps/docs/app/routes/_docs/profil/farger.tsx
@@ -48,7 +48,7 @@ function RouteComponent() {
 
   return (
     <>
-      <h1 className="heading-l mt-9 mb-12">Farger</h1>
+      <h1 className="heading-l my-12">Farger</h1>
       <div className="prose mb-12">
         <p>Grunnmuren har {Object.keys(colors).length} forskjellige farger.</p>
       </div>

--- a/apps/docs/app/routes/_docs/profil/ikoner.tsx
+++ b/apps/docs/app/routes/_docs/profil/ikoner.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/_docs/profil/ikoner')({
 function Page() {
   return (
     <>
-      <h1 className="heading-l mt-9 mb-12">Ikoner</h1>
+      <h1 className="heading-l my-12">Ikoner</h1>
       <div className="prose">
         <p>
           Grunnmuren sitt ikonsett består av {Object.keys(icons).length}{' '}

--- a/apps/docs/app/routes/_docs/profil/index.tsx
+++ b/apps/docs/app/routes/_docs/profil/index.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute('/_docs/profil/')({
 function Page() {
   return (
     <>
-      <h1 className="heading-l mt-9 mb-12">Profil</h1>
+      <h1 className="heading-l my-12">Profil</h1>
       <div className="grid grid-cols-2 gap-4">
         <Card variant="outlined">
           <Heading level={2}>


### PR DESCRIPTION
## Top spacing for `<h1>` tags

Adding equal spacing above and below `<h1>` tags in the docs. It would be closer to `my-9` in figma, but that just looks off next to the OBOS logo in the menu. So increasing it a bit made it look more deliberant

![Screenshot 2025-03-25 at 09 23 28](https://github.com/user-attachments/assets/bfca0efe-a29c-4cfc-a796-2f2f6584769c)

![Screenshot 2025-03-25 at 09 24 09](https://github.com/user-attachments/assets/cf6b3f98-e1c1-49bb-b967-4929f4dd3c70)
