### PR TITLE
Flexible heading sizes in card

### DIFF
--- a/.changeset/plenty-pots-relax.md
+++ b/.changeset/plenty-pots-relax.md
@@ -1,0 +1,16 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+`<Card>` now respects the `size` prop (if set) on it's `<Heading>`. This makes it possible to customize the size of the heading in a `<Card>`:
+
+``` tsx
+<Card>
+  <Content>
+    <Heading level={3} size="m">Medium heading</Heading>
+    <p>
+      This heading is customized
+    </p>
+  </Content>
+</Card>
+```

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -21,9 +21,7 @@ const meta: Meta<typeof Card> = {
   render: () => (
     <Card>
       <Content>
-        <Heading className="heading-s" level={3}>
-          Min bolig
-        </Heading>
+        <Heading level={3}>Min bolig</Heading>
         <p>
           Her finner du alt om din nye bolig og hva som venter deg fremover. Du
           finner dine dokumenter, salgsoppgave og mye mer.
@@ -54,9 +52,7 @@ export const WithBackground = () => {
           key={bgColor}
         >
           <Content>
-            <Heading className="heading-s" level={3}>
-              Bakgrunn {bgColor}
-            </Heading>
+            <Heading level={3}>Bakgrunn {bgColor}</Heading>
             <p>Dette kortet har {bgColor} som bakgrunnsfarge</p>
           </Content>
         </Card>
@@ -74,9 +70,7 @@ export const WithImage = () => (
       />
     </Media>
     <Content>
-      <Heading className="heading-s" level={3}>
-        Kort med bilde
-      </Heading>
+      <Heading level={3}>Kort med bilde</Heading>
       <p>
         Dette kortet har et bilde og er uten border. Derfor er alle hjørner på
         bildet avrundet.
@@ -94,9 +88,7 @@ export const OutlinedWithImageAnd = () => (
       />
     </Media>
     <Content>
-      <Heading className="heading-s" level={3}>
-        Kort med bilde og border
-      </Heading>
+      <Heading level={3}>Kort med bilde og border</Heading>
       <p>
         Dette kortet har et bilde og border. Derfor er kun hjørnene i toppen
         avrundet.
@@ -109,9 +101,7 @@ export const WithIconTop = () => (
   <Card variant="outlined">
     <PiggyBank />
     <Content>
-      <Heading className="heading-s" level={3}>
-        Kort med ikon i topp
-      </Heading>
+      <Heading level={3}>Kort med ikon i topp</Heading>
       <p>Dette kortet har svart border og et ikon i toppen</p>
     </Content>
   </Card>
@@ -120,9 +110,7 @@ export const WithIconTop = () => (
 export const WithIconBottom = () => (
   <Card variant="outlined">
     <Content>
-      <Heading className="heading-s" level={3}>
-        Kort med ikon i bunn
-      </Heading>
+      <Heading level={3}>Kort med ikon i bunn</Heading>
       <p>Dette kortet har svart border og et ikon i bunn</p>
     </Content>
     <PiggyBank />
@@ -174,9 +162,7 @@ export const CardWithInlineTopIllustration = () => (
   <Card variant="outlined" className="w-72">
     <Illustration />
     <Content>
-      <Heading className="heading-s" level={3}>
-        Utemiljø og grøntanlegg
-      </Heading>
+      <Heading level={3}>Utemiljø og grøntanlegg</Heading>
       <p>
         Et godt utemiljø er viktig for trivselen. Vi har en egen utenhusavdeling
         med flinke folk som kan hjelpe med realisering av nye prosjekter.
@@ -192,9 +178,7 @@ export const CardWithCoveringIllustration = () => (
     </Media>
     <Content>
       <div className="grid gap-1">
-        <Heading className="heading-s" level={3}>
-          Rødbergvn 88C
-        </Heading>
+        <Heading level={3}>Rødbergvn 88C</Heading>
         <small className="description">Bjerke - Oslo</small>
       </div>
       <small className="description -order-1">
@@ -220,7 +204,7 @@ export const CardWithCoveringIllustration = () => (
 export const ClickableWithIcon = () => (
   <Card variant="outlined">
     <Content>
-      <Heading className="heading-s" level={3}>
+      <Heading level={3}>
         <CardLink href="#card">Klikkbar med ikon</CardLink>
       </Heading>
       <p>Dette kortet er klikkbart og har svart border med et ikon</p>
@@ -238,7 +222,7 @@ export const ClickableWithImage = () => (
       />
     </Media>
     <Content>
-      <Heading className="heading-s" level={3}>
+      <Heading level={3}>
         <CardLink href="#card">Klikkbar med bilde</CardLink>
       </Heading>
       <p>
@@ -252,7 +236,7 @@ export const ClickableWithImage = () => (
 export const ClickableWithBackground = () => (
   <Card className="bg-blue-dark text-white">
     <Content>
-      <Heading className="heading-s" level={3}>
+      <Heading level={3}>
         <CardLink href="#card">Klikkbar med bakgrunnsfarge</CardLink>
       </Heading>
       <p>Dette kortet er klikkbart og har en bakgrunnsfarge</p>
@@ -270,9 +254,7 @@ export const ClickableWithImageAndCTA = () => (
       />
     </Media>
     <Content>
-      <Heading className="heading-s" level={3}>
-        Med bilde og CTA
-      </Heading>
+      <Heading level={3}>Med bilde og CTA</Heading>
       <p>Dette kortet har bilde og er klikkbart mot en CTA-lenke</p>
       <CardLink className="group/cta">
         <Button href="#cta" variant="tertiary">
@@ -287,9 +269,7 @@ export const ClickableWithImageAndCTA = () => (
 export const ClickableWithBackgroundAndCTA = () => (
   <Card className="bg-blue-dark text-white">
     <Content>
-      <Heading className="heading-s" level={3}>
-        Bakgrunnsfarge og CTA
-      </Heading>
+      <Heading level={3}>Bakgrunnsfarge og CTA</Heading>
       <p>Dette kortet har bakgrunnsfarge og er klikkbart mot en CTA-lenke.</p>
       <CardLink className="group/cta mt-1">
         <Button href="#cta" variant="tertiary">
@@ -312,7 +292,7 @@ export const ClickableWithOtherClickableElements = () => (
       </Media>
       <Content className="grow">
         <div className="grid gap-1">
-          <Heading className="heading-s" level={3}>
+          <Heading level={3}>
             <CardLink href="#card">Rødbergvn 88C</CardLink>
           </Heading>
           <small className="description">Bjerke - Oslo</small>
@@ -355,7 +335,7 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
     </Media>
     <Content>
       <div className="grid gap-1">
-        <Heading className="heading-s" level={3}>
+        <Heading level={3}>
           <CardLink href="#card">Rødbergvn 88C</CardLink>
         </Heading>
         <small className="description">Bjerke - Oslo</small>
@@ -405,7 +385,7 @@ export const ClickableWithBadge = () => (
     </Media>
     <Content>
       <div className="grid gap-1">
-        <Heading className="heading-s" level={3}>
+        <Heading level={3}>
           <CardLink href="#card">Rødbergvn 88C</CardLink>
         </Heading>
         <small className="description">Bjerke - Oslo</small>
@@ -455,7 +435,7 @@ export const ClickableWithBadgeRight = () => (
     </Media>
     <Content>
       <div className="grid gap-1">
-        <Heading className="heading-s" level={3}>
+        <Heading level={3}>
           <CardLink href="#card">Rødbergvn 88C</CardLink>
         </Heading>
         <small className="description">Bjerke - Oslo</small>
@@ -500,9 +480,7 @@ export const HorizontalLeft = () => (
       />
     </Media>
     <Content>
-      <Heading className="heading-s" level={3}>
-        Med bilde til venstre
-      </Heading>
+      <Heading level={3}>Med bilde til venstre</Heading>
       <p>
         Dette kortet har bilde til venstre på større skjermer og er klikkbart
         mot en CTA-lenke
@@ -520,9 +498,7 @@ export const HorizontalLeft = () => (
 export const HorizontalRight = () => (
   <Card layout="horizontal">
     <Content>
-      <Heading className="heading-s" level={3}>
-        Med bilde til høyre
-      </Heading>
+      <Heading level={3}>Med bilde til høyre</Heading>
       <p>
         Dette kortet har bilde til høyre på større skjermer og er klikkbart mot
         en CTA-lenke
@@ -547,9 +523,7 @@ export const HorizontalWithIconLeft = () => (
   <Card layout="horizontal" variant="outlined">
     <PiggyBank />
     <Content>
-      <Heading className="heading-s" level={3}>
-        Med ikon til venstre
-      </Heading>
+      <Heading level={3}>Med ikon til venstre</Heading>
       <p>
         Dette kortet er liggende, har et ikon til venstre og er klikkbart mot en
         CTA-lenke
@@ -567,9 +541,7 @@ export const HorizontalWithIconLeft = () => (
 export const HorizontalWithIconRight = () => (
   <Card layout="horizontal" variant="outlined">
     <Content>
-      <Heading className="heading-s" level={3}>
-        Med ikon til høyre
-      </Heading>
+      <Heading level={3}>Med ikon til høyre</Heading>
       <p>
         Dette kortet er liggende, har et ikon til høyre og er klikkbart mot en
         CTA-lenke
@@ -590,9 +562,7 @@ export const WithAvatar = () => (
     <Avatar src="https://res.cloudinary.com/obosit-prd-ch-clry/image/upload/v1578474487/Boligkonferansen/obosbk%202017/Daniel_Kj%C3%B8rberg_Siraj_1x1.jpg" />
     <Content>
       <div className="flex flex-col-reverse gap-2">
-        <Heading className="heading-s" level={3}>
-          Daniel Kjørberg Siraj
-        </Heading>
+        <Heading level={3}>Daniel Kjørberg Siraj</Heading>
         <Description>Konsernsjef (CEO)</Description>
       </div>
       <p>Dette kortet er liggende, med et rundt bilde til høyre</p>

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -1,5 +1,10 @@
-import { type VariantProps, cva } from 'cva';
-import { Link, type LinkProps as RACLinkProps } from 'react-aria-components';
+import { type VariantProps, cva, cx } from 'cva';
+import {
+  Link,
+  Provider,
+  type LinkProps as RACLinkProps,
+} from 'react-aria-components';
+import { HeadingContext } from '../content';
 
 type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
@@ -12,15 +17,6 @@ const cardVariants = cva({
     'rounded-2xl border p-3',
     'flex gap-y-4', // y-gap ensures a vertical spacing for both verical layout and responsive horizontal layout
     'relative', // Needed for positiong of the clickable pseudo-element (and can also be used for other absolute positioned elements the consumer might add)
-
-    // **** Heading ****
-    '[&_[data-slot="heading"]]:inline',
-    '[&_[data-slot="heading"]]:heading-s',
-    '[&_[data-slot="heading"]]:leading-6', // A bit more line height than the default is necessary to make the underline align with the text if the heading has a card link
-    '[&_[data-slot="heading"]]:w-fit',
-    '[&_[data-slot="heading"]]:text-pretty',
-    '[&_[data-slot="heading"]]:hyphens-auto',
-    '[&_[data-slot="heading"]]:[word-break:break-word]', // necessary to make hyphens work in grid containers in Safari
 
     // **** Content ****
     '[&_[data-slot="content"]]:flex [&_[data-slot="content"]]:flex-col [&_[data-slot="content"]]:gap-y-4',
@@ -41,21 +37,7 @@ const cardVariants = cva({
     // **** Hover ****
     // Enables the zoom hover effect on media (note that we can't use group-hover/card here, because there might be other clickable elements in the card aside from the heading)
     '[&:has([data-slot="card-link"]_a:hover)_[data-slot="media"]>img]:scale-110',
-    // **** Card link in Heading ****
     '[&:has([data-slot="heading"]_[data-slot="card-link"]:hover)_[data-slot="media"]>img]:scale-110',
-    // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
-    // Border top is set to even out the border bottom used for the underline
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:no-underline',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-2',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:border-y-transparent',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:transition-colors',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]:hover]:border-b-current',
-    // Mimic heading styles for the card link if placed in the heading slot. This is necessary to make the custom underline align with the link text
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:heading-s',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:leading-6',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:text-pretty',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:hyphens-auto',
-    '[&_[data-slot="heading"]_[data-slot="card-link"]]:[word-break:break-word]', // necessary to make hyphens work in grid containers in Safari
 
     // **** Fail-safe for interactive elements ****
     // Make interactive elements clickable by themselves, while the rest of the card is clickable as a whole
@@ -171,7 +153,38 @@ const Card = ({
   });
   return (
     <div className={className} {...restProps}>
-      {children}
+      <Provider
+        values={[
+          [
+            HeadingContext,
+            {
+              size: 's',
+              className: cx([
+                'inline',
+                'w-fit',
+                'text-pretty',
+                'hyphens-auto',
+                '[word-break:break-word]', // necessary to make hyphens work in grid containers in Safari
+                // **** Card link in Heading ****
+                // Border (bottom/top) is set to transparent to make sure the bottom underline is not visible when the card is hovered
+                // Border top is set to even out the border bottom used for the underline
+                '*:data-[slot="card-link"]:no-underline',
+                '*:data-[slot="card-link"]:border-y-2',
+                '*:data-[slot="card-link"]:border-y-transparent',
+                '*:data-[slot="card-link"]:transition-colors',
+                '*:data-[slot="card-link"]:hover:border-b-current',
+                // Mimic heading styles for the card link if placed in the heading slot. This is necessary to make the custom underline align with the link text
+                '*:data-[slot="card-link"]:font-inherit',
+                '*:data-[slot="card-link"]:text-pretty',
+                '*:data-[slot="card-link"]:hyphens-auto',
+                '*:data-[slot="card-link"]:[word-break:break-word]', // necessary to make hyphens work in grid containers in Safari
+              ]),
+            },
+          ],
+        ]}
+      >
+        {children}
+      </Provider>
     </div>
   );
 };


### PR DESCRIPTION
## Support various heading sizes in Card

`<Card>` now respects the `size` prop (if set) on it's `<Heading>`. This makes it possible to customize the size of the heading in a `<Card>`:

``` tsx
<Card variant="outlined" className="w-72">
  <Content>
    <Heading level={3} size="m">Medium heading</Heading>
    <p>
      This heading is customized
    </p>
  </Content>
</Card>
```
<img width="341" alt="Screenshot 2025-06-10 at 09 22 10" src="https://github.com/user-attachments/assets/865708d7-c9ab-4e55-a02c-a981db000eba" />
