### PR TITLE
Hero

### DIFF
--- a/.changeset/famous-islands-tan.md
+++ b/.changeset/famous-islands-tan.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": minor
+---
+
+Added new breakpoints for large screens: 3xl (108rem) and 4xl (120rem). This enables better control of elements that spans the entire viewport.

--- a/.changeset/orange-flowers-learn.md
+++ b/.changeset/orange-flowers-learn.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+New (unstable) `<Hero>` component that supports a `<Heading>`, `<Description>` and `<Media>`. This initial version only has one single layout, but will be extended with other layout variants in the future (breaking layout/api changes are to be expected).

--- a/packages/react/src/hero/hero.stories.tsx
+++ b/packages/react/src/hero/hero.stories.tsx
@@ -25,36 +25,6 @@ const meta: Meta<typeof Hero> = {
           />
         </Media>
       </Hero>
-      <div>
-        <h2 className="heading-l">Typografi i Grunnmuren</h2>
-        <p className="paragraph">
-          Typografien i Grunnmuren defineres av tailwind-klasser. Denne teksten
-          har for eksempel klassen <code>paragraph</code>.
-        </p>
-        <h3 className="heading-m">Sitater</h3>
-        <p className="paragraph">
-          Lengre sitater kan framheves med klassen <code>blockquote</code>:
-        </p>
-        <blockquote className="blockquote">
-          Typografi er grunnmuren i all visuell kommunikasjon; den bærer
-          budskapets vekt og gir strukturen vi bygger vår forståelse på.
-        </blockquote>
-        <h3 className="heading-m">Bildetekster</h3>
-        <p className="paragraph">
-          Klassen <code>description</code> kan f.eks. brukes for bildetekster:
-        </p>
-        <figure>
-          <img
-            className="mb-4 max-w-96 bg-blue-dark p-4"
-            src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/q_auto/v1619689575/OBOS%20Merkevare/OBOS/Liggende/obos_liggende_hus_hvit.svg"
-            alt="OBOS logo"
-          />
-          <figcaption className="description">
-            OBOS sin logo har hvit tekst, og bildet må derfor ha en mørk
-            bakgrunn. Slik at man kan se hva det står.
-          </figcaption>
-        </figure>
-      </div>
     </main>
   ),
 };
@@ -82,35 +52,5 @@ export const WithVideoLoop = () => (
         />
       </Media>
     </Hero>
-    <div>
-      <h2 className="heading-l">Typografi i Grunnmuren</h2>
-      <p className="paragraph">
-        Typografien i Grunnmuren defineres av tailwind-klasser. Denne teksten
-        har for eksempel klassen <code>paragraph</code>.
-      </p>
-      <h3 className="heading-m">Sitater</h3>
-      <p className="paragraph">
-        Lengre sitater kan framheves med klassen <code>blockquote</code>:
-      </p>
-      <blockquote className="blockquote">
-        Typografi er grunnmuren i all visuell kommunikasjon; den bærer
-        budskapets vekt og gir strukturen vi bygger vår forståelse på.
-      </blockquote>
-      <h3 className="heading-m">Bildetekster</h3>
-      <p className="paragraph">
-        Klassen <code>description</code> kan f.eks. brukes for bildetekster:
-      </p>
-      <figure>
-        <img
-          className="mb-4 max-w-96 bg-blue-dark p-4"
-          src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/q_auto/v1619689575/OBOS%20Merkevare/OBOS/Liggende/obos_liggende_hus_hvit.svg"
-          alt="OBOS logo"
-        />
-        <figcaption className="description">
-          OBOS sin logo har hvit tekst, og bildet må derfor ha en mørk bakgrunn.
-          Slik at man kan se hva det står.
-        </figcaption>
-      </figure>
-    </div>
   </main>
 );

--- a/packages/react/src/hero/hero.stories.tsx
+++ b/packages/react/src/hero/hero.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Heading, Media, Content } from '../content';
+import { UNSAFE_Hero as Hero } from './hero';
+import { Description } from '../label';
+import { VideoLoop } from '../video-loop';
+
+const meta: Meta<typeof Hero> = {
+  title: 'Hero',
+  component: Hero,
+  parameters: {
+    // disable built in padding in story, because we provide our own
+    layout: 'fullscreen',
+  },
+  render: () => (
+    <main className="container">
+      <Hero>
+        <Content>
+          <Heading level={2}>Dette er en Hero</Heading>
+          <Description>– et samarbeidsprosjekt med Nordr</Description>
+        </Content>
+        <Media>
+          <img
+            src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
+            alt="Random"
+          />
+        </Media>
+      </Hero>
+      <p>Test</p>
+      <VideoLoop
+        src="https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4"
+        format="mp4"
+        alt="En postbil kjører rundt i det moderne nabolaget på Frysja. Her finnes det fine uteområder, med husker og kafeer."
+      />
+    </main>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Hero>;
+
+export const WithImage: Story = {
+  args: {},
+};
+
+export const WithVideoLoop = () => (
+  <main className="container">
+    <Hero>
+      <Content>
+        <Heading level={2}>Dette er en Hero</Heading>
+        <Description>– et samarbeidsprosjekt med Nordr</Description>
+      </Content>
+      <Media>
+        <VideoLoop
+          src="https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4"
+          format="mp4"
+          alt="En postbil kjører rundt i det moderne nabolaget på Frysja. Her finnes det fine uteområder, med husker og kafeer."
+        />
+      </Media>
+    </Hero>
+
+    <p>Test</p>
+    <VideoLoop
+      src="https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4"
+      format="mp4"
+      alt="En postbil kjører rundt i det moderne nabolaget på Frysja. Her finnes det fine uteområder, med husker og kafeer."
+    />
+  </main>
+);

--- a/packages/react/src/hero/hero.stories.tsx
+++ b/packages/react/src/hero/hero.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof Hero> = {
         <Media>
           <img
             src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/f_auto,c_limit,w_2048,q_auto/v1582122753/Boligprosjekter/Oslo/Ulven/Ulven-N%C3%A6romr%C3%A5de-Oslo-OBOS-Construction-city.jpg"
-            alt="Random"
+            alt=""
           />
         </Media>
       </Hero>

--- a/packages/react/src/hero/hero.stories.tsx
+++ b/packages/react/src/hero/hero.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Heading, Media, Content } from '../content';
-import { UNSAFE_Hero as Hero } from './hero';
+import { Content, Heading, Media } from '../content';
 import { Description } from '../label';
 import { VideoLoop } from '../video-loop';
+import { UNSAFE_Hero as Hero } from './hero';
 
 const meta: Meta<typeof Hero> = {
   title: 'Hero',

--- a/packages/react/src/hero/hero.stories.tsx
+++ b/packages/react/src/hero/hero.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Hero> = {
     layout: 'fullscreen',
   },
   render: () => (
-    <main className="container">
+    <main className="container grid gap-y-8">
       <Hero>
         <Content>
           <Heading level={2}>Dette er en Hero</Heading>
@@ -25,12 +25,36 @@ const meta: Meta<typeof Hero> = {
           />
         </Media>
       </Hero>
-      <p>Test</p>
-      <VideoLoop
-        src="https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4"
-        format="mp4"
-        alt="En postbil kjører rundt i det moderne nabolaget på Frysja. Her finnes det fine uteområder, med husker og kafeer."
-      />
+      <div>
+        <h2 className="heading-l">Typografi i Grunnmuren</h2>
+        <p className="paragraph">
+          Typografien i Grunnmuren defineres av tailwind-klasser. Denne teksten
+          har for eksempel klassen <code>paragraph</code>.
+        </p>
+        <h3 className="heading-m">Sitater</h3>
+        <p className="paragraph">
+          Lengre sitater kan framheves med klassen <code>blockquote</code>:
+        </p>
+        <blockquote className="blockquote">
+          Typografi er grunnmuren i all visuell kommunikasjon; den bærer
+          budskapets vekt og gir strukturen vi bygger vår forståelse på.
+        </blockquote>
+        <h3 className="heading-m">Bildetekster</h3>
+        <p className="paragraph">
+          Klassen <code>description</code> kan f.eks. brukes for bildetekster:
+        </p>
+        <figure>
+          <img
+            className="mb-4 max-w-96 bg-blue-dark p-4"
+            src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/q_auto/v1619689575/OBOS%20Merkevare/OBOS/Liggende/obos_liggende_hus_hvit.svg"
+            alt="OBOS logo"
+          />
+          <figcaption className="description">
+            OBOS sin logo har hvit tekst, og bildet må derfor ha en mørk
+            bakgrunn. Slik at man kan se hva det står.
+          </figcaption>
+        </figure>
+      </div>
     </main>
   ),
 };
@@ -44,7 +68,7 @@ export const WithImage: Story = {
 };
 
 export const WithVideoLoop = () => (
-  <main className="container">
+  <main className="container grid gap-y-8">
     <Hero>
       <Content>
         <Heading level={2}>Dette er en Hero</Heading>
@@ -58,12 +82,35 @@ export const WithVideoLoop = () => (
         />
       </Media>
     </Hero>
-
-    <p>Test</p>
-    <VideoLoop
-      src="https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4"
-      format="mp4"
-      alt="En postbil kjører rundt i det moderne nabolaget på Frysja. Her finnes det fine uteområder, med husker og kafeer."
-    />
+    <div>
+      <h2 className="heading-l">Typografi i Grunnmuren</h2>
+      <p className="paragraph">
+        Typografien i Grunnmuren defineres av tailwind-klasser. Denne teksten
+        har for eksempel klassen <code>paragraph</code>.
+      </p>
+      <h3 className="heading-m">Sitater</h3>
+      <p className="paragraph">
+        Lengre sitater kan framheves med klassen <code>blockquote</code>:
+      </p>
+      <blockquote className="blockquote">
+        Typografi er grunnmuren i all visuell kommunikasjon; den bærer
+        budskapets vekt og gir strukturen vi bygger vår forståelse på.
+      </blockquote>
+      <h3 className="heading-m">Bildetekster</h3>
+      <p className="paragraph">
+        Klassen <code>description</code> kan f.eks. brukes for bildetekster:
+      </p>
+      <figure>
+        <img
+          className="mb-4 max-w-96 bg-blue-dark p-4"
+          src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/q_auto/v1619689575/OBOS%20Merkevare/OBOS/Liggende/obos_liggende_hus_hvit.svg"
+          alt="OBOS logo"
+        />
+        <figcaption className="description">
+          OBOS sin logo har hvit tekst, og bildet må derfor ha en mørk bakgrunn.
+          Slik at man kan se hva det står.
+        </figcaption>
+      </figure>
+    </div>
   </main>
 );

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -1,5 +1,5 @@
-import type { HTMLProps } from 'react';
 import { cx } from 'cva';
+import type { HTMLProps } from 'react';
 
 type HeroProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -29,4 +29,4 @@ const Hero = ({ className, children }: HeroProps) => {
   );
 };
 
-export { Hero as UNSAFE_Hero };
+export { Hero as UNSAFE_Hero, type HeroProps as UNSAFE_HeroProps };

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -9,11 +9,18 @@ const Hero = ({ className, children }: HeroProps) => {
   return (
     <div
       className={cx(
+        // Wrap text content in a container
         '*:data-[slot="content"]:container',
+        // Style the Hero heading
         '**:data-[slot="heading"]:heading-l',
+        // Spacing between the media and the text content above it
         '*:data-[slot="media"]:mt-8 lg:*:data-[slot="media"]:mt-10',
-        '*:data-[slot="media"]:h-80 lg:*:data-[slot="media"]:h-[39.875rem]',
-        '*:data-[slot="media"]:*:absolute *:data-[slot="media"]:*:left-0 *:data-[slot="media"]:*:h-80 *:data-[slot="media"]:*:w-full *:data-[slot="media"]:*:object-cover lg:*:data-[slot="media"]:*:h-[39.875rem]',
+        // Responsive heights for the <Media> wrapper component
+        '*:data-[slot="media"]:h-80 sm:*:data-[slot="media"]:h-96 md:*:data-[slot="media"]:h-[30rem] lg:*:data-[slot="media"]:h-[39.875rem] xl:*:data-[slot="media"]:h-[45rem] 2xl:*:data-[slot="media"]:h-[50rem]',
+        // Match the heights of the <Media> wrapper for the Media content (e.g. image, VideoLoop, video etc.)
+        '*:data-[slot="media"]:*:h-80 sm:*:data-[slot="media"]:*:h-96 md:*:data-[slot="media"]:*:h-[30rem] lg:*:data-[slot="media"]:*:h-[39.875rem] xl:*:data-[slot="media"]:*:h-[45rem] 2xl:*:data-[slot="media"]:*:h-[50rem]',
+        // Position the media content to fill the entire viewport width
+        '*:data-[slot="media"]:*:absolute *:data-[slot="media"]:*:left-0 *:data-[slot="media"]:*:w-full *:data-[slot="media"]:*:object-cover',
         className,
       )}
     >

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -16,9 +16,11 @@ const Hero = ({ className, children }: HeroProps) => {
         // Spacing between the media and the text content above it
         '*:data-[slot="media"]:mt-8 lg:*:data-[slot="media"]:mt-10',
         // Responsive heights for the <Media> wrapper component
-        '*:data-[slot="media"]:h-80 sm:*:data-[slot="media"]:h-96 md:*:data-[slot="media"]:h-[30rem] lg:*:data-[slot="media"]:h-[39.875rem] xl:*:data-[slot="media"]:h-[45rem] 2xl:*:data-[slot="media"]:h-[50rem]',
+        // biome-ignore lint/nursery/useSortedClasses: biome is unable to sort the custom classes for 3xl and 4xl breakpoints
+        '*:data-[slot="media"]:h-70 sm:*:data-[slot="media"]:h-[25rem] md:*:data-[slot="media"]:h-[30rem] lg:*:data-[slot="media"]:h-[35rem] xl:*:data-[slot="media"]:h-[40rem] 2xl:*:data-[slot="media"]:h-[42rem] 3xl:*:data-[slot="media"]:h-[48rem] 4xl:*:data-[slot="media"]:h-[53rem]',
         // Match the heights of the <Media> wrapper for the Media content (e.g. image, VideoLoop, video etc.)
-        '*:data-[slot="media"]:*:h-80 sm:*:data-[slot="media"]:*:h-96 md:*:data-[slot="media"]:*:h-[30rem] lg:*:data-[slot="media"]:*:h-[39.875rem] xl:*:data-[slot="media"]:*:h-[45rem] 2xl:*:data-[slot="media"]:*:h-[50rem]',
+        // biome-ignore lint/nursery/useSortedClasses: biome is unable to sort the custom classes for 3xl and 4xl breakpoints
+        '*:data-[slot="media"]:*:h-70 sm:*:data-[slot="media"]:*:h-[25rem] md:*:data-[slot="media"]:*:h-[30rem] lg:*:data-[slot="media"]:*:h-[35rem] xl:*:data-[slot="media"]:*:h-[40rem] 2xl:*:data-[slot="media"]:*:h-[42rem] 3xl:*:data-[slot="media"]:*:h-[48rem] 4xl:*:data-[slot="media"]:*:h-[53rem]',
         // Position the media content to fill the entire viewport width
         '*:data-[slot="media"]:*:absolute *:data-[slot="media"]:*:left-0 *:data-[slot="media"]:*:w-full *:data-[slot="media"]:*:object-cover',
         className,

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, type HTMLProps } from 'react';
+import type { HTMLProps } from 'react';
 import { cx } from 'cva';
 
 type HeroProps = HTMLProps<HTMLDivElement> & {
@@ -6,30 +6,14 @@ type HeroProps = HTMLProps<HTMLDivElement> & {
 };
 
 const Hero = ({ className, children }: HeroProps) => {
-  const ref = useRef<HTMLDivElement>(null);
-  useLayoutEffect(() => {
-    const container = ref.current;
-    if (!container) return;
-
-    const media = container.querySelector(
-      '[data-slot="media"]',
-    ) as HTMLElement | null;
-
-    if (media === null) return;
-
-    media.style.marginLeft = `calc(-${document.documentElement.clientWidth / 2}px + 50%)`;
-    const scrollbarWidth = `${window.innerWidth - document.body.clientWidth}px`;
-    media.style.maxWidth = `calc(100vw - ${scrollbarWidth})`;
-  }, []);
   return (
     <div
-      ref={ref}
       className={cx(
         '*:data-[slot="content"]:container',
         '**:data-[slot="heading"]:heading-l',
         '*:data-[slot="media"]:mt-8 lg:*:data-[slot="media"]:mt-10',
-        '*:data-[slot="media"]:w-screen lg:*:data-[slot="media"]:mt-10',
-        '*:data-[slot="media"]:*:max-h-[39.875rem] *:data-[slot="media"]:*:w-full *:data-[slot="media"]:*:object-cover',
+        '*:data-[slot="media"]:h-80 lg:*:data-[slot="media"]:h-[39.875rem]',
+        '*:data-[slot="media"]:*:absolute *:data-[slot="media"]:*:left-0 *:data-[slot="media"]:*:h-80 *:data-[slot="media"]:*:w-full *:data-[slot="media"]:*:object-cover lg:*:data-[slot="media"]:*:h-[39.875rem]',
         className,
       )}
     >

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -1,0 +1,41 @@
+import { useLayoutEffect, useRef, type HTMLProps } from 'react';
+import { cx } from 'cva';
+
+type HeroProps = HTMLProps<HTMLDivElement> & {
+  children: React.ReactNode;
+};
+
+const Hero = ({ className, children }: HeroProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const media = container.querySelector(
+      '[data-slot="media"]',
+    ) as HTMLElement | null;
+
+    if (media === null) return;
+
+    media.style.marginLeft = `calc(-${document.documentElement.clientWidth / 2}px + 50%)`;
+    const scrollbarWidth = `${window.innerWidth - document.body.clientWidth}px`;
+    media.style.maxWidth = `calc(100vw - ${scrollbarWidth})`;
+  }, []);
+  return (
+    <div
+      ref={ref}
+      className={cx(
+        '*:data-[slot="content"]:container',
+        '**:data-[slot="heading"]:heading-l',
+        '*:data-[slot="media"]:mt-8 lg:*:data-[slot="media"]:mt-10',
+        '*:data-[slot="media"]:w-screen lg:*:data-[slot="media"]:mt-10',
+        '*:data-[slot="media"]:*:max-h-[39.875rem] *:data-[slot="media"]:*:w-full *:data-[slot="media"]:*:object-cover',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export { Hero as UNSAFE_Hero };

--- a/packages/react/src/hero/index.ts
+++ b/packages/react/src/hero/index.ts
@@ -1,0 +1,1 @@
+export * from './hero';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,3 +26,4 @@ export * from './label';
 export * from './avatar';
 export * from './modal';
 export * from './tag-group';
+export * from './hero';

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -69,7 +69,7 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
         aria-hidden
         ref={videoRef}
         // cursor-pointer is not working on the button below, so we add it here for the same effect
-        className="h-full w-full cursor-pointer object-cover"
+        className="h-full max-h-[inherit] w-full cursor-pointer object-cover"
         playsInline
         loop={userPrefersReducedMotion === false}
         autoPlay={userPrefersReducedMotion === false}

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -38,6 +38,10 @@
   --color-orange: #e8a74a;
   --color-orange-light: #f8e5c9;
   --color-yellow: #fff5d2;
+
+  /** Breakpoints ***/
+  --breakpoint-3xl: 108rem;
+  --breakpoint-4xl: 120rem;
 }
 
 @layer base {


### PR DESCRIPTION
## Hero component

New `<Hero>` component and new custom breakpoints for larger screens: `3xl` and `4xl`.

This first version supports one layout variant that looks like this:
![Screenshot 2025-05-23 at 09 40 37](https://github.com/user-attachments/assets/cd57159e-c714-4431-9245-e4e41654c77b)

This layout is intended for use on pages where the images spans the entire width.

The new breakpoints are added to enable more control of the height of the `Hero` media on larger screens.

The plan is to eventually extend this component with a layout variant prop that can be used to choose different layouts (different pages will ultimately have slightly different Hero layouts). The API could then become something like:


```
<Hero variant="bleed">
```

```
<Hero variant="contain">
```

This could also mean that a release of this feature to the component introduces breaking changes, as it might mean that this initial layout variant might not be the default.

### Note
The image is positioned as `absolute`, which means that wrapping the `<Hero>` component in a container with position `relative` might affect the bleeding if that relative container itself does not span 100% of the viewport.