### PR TITLE
Replace legacy --gm properties with valid gap-classes

### DIFF
--- a/apps/docs/app/routes/_docs/$slug.tsx
+++ b/apps/docs/app/routes/_docs/$slug.tsx
@@ -57,7 +57,7 @@ function Page() {
           )}
         </ResourceLinks>
       )}
-      <div className="lg:relative lg:flex lg:gap-[var(--gm-container-gutter-width)] lg:pt-9">
+      <div className="lg:relative lg:flex lg:gap-4 lg:pt-9">
         <TableOfContentsNav
           className="w-56 lg:sticky lg:top-9 lg:order-1 lg:shrink-0"
           content={data.content}

--- a/apps/docs/app/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/app/routes/_docs/komponenter/$slug.tsx
@@ -65,7 +65,7 @@ function Page() {
             ),
         )}
       </ResourceLinks>
-      <div className="lg:relative lg:flex lg:gap-[var(--gm-container-gutter-width)]">
+      <div className="lg:relative lg:flex lg:gap-4">
         <TableOfContentsNav
           className="hidden w-56 lg:sticky lg:top-9 lg:order-1 lg:block lg:shrink-0"
           content={data.content}


### PR DESCRIPTION
Replaces the use of the custom property `--gm-container-gutter-width`, which has now been removed from the `grunnmuren-tailwind` package.