### PR TITLE
Remove internal fonts folder

### DIFF
--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -13,8 +13,7 @@
   "files": [
     "tailwind-base.css",
     "tailwind-typography.css",
-    "font.css",
-    "./fonts"
+    "font.css"
   ],
   "scripts": {
     "font-fallback": "bun --cwd=./fonts ./generate-font-fallback.ts"


### PR DESCRIPTION
Removes internal `fonts` folder from files in `package.json` - these files are only used to build the font.css file.