### PR TITLE
Filter out empty dummy file object in from examples

### DIFF
--- a/packages/react/src/file-upload/file-upload.stories.tsx
+++ b/packages/react/src/file-upload/file-upload.stories.tsx
@@ -101,11 +101,14 @@ export const Required: Story = {
         onSubmit={(e) => {
           e.preventDefault();
           const formData = new FormData(e.target as HTMLFormElement);
+          const files = formData
+            .getAll('files')
+            .filter(
+              (file) => file instanceof File && file.size > 0 && file.name,
+            );
+
           alert(
-            `Lastet opp ${formData
-              .getAll('files')
-              .map((file) => (file as File).name)
-              .join(', ')}`,
+            `Lastet opp ${files.map((file) => (file as File).name).join(', ')}`,
           );
         }}
       >
@@ -143,17 +146,17 @@ export const InForm = () => (
     onSubmit={(e) => {
       e.preventDefault();
       const formData = new FormData(e.target as HTMLFormElement);
+      const files = formData
+        .getAll('files')
+        .filter((file) => file instanceof File && file.size > 0 && file.name);
+
       alert(
-        `Lastet opp ${formData
-          .getAll('files')
-          .map((file) => (file as File).name)
-          .join(', ')}`,
+        `Lastet opp ${files.map((file) => (file as File).name).join(', ')}`,
       );
     }}
   >
     <FileUpload
       validate={(file) => file.size < 1000000 || 'Filen er for stor'}
-      isRequired
       allowsMultiple
       name="files"
     >


### PR DESCRIPTION
## Update examples for FileUpload in Form

Updates examples for FileUpload used in Form, to filter out the "dummy file object" persisted in FormData by the browser throught the `getAll` API.

See: [https://grunnmuren.obos.no/komponenter/file-upload#b0cfafd73e91](https://grunnmuren.obos.no/komponenter/file-upload#b0cfafd73e91)