### PR TITLE
Remove ref forwarding

### DIFF
--- a/packages/react/src/accordion/accordion.tsx
+++ b/packages/react/src/accordion/accordion.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown } from '@obosbbl/grunnmuren-icons-react';
 import { useLayoutEffect } from '@react-aria/utils';
 import { cx } from 'cva';
-import { Children, type Ref, forwardRef, useId, useState } from 'react';
+import { Children, type Ref, useId, useState } from 'react';
 import { Provider } from 'react-aria-components';
 
 import { ContentContext, HeadingContext } from '../content';
@@ -14,6 +14,8 @@ type AccordionProps = {
 
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref to the element. */
+  ref?: Ref<HTMLDivElement>;
 };
 
 type AccordionItemProps = {
@@ -31,6 +33,7 @@ type AccordionItemProps = {
   defaultOpen?: boolean;
   /** Handler that is called when the accordion's open state changes */
   onOpenChange?: (isOpen: boolean) => void;
+  ref?: Ref<HTMLDivElement>;
 };
 
 function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
@@ -169,11 +172,9 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
   );
 }
 
-const _Accordion = forwardRef(Accordion);
-const _AccordionItem = forwardRef(AccordionItem);
 export {
-  _Accordion as Accordion,
-  _AccordionItem as AccordionItem,
+  Accordion,
+  AccordionItem,
   type AccordionItemProps,
   type AccordionProps,
 };

--- a/packages/react/src/accordion/accordion.tsx
+++ b/packages/react/src/accordion/accordion.tsx
@@ -36,17 +36,13 @@ type AccordionItemProps = {
   ref?: Ref<HTMLDivElement>;
 };
 
-function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
+function Accordion(props: AccordionProps) {
   const { children, className, ...restProps } = props;
 
   const childCount = Children.count(children);
 
   return (
-    <div
-      {...restProps}
-      ref={ref}
-      className={cx('rounded-lg bg-white', className)}
-    >
+    <div {...restProps} className={cx('rounded-lg bg-white', className)}>
       {Children.map(children, (child, index) => (
         <>
           {child}
@@ -60,7 +56,7 @@ function Accordion(props: AccordionProps, ref: Ref<HTMLDivElement>) {
   );
 }
 
-function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
+function AccordionItem(props: AccordionItemProps) {
   const {
     className,
     children,
@@ -109,7 +105,6 @@ function AccordionItem(props: AccordionItemProps, ref: Ref<HTMLDivElement>) {
     <div
       {...restProps}
       className={cx('relative px-2', className)}
-      ref={ref}
       data-open={isOpen}
     >
       <Provider

--- a/packages/react/src/backlink/backlink.tsx
+++ b/packages/react/src/backlink/backlink.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref, CSSProperties } from 'react';
 import {
   Button,
   type ButtonProps,
@@ -18,6 +18,8 @@ type ButtonOrLinkProps = {
    * @default false
    */
   withUnderline?: boolean;
+  /** Ref to the element. */
+  ref?: Ref<HTMLAnchorElement | HTMLButtonElement>;
 };
 
 type BacklinkProps = (ButtonProps | RACLinkProps) & ButtonOrLinkProps;
@@ -28,24 +30,17 @@ function isLinkProps(
   return !!props.href;
 }
 
-function Backlink(
-  props: BacklinkProps,
-  ref: Ref<HTMLAnchorElement | HTMLButtonElement>,
-) {
-  const { className, children, withUnderline, ...restProps } = props;
+function Backlink(props: BacklinkProps) {
+  const { className, style, children, withUnderline, ref, ...restProps } =
+    props;
 
-  const Component = isLinkProps(props) ? Link : Button;
+  const _className = cx(
+    className,
+    'group flex max-w-fit cursor-pointer items-center gap-3 rounded-md p-2.5 no-underline focus-visible:outline-focus',
+  );
 
-  return (
-    <Component
-      className={cx(
-        className,
-        'group flex max-w-fit cursor-pointer items-center gap-3 rounded-md p-2.5 no-underline focus-visible:outline-focus',
-      )}
-      {...restProps}
-      // @ts-expect-error ignore the type of the ref here
-      ref={ref}
-    >
+  const content = (
+    <>
       <ChevronLeft
         className={cx(
           '-ml-[0.5em] group-hover:-translate-x-1 shrink-0 transition-transform duration-300',
@@ -62,9 +57,32 @@ function Backlink(
           {children}
         </span>
       </span>
-    </Component>
+    </>
+  );
+
+  if (isLinkProps(props)) {
+    return (
+      <Link
+        {...restProps}
+        className={_className}
+        style={style as CSSProperties}
+        ref={ref as Ref<HTMLAnchorElement>}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <Button
+      {...restProps}
+      className={_className}
+      style={style as CSSProperties}
+      ref={ref as Ref<HTMLButtonElement>}
+    >
+      {content}
+    </Button>
   );
 }
 
-const _Backlink = forwardRef(Backlink);
-export { _Backlink as Backlink, type BacklinkProps };
+export { Backlink, type BacklinkProps };

--- a/packages/react/src/backlink/backlink.tsx
+++ b/packages/react/src/backlink/backlink.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import type { Ref, CSSProperties } from 'react';
+import type { CSSProperties, Ref } from 'react';
 import {
   Button,
   type ButtonProps,

--- a/packages/react/src/badge/badge.tsx
+++ b/packages/react/src/badge/badge.tsx
@@ -1,9 +1,12 @@
 import { type VariantProps, cva } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 
 type BadgeProps = VariantProps<typeof badgeVariants> & {
   children?: React.ReactNode;
+  /** Additional CSS className for the element. */
   className?: string;
+  /** Ref to the element. */
+  ref?: Ref<HTMLSpanElement>;
 };
 
 const badgeVariants = cva({
@@ -30,7 +33,7 @@ const badgeVariants = cva({
   },
 });
 
-function Badge(props: BadgeProps, ref: Ref<HTMLSpanElement>) {
+function Badge(props: BadgeProps) {
   const { className: _className, color, size, ...restProps } = props;
 
   const className = badgeVariants({
@@ -39,10 +42,7 @@ function Badge(props: BadgeProps, ref: Ref<HTMLSpanElement>) {
     size,
   });
 
-  return (
-    <span className={className} {...restProps} ref={ref} data-slot="badge" />
-  );
+  return <span className={className} {...restProps} data-slot="badge" />;
 }
 
-const _Badge = forwardRef(Badge);
-export { _Badge as Badge, type BadgeProps };
+export { Badge, type BadgeProps };

--- a/packages/react/src/breadcrumbs/breadcrumb.tsx
+++ b/packages/react/src/breadcrumbs/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   Link,
   Breadcrumb as RACBreadcrumb,
@@ -18,16 +18,17 @@ type BreadcrumbProps = {
 
   /** The URL to navigate to when clicking the breadcrumb. */
   href?: RACLinkProps['href'];
+  /** Ref to the element. */
+  ref?: Ref<HTMLLIElement>;
 } & Omit<RACBreadcrumbProps, 'className' | 'style'>;
 
-function Breadcrumb(props: BreadcrumbProps, ref: Ref<HTMLLIElement>) {
+function Breadcrumb(props: BreadcrumbProps) {
   const { className, children, href, ...restProps } = props;
 
   return (
     <RACBreadcrumb
       className={cx(className, 'group flex items-center')}
       {...restProps}
-      ref={ref}
     >
       {href ? (
         <Link
@@ -45,5 +46,4 @@ function Breadcrumb(props: BreadcrumbProps, ref: Ref<HTMLLIElement>) {
   );
 }
 
-const _Breadcrumb = forwardRef(Breadcrumb);
-export { _Breadcrumb as Breadcrumb, type BreadcrumbProps };
+export { Breadcrumb, type BreadcrumbProps };

--- a/packages/react/src/breadcrumbs/breadcrumbs.tsx
+++ b/packages/react/src/breadcrumbs/breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   Breadcrumbs as RACBreadcrumbs,
   type BreadcrumbsProps as RACBreadcrumbsProps,
@@ -12,21 +12,21 @@ type BreadcrumbsProps = {
 
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref to the element. */
+  ref?: Ref<HTMLOListElement>;
 } & Omit<RACBreadcrumbsProps<BreadcrumbProps>, 'className' | 'style'>;
 
-function Breadcrumbs(props: BreadcrumbsProps, ref: Ref<HTMLOListElement>) {
+function Breadcrumbs(props: BreadcrumbsProps) {
   const { className, children, ...restProps } = props;
 
   return (
     <RACBreadcrumbs
       {...restProps}
       className={cx(className, 'flex flex-wrap text-sm leading-6')}
-      ref={ref}
     >
       {children}
     </RACBreadcrumbs>
   );
 }
 
-const _Breadcrumbs = forwardRef(Breadcrumbs);
-export { _Breadcrumbs as Breadcrumbs, type BreadcrumbsProps };
+export { Breadcrumbs, type BreadcrumbsProps };

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@obosbbl/grunnmuren-icons-react';
 import { type VariantProps, cva } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import { useProgressBar } from 'react-aria';
 import {
   Button as RACButton,
@@ -124,6 +124,8 @@ type ButtonOrLinkProps = VariantProps<typeof buttonVariants> & {
   isLoading?: boolean;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref to the element. */
+  ref?: Ref<HTMLButtonElement | HTMLAnchorElement>;
 };
 
 type ButtonProps = (RACButtonProps | RACLinkProps) & ButtonOrLinkProps;
@@ -134,10 +136,7 @@ function isLinkProps(
   return !!props.href;
 }
 
-function Button(
-  props: ButtonProps,
-  ref: Ref<HTMLButtonElement | HTMLAnchorElement>,
-) {
+function Button(props: ButtonProps) {
   const {
     children: _children,
     color,
@@ -145,6 +144,7 @@ function Button(
     isLoading,
     variant,
     isPending: _isPending,
+    ref,
     ...restProps
   } = props;
 
@@ -181,7 +181,7 @@ function Button(
     <RACLink
       {...restProps}
       className={className}
-      ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+      ref={ref as Ref<HTMLAnchorElement>}
     >
       {children}
     </RACLink>
@@ -190,12 +190,11 @@ function Button(
       {...restProps}
       className={className}
       isPending={isPending}
-      ref={ref as React.ForwardedRef<HTMLButtonElement>}
+      ref={ref as Ref<HTMLButtonElement>}
     >
       {children}
     </RACButton>
   );
 }
 
-const _Button = forwardRef(Button);
-export { _Button as Button, type ButtonProps };
+export { Button, type ButtonProps };

--- a/packages/react/src/checkbox/checkbox-group.tsx
+++ b/packages/react/src/checkbox/checkbox-group.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   CheckboxGroup as RACCheckboxGroup,
   type CheckboxGroupProps as RACCheckboxGroupProps,
@@ -21,6 +21,8 @@ type CheckboxGroupProps = {
   label?: React.ReactNode;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref to the element. */
+  ref?: Ref<HTMLDivElement>;
 } & Omit<
   RACCheckboxGroupProps,
   | 'className'
@@ -31,7 +33,7 @@ type CheckboxGroupProps = {
   | 'orientation'
 >;
 
-function CheckboxGroup(props: CheckboxGroupProps, ref: Ref<HTMLDivElement>) {
+function CheckboxGroup(props: CheckboxGroupProps) {
   const {
     children,
     className,
@@ -53,7 +55,6 @@ function CheckboxGroup(props: CheckboxGroupProps, ref: Ref<HTMLDivElement>) {
       className={cx(className, 'flex flex-col gap-2')}
       isInvalid={isInvalid}
       isRequired={isRequired}
-      ref={ref}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
@@ -63,5 +64,4 @@ function CheckboxGroup(props: CheckboxGroupProps, ref: Ref<HTMLDivElement>) {
   );
 }
 
-const _CheckboxGroup = forwardRef(CheckboxGroup);
-export { _CheckboxGroup as CheckboxGroup, type CheckboxGroupProps };
+export { CheckboxGroup, type CheckboxGroupProps };

--- a/packages/react/src/checkbox/checkbox.tsx
+++ b/packages/react/src/checkbox/checkbox.tsx
@@ -1,6 +1,6 @@
 import { Check as CheckIcon } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import { useId } from 'react';
 import {
   CheckboxContext,
@@ -52,12 +52,14 @@ type CheckboxProps = {
   errorMessage?: React.ReactNode;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref for the element. */
+  ref?: Ref<HTMLLabelElement>;
 } & Omit<
   RACCheckboxProps,
   'isDisabled' | 'style' | 'children' | 'isIndeterminate' | 'isReadOnly'
 >;
 
-function Checkbox(props: CheckboxProps, ref: Ref<HTMLLabelElement>) {
+function Checkbox(props: CheckboxProps) {
   const {
     children,
     className,
@@ -86,7 +88,6 @@ function Checkbox(props: CheckboxProps, ref: Ref<HTMLLabelElement>) {
           {...restProps}
           className={cx(className, defaultClasses)}
           isInvalid={isInvalid}
-          ref={ref}
         >
           <CheckmarkBox />
           {children}
@@ -112,5 +113,4 @@ function Checkbox(props: CheckboxProps, ref: Ref<HTMLLabelElement>) {
   );
 }
 
-const _Checkbox = forwardRef(Checkbox);
-export { _Checkbox as Checkbox, type CheckboxProps };
+export { Checkbox, type CheckboxProps };

--- a/packages/react/src/combobox/combobox.stories.tsx
+++ b/packages/react/src/combobox/combobox.stories.tsx
@@ -56,7 +56,7 @@ const Template = <T extends object>(args: ComboboxProps<T>) => {
 };
 
 const ControlledTemplate = <T extends object>(args: ComboboxProps<T>) => {
-  const [value, setValue] = useState<string | number>(counties[0].name);
+  const [value, setValue] = useState<string | number | null>(counties[0].name);
 
   return (
     <div className="flex flex-col gap-2">

--- a/packages/react/src/combobox/combobox.tsx
+++ b/packages/react/src/combobox/combobox.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, LoadingSpinner } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   Button,
   Group,
@@ -46,15 +46,14 @@ type ComboboxProps<T extends object> = {
   placeholder?: string;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref for the input element. */
+  ref?: Ref<HTMLInputElement>;
 } & Omit<
   RACComboboxProps<T>,
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-function Combobox<T extends object>(
-  props: ComboboxProps<T>,
-  ref: Ref<HTMLInputElement>,
-) {
+function Combobox<T extends object>(props: ComboboxProps<T>) {
   const {
     className,
     children,
@@ -64,6 +63,7 @@ function Combobox<T extends object>(
     isPending: _isPending,
     label,
     isInvalid: _isInvalid,
+    ref,
     ...restProps
   } = props;
 
@@ -112,10 +112,8 @@ function Combobox<T extends object>(
   );
 }
 
-const _Combobox = forwardRef(Combobox);
-
 export {
-  _Combobox as Combobox,
+  Combobox,
   ListBoxHeader as ComboboxHeader,
   ListBoxItem as ComboboxItem,
   ListBoxSection as ComboboxSection,

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'cva';
-import { type HTMLProps, type Ref, createContext, forwardRef } from 'react';
+import { type HTMLProps, type Ref, createContext } from 'react';
 import { type ContextValue, useContextProps } from 'react-aria-components';
 
 type HeadingProps = HTMLProps<HTMLHeadingElement> & {
@@ -10,14 +10,15 @@ type HeadingProps = HTMLProps<HTMLHeadingElement> & {
   _innerWrapper?: (children: React.ReactNode) => React.ReactNode;
   /** @private Used internally for slotted components */
   _outerWrapper?: (children: React.ReactNode) => React.ReactNode;
+  /** Ref for the element. */
+  ref?: Ref<HTMLHeadingElement>;
 };
 
 const HeadingContext = createContext<
   ContextValue<Partial<HeadingProps>, HTMLHeadingElement>
 >({});
 
-const Heading = (props: HeadingProps, ref: Ref<HTMLHeadingElement>) => {
-  // biome-ignore lint/style/noParameterAssign: fix when removing refs for React 19
+const Heading = ({ ref = null, ...props }: HeadingProps) => {
   [props, ref] = useContextProps(props, ref, HeadingContext);
 
   const {
@@ -48,10 +49,11 @@ type ContentProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
   /** @private Used internally for slotted components */
   _outerWrapper?: (children: React.ReactNode) => React.ReactNode;
+  /** Ref for the element. */
+  ref?: Ref<HTMLDivElement>;
 };
 
-const Content = (props: ContentProps, ref: Ref<HTMLDivElement>) => {
-  // biome-ignore lint/style/noParameterAssign: fix when removing refs for React 19
+const Content = ({ ref = null, ...props }: ContentProps) => {
   [props, ref] = useContextProps(props, ref, ContentContext);
   const { _outerWrapper: outerWrapper, ...restProps } = props;
 
@@ -84,15 +86,12 @@ const Caption = ({ className, ...restProps }: CaptionProps) => (
 
 const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
-const _Heading = forwardRef(Heading);
-const _Content = forwardRef(Content);
-
 export {
   Caption,
-  _Content as Content,
+  Content,
   ContentContext,
   Footer,
-  _Heading as Heading,
+  Heading,
   HeadingContext,
   Media,
   type CaptionProps,

--- a/packages/react/src/numberfield/numberfield.tsx
+++ b/packages/react/src/numberfield/numberfield.tsx
@@ -1,6 +1,6 @@
 // This component is based on a copy of ../textfield/TextField, refactoring is TBD: https://github.com/code-obos/grunnmuren/pull/722#issuecomment-1931478786
 import { compose, cva, cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   Group,
   Input,
@@ -44,6 +44,8 @@ type NumberFieldProps = {
   maxValue?: number;
   /** Defines the minimum numeric value */
   minValue?: number;
+  /** Ref for the input element. */
+  ref?: Ref<HTMLInputElement>;
 } & Omit<
   RACNumberFieldProps,
   | 'className'
@@ -71,7 +73,7 @@ const inputVariants = compose(
   }),
 );
 
-function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
+function NumberField(props: NumberFieldProps) {
   const {
     className,
     description,
@@ -83,6 +85,7 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
     rightAddon,
     withAddonDivider,
     size,
+    ref,
     ...restProps
   } = props;
 
@@ -128,5 +131,4 @@ function NumberField(props: NumberFieldProps, ref: Ref<HTMLInputElement>) {
   );
 }
 
-const _NumberField = forwardRef(NumberField);
-export { _NumberField as NumberField, type NumberFieldProps };
+export { NumberField, type NumberFieldProps };

--- a/packages/react/src/radiogroup/radio-group.tsx
+++ b/packages/react/src/radiogroup/radio-group.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   RadioGroup as RACRadioGroup,
   type RadioGroupProps as RACRadioGroupProps,
@@ -21,6 +21,8 @@ type RadioGroupProps = {
   label?: React.ReactNode;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref for the element. */
+  ref?: Ref<HTMLDivElement>;
 } & Omit<
   RACRadioGroupProps,
   | 'className'
@@ -31,7 +33,7 @@ type RadioGroupProps = {
   | 'orientation'
 >;
 
-function RadioGroup(props: RadioGroupProps, ref: Ref<HTMLDivElement>) {
+function RadioGroup(props: RadioGroupProps) {
   const {
     children,
     className,
@@ -53,7 +55,6 @@ function RadioGroup(props: RadioGroupProps, ref: Ref<HTMLDivElement>) {
       className={cx(className, 'flex flex-col gap-2')}
       isInvalid={isInvalid}
       isRequired={isRequired}
-      ref={ref}
     >
       {label && <Label>{label}</Label>}
       {description && <Description>{description}</Description>}
@@ -63,5 +64,4 @@ function RadioGroup(props: RadioGroupProps, ref: Ref<HTMLDivElement>) {
   );
 }
 
-const _RadioGroup = forwardRef(RadioGroup);
-export { _RadioGroup as RadioGroup, type RadioGroupProps };
+export { RadioGroup, type RadioGroupProps };

--- a/packages/react/src/radiogroup/radio.tsx
+++ b/packages/react/src/radiogroup/radio.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   type RadioProps as RACRAdioProps,
   Radio as RACRadio,
@@ -35,16 +35,14 @@ type RadioProps = {
   description?: React.ReactNode;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref for the element. */
+  ref?: Ref<HTMLLabelElement>;
 } & Omit<RACRAdioProps, 'isDisabled' | 'children' | 'style'>;
 
-function Radio(props: RadioProps, ref: Ref<HTMLLabelElement>) {
+function Radio(props: RadioProps) {
   const { children, className, description, ...restProps } = props;
   return (
-    <RACRadio
-      {...restProps}
-      className={cx(className, defaultClasses)}
-      ref={ref}
-    >
+    <RACRadio {...restProps} className={cx(className, defaultClasses)}>
       <div>
         {children}
         {description && (
@@ -55,5 +53,4 @@ function Radio(props: RadioProps, ref: Ref<HTMLLabelElement>) {
   );
 }
 
-const _Radio = forwardRef(Radio);
-export { _Radio as Radio, type RadioProps };
+export { Radio, type RadioProps };

--- a/packages/react/src/select/select.tsx
+++ b/packages/react/src/select/select.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   Button,
   Popover,
@@ -35,15 +35,14 @@ type SelectProps<T extends object> = {
   placeholder?: string;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
+  /** Ref for the button element. */
+  ref?: Ref<HTMLButtonElement>;
 } & Omit<
   RACSelectProps<T>,
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-function Select<T extends object>(
-  props: SelectProps<T>,
-  ref: Ref<HTMLButtonElement>,
-) {
+function Select<T extends object>(props: SelectProps<T>) {
   const {
     className,
     children,
@@ -51,6 +50,7 @@ function Select<T extends object>(
     errorMessage,
     label,
     isInvalid: _isInvalid,
+    ref,
     ...restProps
   } = props;
 
@@ -89,9 +89,8 @@ function Select<T extends object>(
   );
 }
 
-const _Select = forwardRef(Select);
 export {
-  _Select as Select,
+  Select,
   ListBoxItem as SelectItem,
   type SelectProps,
   type ListBoxItemProps as SelectItemProps,

--- a/packages/react/src/textarea/textarea.tsx
+++ b/packages/react/src/textarea/textarea.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   TextArea as RACTextArea,
   TextField as RACTextField,
@@ -29,12 +29,14 @@ type TextAreaProps = {
    * @default 2
    */
   rows?: number;
+  /** Ref for the textarea element. */
+  ref?: Ref<HTMLTextAreaElement>;
 } & Omit<
   RACTextFieldProps,
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
 >;
 
-function TextArea(props: TextAreaProps, ref: Ref<HTMLTextAreaElement>) {
+function TextArea(props: TextAreaProps) {
   const {
     className,
     description,
@@ -42,6 +44,7 @@ function TextArea(props: TextAreaProps, ref: Ref<HTMLTextAreaElement>) {
     label,
     isInvalid: _isInvalid,
     rows,
+    ref,
     ...restProps
   } = props;
 
@@ -61,5 +64,4 @@ function TextArea(props: TextAreaProps, ref: Ref<HTMLTextAreaElement>) {
   );
 }
 
-const _TextArea = forwardRef(TextArea);
-export { _TextArea as TextArea, type TextAreaProps };
+export { TextArea, type TextAreaProps };

--- a/packages/react/src/textfield/textfield.tsx
+++ b/packages/react/src/textfield/textfield.tsx
@@ -1,5 +1,5 @@
 import { compose, cva, cx } from 'cva';
-import { type Ref, forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   Group,
   Input,
@@ -39,6 +39,8 @@ type TextFieldProps = {
   withAddonDivider?: boolean;
   /** Defines the number of characters and determines the width of the input element */
   size?: number;
+  /** Ref for the input element. */
+  ref?: Ref<HTMLInputElement>;
 } & Omit<
   RACTextFieldProps,
   'className' | 'isReadOnly' | 'isDisabled' | 'children' | 'style'
@@ -61,7 +63,7 @@ const inputVariants = compose(
   }),
 );
 
-function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
+function TextField(props: TextFieldProps) {
   const {
     className,
     description,
@@ -73,6 +75,7 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
     rightAddon,
     withAddonDivider,
     size,
+    ref,
     ...restProps
   } = props;
 
@@ -118,5 +121,4 @@ function TextField(props: TextFieldProps, ref: Ref<HTMLInputElement>) {
   );
 }
 
-const _TextField = forwardRef(TextField);
-export { _TextField as TextField, type TextFieldProps };
+export { TextField, type TextFieldProps };


### PR DESCRIPTION
## Remove ref forwarding

Removes `ref` forwarding as it is no longer necessary (since we dropped support for React 18)