### PR TITLE
Fix line-height for heading-s

### DIFF
--- a/.changeset/stupid-paths-matter.md
+++ b/.changeset/stupid-paths-matter.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+Fix the `line-height` of the `heading-s` class. The correct `line-height` is `1.875rem`, but it was set to `1.1875rem` for small screens.

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -127,7 +127,7 @@
 }
 
 @utility heading-s {
-  @apply font-text font-medium text-[1.1875rem]/[1.1875rem] lg:text-[1.3125rem]/[2.125rem];
+  @apply font-text font-medium text-[1.1875rem]/[1.875rem] lg:text-[1.3125rem]/[2.125rem];
 }
 
 @utility heading-xs {


### PR DESCRIPTION
## Fix line-height for heading-s

Sets the correct line-height for the heading-s class on small screens.