### PR TITLE
Remove redundant x-padding

### DIFF
--- a/.changeset/four-insects-fetch.md
+++ b/.changeset/four-insects-fetch.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Removes redundant x-padding on the `<Hero>` component, as the component will typically be rendered inside a `<main className="container">` parent.

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -28,7 +28,7 @@ const oneColumnLayout = [
 
 const variants = cva({
   base: [
-    'container',
+    'container px-0', // We want to eliminate the default padding on the container, as this component will typically be put inside a container
     // Grid variant to position the Hero's content
     'grid lg:grid-cols-12 lg:gap-x-12 xl:gap-x-16',
     'gap-y-10 lg:gap-y-12',


### PR DESCRIPTION
## Hero padding-x fix

Removes redundant x-padding on the `<Hero>` component, as the component will typically be rendered inside a `<main className="container">` parent.

https://github.com/user-attachments/assets/70d79a77-100a-40c2-811f-3aaa54c91bcd

