### PR TITLE
Remove isLoading prop

### DIFF
--- a/.changeset/public-loops-give.md
+++ b/.changeset/public-loops-give.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": major
+---
+
+Removes the deprecated `isLoading` prop from `<Button>`, it is now fully replaced by the `isPending` prop.

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -118,12 +118,6 @@ const buttonVariants = cva({
 type ButtonOrLinkProps = VariantProps<typeof buttonVariants> & {
   children?: React.ReactNode;
   href?: RACLinkProps['href'];
-  /**
-   * Display the button in a loading state
-   * @deprecated Use isPending instead.
-   * @default false
-   */
-  isLoading?: boolean;
   /** Additional style properties for the element. */
   style?: React.CSSProperties;
   /** Ref to the element. */
@@ -148,13 +142,10 @@ function Button({ ref = null, ...props }: ButtonProps) {
     children: _children,
     color,
     isIconOnly,
-    isLoading,
     variant,
-    isPending: _isPending,
+    isPending,
     ...restProps
   } = props;
-
-  const isPending = _isPending || isLoading;
 
   const className = buttonVariants({
     className: props.className,


### PR DESCRIPTION
Removes the deprecated `isLoading` prop from `<Button>`, it is now fully replaced by the `isPending` prop.