### PR TITLE
hide table of contents nav on small view screens

### DIFF
--- a/apps/docs/app/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/$slug.tsx
@@ -67,7 +67,7 @@ function Page() {
       </ResourceLinks>
       <div className="lg:relative lg:flex lg:gap-[var(--gm-container-gutter-width)]">
         <TableOfContentsNav
-          className="w-56 lg:sticky lg:top-9 lg:order-1 lg:shrink-0"
+          className="hidden w-56 lg:sticky lg:top-9 lg:order-1 lg:block lg:shrink-0"
           content={data.content}
           propsTables={data.propsComponents}
         />


### PR DESCRIPTION
Hides table of contents `nav` on small screens