### PR TITLE
Use responsive aspect ratios for Media

### DIFF
--- a/.changeset/real-dryers-jog.md
+++ b/.changeset/real-dryers-jog.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+The `Hero` component now renders `<Media>` in responsive aspect ratios for the `standard` and `two-column` variants. The same behaviour is also applied to the `<Carousel>` component.

--- a/packages/react/src/carousel/carousel.tsx
+++ b/packages/react/src/carousel/carousel.tsx
@@ -277,9 +277,8 @@ const CarouselItem = ({ className, children, id }: CarouselItemProps) => {
               fit: 'cover',
               className: cx(
                 'data-[fit="contain"]:bg-blue-dark',
-                '*:w-full',
-                // biome-ignore lint/nursery/useSortedClasses: biome is unable to sort the custom classes for 3xl and 4xl breakpoints
-                '*:h-70 sm:*:h-[25rem] lg:*:h-[35rem] xl:*:h-[40rem] 2xl:*:h-[42rem] 3xl:*:h-[48rem] 4xl:*:h-[53rem]',
+                '*:h-full *:w-full',
+                'aspect-1/1 max-sm:data-[fit="contain"]:*:object-cover sm:aspect-4/3 md:aspect-3/2 lg:aspect-2/1',
               ),
             },
           ],

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -27,6 +27,9 @@ const oneColumnLayout = [
   'lg:items-end',
 ];
 
+const nonFullBleedAspectRatiosForSmallScreens =
+  '*:data-[slot="media"]:*:aspect-[1/1] sm:*:data-[slot="media"]:*:aspect-4/3 md:*:data-[slot="media"]:*:aspect-3/2';
+
 const variants = cva({
   base: [
     'container px-0', // We want to eliminate the default padding on the container, as this component will typically be put inside a container
@@ -46,18 +49,29 @@ const variants = cva({
      * @default standard
      * */
     variant: {
-      standard: [roundedMediaCorners, oneColumnLayout],
+      standard: [
+        roundedMediaCorners,
+        oneColumnLayout,
+        nonFullBleedAspectRatiosForSmallScreens,
+        'lg:*:data-[slot="media"]:*:aspect-2/1',
+      ],
       'full-bleed': [
         oneColumnLayout,
         // Position the media and carousel content to fill the entire viewport width
         '*:data-[slot="media"]:*:absolute *:data-[slot="media"]:*:left-0',
-        '*:data-[slot="carousel"]:*:absolute *:data-[slot="carousel"]:*:left-0',
+        // Special case for Carousel, where the Media is nested inside a CarouselItem
+        '*:data-[slot="carousel"]:**:data-[slot="media"]:w-full *:data-[slot="carousel"]:*:absolute *:data-[slot="carousel"]:*:left-0',
         // Match the heights of the <Media> or <Carousel> wrapper for the Media content (e.g. image, VideoLoop, video etc.)
         // This is necessary due to the absolute positioning of the media and carousel containers in this variant
         // biome-ignore lint/nursery/useSortedClasses: biome is unable to sort the custom classes for 3xl and 4xl breakpoints
-        '*:data-[slot="media"]:*:h-70 sm:*:data-[slot="media"]:*:h-[25rem] md:*:data-[slot="media"]:*:h-[30rem] lg:*:data-[slot="media"]:*:h-[35rem] xl:*:data-[slot="media"]:*:h-[40rem] 2xl:*:data-[slot="media"]:*:h-[42rem] 3xl:*:data-[slot="media"]:*:h-[48rem] 4xl:*:data-[slot="media"]:*:h-[53rem]',
+        '**:data-[slot="media"]:h-70 sm:**:data-[slot="media"]:h-[25rem] md:**:data-[slot="media"]:h-[30rem] lg:**:data-[slot="media"]:h-[35rem] xl:**:data-[slot="media"]:h-[40rem] 2xl:**:data-[slot="media"]:h-[42rem] 3xl:**:data-[slot="media"]:h-[48rem] 4xl:**:data-[slot="media"]:h-[53rem]',
+        // biome-ignore lint/nursery/useSortedClasses: biome is unable to sort the custom classes for 3xl and 4xl breakpoints
+        '**:data-[slot="media"]:*:h-70 sm:**:data-[slot="media"]:*:h-[25rem] md:**:data-[slot="media"]:*:h-[30rem] lg:**:data-[slot="media"]:*:h-[35rem] xl:**:data-[slot="media"]:*:h-[40rem] 2xl:**:data-[slot="media"]:*:h-[42rem] 3xl:**:data-[slot="media"]:*:h-[48rem] 4xl:**:data-[slot="media"]:*:h-[53rem]',
         // biome-ignore lint/nursery/useSortedClasses: biome is unable to sort the custom classes for 3xl and 4xl breakpoints
         '*:data-[slot="carousel"]:h-70 sm:*:data-[slot="carousel"]:h-[25rem] md:*:data-[slot="carousel"]:h-[30rem] lg:*:data-[slot="carousel"]:h-[35rem] xl:*:data-[slot="carousel"]:h-[40rem] 2xl:*:data-[slot="carousel"]:h-[42rem] 3xl:*:data-[slot="carousel"]:h-[48rem] 4xl:*:data-[slot="carousel"]:h-[53rem]',
+
+        // Override aspect ratio of the media and carousel-item slots (since we can not use aspect for full-bleed layout)
+        '**:data-[slot="carousel-item"]:data-[slot="media"]:*:aspect-none',
         '**:data-[slot="carousel-controls"]:container **:data-[slot="carousel-controls"]:right-0 **:data-[slot="carousel-controls"]:bottom-4 **:data-[slot="carousel-controls"]:left-0 **:data-[slot="carousel-controls"]:justify-end',
         // Override rounded corners of Carousel slots
         '*:data-[slot="carousel"]:*:rounded-none',
@@ -67,6 +81,7 @@ const variants = cva({
         // Vertical spacing in the <Content>
         'lg:*:data-[slot="content"]:gap-y-7',
         roundedMediaCorners,
+        nonFullBleedAspectRatiosForSmallScreens,
         // Set media aspect ratio to 1:1 (square)
         'lg:*:data-[slot="media"]:*:aspect-[1/1]',
       ],


### PR DESCRIPTION
## Responsive aspect ratios for Media in Hero

Setting up responsive aspect ratios for `<Media>` content in `<Hero>` and `<Carousel>`. This was handled the same way as for the `full-bleed` variant before, but the `full-bleed` is actually an exception. Since that is the only case where aspect ratio does not make sense (100% width is arbitrary, while the height is given).

The change is most notable for the `two-column` variant.

### Now

https://github.com/user-attachments/assets/eeef0cac-ec46-463c-a0ae-e03e873d2152


https://github.com/user-attachments/assets/6757f977-aced-4073-ac17-5a69b14ea7d8

### Before

https://github.com/user-attachments/assets/2e829031-0ae1-45d2-8de8-ca11944dd400


https://github.com/user-attachments/assets/a6021d72-68a4-4658-ab67-aab2317a06a4

