### PR TITLE
Fix tabindex bug

### DIFF
--- a/.changeset/cold-hats-drive.md
+++ b/.changeset/cold-hats-drive.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixes an accessibility issue with the `<RadioGroup>` component, where passing `value=""` as a prop caused the radio input to get `tabindex="-1"`. Which would make it inaccessible to keyboard and screen reader users.

--- a/packages/react/src/radiogroup/radio-group.tsx
+++ b/packages/react/src/radiogroup/radio-group.tsx
@@ -42,6 +42,7 @@ function RadioGroup(props: RadioGroupProps) {
     label,
     isRequired,
     isInvalid: _isInvalid,
+    value,
     ...restProps
   } = props;
 
@@ -52,6 +53,8 @@ function RadioGroup(props: RadioGroupProps) {
   return (
     <RACRadioGroup
       {...restProps}
+      // Tabindex is set to -1 when the value is an empty string, which makes the radio input not focusable
+      value={value === '' ? undefined : value}
       className={cx(className, 'flex flex-col gap-2')}
       isInvalid={isInvalid}
       isRequired={isRequired}


### PR DESCRIPTION
## Fix accessibility issue for RadioGroup

Fixes an accessibility issue with the `<RadioGroup>` component, where passing `value=""` as a prop caused the radio input to get `tabindex="-1"`. Which would make it inaccessible to keyboard and screen reader users.