### PR TITLE
Fix error message validation logic

### DIFF
--- a/.changeset/clear-rings-think.md
+++ b/.changeset/clear-rings-think.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixes the logic behind validation states for inputs, where passing `errorMessage=""` would set the field in an invalid state. This doesn't really make sense, and can cause strange validation behaviour when using libraries like Zod. With this change setting `errorMessage` to `"" | null | undefined` is now equivalent: the field is valid, unless combined with the `isInvalid` prop set to `true`.

--- a/packages/react/src/checkbox/checkbox-group.tsx
+++ b/packages/react/src/checkbox/checkbox-group.tsx
@@ -47,7 +47,7 @@ function CheckboxGroup(props: CheckboxGroupProps) {
 
   // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
   // which will override any built in validation
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <RACCheckboxGroup

--- a/packages/react/src/checkbox/checkbox.tsx
+++ b/packages/react/src/checkbox/checkbox.tsx
@@ -74,7 +74,7 @@ function Checkbox(props: CheckboxProps) {
   const descriptionId = `desc${id}`;
   const errorMessageId = `error${id}`;
 
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <div>

--- a/packages/react/src/combobox/combobox.tsx
+++ b/packages/react/src/combobox/combobox.tsx
@@ -71,7 +71,7 @@ function Combobox<T extends object>(props: ComboboxProps<T>) {
 
   // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
   // which will override any built in validation
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <RACCombobox

--- a/packages/react/src/numberfield/numberfield.tsx
+++ b/packages/react/src/numberfield/numberfield.tsx
@@ -91,7 +91,7 @@ function NumberField(props: NumberFieldProps) {
 
   // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
   // which will override any built in validation
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <RACNumberField

--- a/packages/react/src/radiogroup/radio-group.stories.tsx
+++ b/packages/react/src/radiogroup/radio-group.stories.tsx
@@ -143,7 +143,6 @@ export const WithErrorMessage: Story = {
 
   args: {
     ...defaultProps,
-    isInvalid: true,
     errorMessage: 'Det valgte alternativet er ikke gyldig',
   },
 };

--- a/packages/react/src/radiogroup/radio-group.tsx
+++ b/packages/react/src/radiogroup/radio-group.tsx
@@ -47,7 +47,7 @@ function RadioGroup(props: RadioGroupProps) {
 
   // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
   // which will override any built in validation
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <RACRadioGroup

--- a/packages/react/src/select/select.tsx
+++ b/packages/react/src/select/select.tsx
@@ -56,7 +56,7 @@ function Select<T extends object>(props: SelectProps<T>) {
 
   // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
   // which will override any built in validation
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <RACSelect

--- a/packages/react/src/textarea/textarea.tsx
+++ b/packages/react/src/textarea/textarea.tsx
@@ -48,7 +48,7 @@ function TextArea(props: TextAreaProps) {
     ...restProps
   } = props;
 
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <RACTextField

--- a/packages/react/src/textfield/textfield.tsx
+++ b/packages/react/src/textfield/textfield.tsx
@@ -81,7 +81,7 @@ function TextField(props: TextFieldProps) {
 
   // the order of the conditions matter here, because providing a value for isInvalid makes the validation state "controlled",
   // which will override any built in validation
-  const isInvalid = errorMessage != null || _isInvalid;
+  const isInvalid = !!errorMessage || _isInvalid;
 
   return (
     <RACTextField


### PR DESCRIPTION
## Fix validation state logic for input components

Fixes the logic behind validation states for inputs, where passing `errorMessage=""` would set the field in an invalid state. This doesn't really make sense, and can cause strange validation behaviour when using libraries like Zod. With this change setting `errorMessage` to `"" | null | undefined` is now equivalent: the field is valid, unless combined with the `isInvalid` prop set to `true`.

## Examples of invalid states

``` tsx
<TexField isInvalid/>
```

``` tsx
<TexField errorMessage="Something went wrong"/>
```

``` tsx
<TexField isInvalid errorMessage="Something went wrong"/>
```

``` tsx
<TexField isInvalid errorMessage=""/>
```

``` tsx
<TexField isInvalid errorMessage={null}/>
```

``` tsx
<TexField isInvalid errorMessage={undefined}/>
```

## Examples of valid states


``` tsx
<TexField/>
```

``` tsx
<TexField isInvalid={false}/>
```

``` tsx
<TexField errorMessage=""/>
```

``` tsx
<TexField errorMessage={null}/>
```

``` tsx
<TexField errorMessage={undefined}/>
```

