### PR TITLE
add fileType to new File in fileupload

### DIFF
--- a/.changeset/shaggy-cycles-go.md
+++ b/.changeset/shaggy-cycles-go.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+FileUpload: fix bug with not adding fileType to files that have been renamed

--- a/packages/react/src/file-upload/file-upload.tsx
+++ b/packages/react/src/file-upload/file-upload.tsx
@@ -99,6 +99,9 @@ function uniqueFileNames(files: File[]) {
         [file],
         // Follow the pattern of adding a number in parentheses to the base name (e.g. "file (1).txt")
         `${baseName} (${fileNameCounts[baseName] - 1})${extension}`,
+        {
+          type: file.type,
+        },
       );
     }
 


### PR DESCRIPTION
Må sende med fileType som options hvis man lager ny fil ellers ender det opp med "" streng og octet-stream i server actions hos oss

eksempel:
![image](https://github.com/user-attachments/assets/aba3bf6e-a531-48d1-a930-6f27600b013a)
