### PR TITLE
Use grid instead of flex

### DIFF
--- a/packages/react/src/tabs/tabs.tsx
+++ b/packages/react/src/tabs/tabs.tsx
@@ -22,11 +22,11 @@ import {
 import { useDebouncedCallback } from 'use-debounce';
 
 const tabsVariants = cva({
-  base: ['flex gap-4'],
+  base: ['grid gap-4'],
   variants: {
     orientation: {
-      horizontal: 'flex-col',
-      vertical: '',
+      horizontal: '',
+      vertical: 'grid-cols-[auto_1fr]',
     },
   },
 });


### PR DESCRIPTION
Use `grid` instead of `flex` for `<Tabs>` to prevent unitended inherited layout issues such as:

<img width="740" height="370" alt="Screenshot 2025-08-05 at 12 33 54" src="https://github.com/user-attachments/assets/62e6a6bd-03cc-417b-96a6-f76f580b9a51" />


With this fix:

<img width="726" height="397" alt="Screenshot 2025-08-05 at 12 34 17" src="https://github.com/user-attachments/assets/cb09dcca-b10d-4d63-87f2-77bc82e7da54" />
