### PR TITLE
Scroll to top

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -38,7 +38,8 @@
     "react-dom": "19.0.0",
     "react-element-to-jsx-string": "17.0.1",
     "react-live": "4.1.8",
-    "sanity": "3.92.0"
+    "sanity": "3.92.0",
+    "use-debounce": "10.0.4"
   },
   "devDependencies": {
     "@obosbbl/grunnmuren-tailwind": "workspace:*",

--- a/apps/docs/src/routes/_docs.tsx
+++ b/apps/docs/src/routes/_docs.tsx
@@ -102,7 +102,7 @@ function RootLayout() {
           )}
         </Disclosure>
 
-        <div className="grid min-h-screen lg:flex">
+        <div className="min-h-screen lg:flex">
           <MainNav className="hidden lg:block" />
           <div className="flex grow flex-col px-6">
             <main className="grow">

--- a/apps/docs/src/routes/_docs/$slug.tsx
+++ b/apps/docs/src/routes/_docs/$slug.tsx
@@ -1,6 +1,7 @@
 import { sanityFetch } from '@/lib/sanity';
 import { ResourceLink, ResourceLinks } from '@/ui/resource-links';
 import { SanityContent } from '@/ui/sanity-content';
+import { ScrollToTop } from '@/ui/scroll-to-top';
 import { TableOfContentsNav } from '@/ui/table-of-contents-nav';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import { defineQuery } from 'groq';
@@ -64,6 +65,7 @@ function Page() {
         />
 
         <SanityContent className="mb-12 grow" content={data.content ?? []} />
+        <ScrollToTop />
       </div>
     </>
   );

--- a/apps/docs/src/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/src/routes/_docs/komponenter/$slug.tsx
@@ -3,11 +3,11 @@ import { AnchorHeading } from '@/ui/anchor-heading';
 import { PropsTable } from '@/ui/props-table';
 import { ResourceLink, ResourceLinks } from '@/ui/resource-links';
 import { SanityContent } from '@/ui/sanity-content';
+import { ScrollToTop } from '@/ui/scroll-to-top';
 import { TableOfContentsNav } from '@/ui/table-of-contents-nav';
-import { ArrowUp, Child, CircusTent } from '@obosbbl/grunnmuren-icons-react';
+import { Child, CircusTent } from '@obosbbl/grunnmuren-icons-react';
 import { Alertbox, Content } from '@obosbbl/grunnmuren-react';
 import { createFileRoute, notFound } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
 import type * as props from 'component-props';
 import { defineQuery } from 'groq';
 
@@ -46,25 +46,6 @@ export const Route = createFileRoute('/_docs/komponenter/$slug')({
 
 function Page() {
   const { data } = Route.useLoaderData();
-  const [showScrollToTop, setShowScrollToTop] = useState(false);
-
-  // Show/hide scroll to top button based on scroll position
-  useEffect(() => {
-    const handleScroll = () => {
-      const scrollTop = window.scrollY || document.documentElement.scrollTop;
-      setShowScrollToTop(scrollTop > 300); // Show after scrolling 300px
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
-
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-  };
 
   const ghLink = data.resourceLinks?.find(
     (link) => link.linkType === 'github',
@@ -157,20 +138,7 @@ function Page() {
         </div>
       </div>
 
-      {/* Scroll to top button */}
-      {showScrollToTop && (
-        <div className="fixed right-4 bottom-4 z-50 flex flex-col items-center md:right-16 md:bottom-16">
-          <button
-            onClick={scrollToTop}
-            className="hover:-translate-y-1 flex h-12 w-12 items-center justify-center rounded-full bg-blue-dark transition-all duration-300 focus-visible:outline-focus"
-            aria-label="Scroll to top"
-            type="button"
-          >
-            <ArrowUp className="h-6 w-6 text-white" />
-          </button>
-          <span className="mt-2 font-medium">Til tops</span>
-        </div>
-      )}
+      <ScrollToTop />
     </>
   );
 }

--- a/apps/docs/src/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/src/routes/_docs/komponenter/$slug.tsx
@@ -127,14 +127,12 @@ function Page() {
               Props
             </AnchorHeading>
           )}
-          <div className="overflow-x-auto">
-            {data.propsComponents?.map((componentName) => (
-              <PropsTable
-                key={componentName}
-                componentName={componentName as keyof typeof props}
-              />
-            ))}
-          </div>
+          {data.propsComponents?.map((componentName) => (
+            <PropsTable
+              key={componentName}
+              componentName={componentName as keyof typeof props}
+            />
+          ))}
         </div>
       </div>
 

--- a/apps/docs/src/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/src/routes/_docs/komponenter/$slug.tsx
@@ -162,7 +162,7 @@ function Page() {
         <div className="fixed right-4 bottom-4 z-50 flex flex-col items-center md:right-16 md:bottom-16">
           <button
             onClick={scrollToTop}
-            className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-dark transition-all duration-300 hover:animate-spin focus-visible:outline-focus"
+            className="hover:-translate-y-1 flex h-12 w-12 items-center justify-center rounded-full bg-blue-dark transition-all duration-300 focus-visible:outline-focus"
             aria-label="Scroll to top"
             type="button"
           >

--- a/apps/docs/src/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/src/routes/_docs/komponenter/$slug.tsx
@@ -146,12 +146,14 @@ function Page() {
               Props
             </AnchorHeading>
           )}
-          {data.propsComponents?.map((componentName) => (
-            <PropsTable
-              key={componentName}
-              componentName={componentName as keyof typeof props}
-            />
-          ))}
+          <div className="overflow-x-auto">
+            {data.propsComponents?.map((componentName) => (
+              <PropsTable
+                key={componentName}
+                componentName={componentName as keyof typeof props}
+              />
+            ))}
+          </div>
         </div>
       </div>
 

--- a/apps/docs/src/routes/_docs/komponenter/$slug.tsx
+++ b/apps/docs/src/routes/_docs/komponenter/$slug.tsx
@@ -4,9 +4,10 @@ import { PropsTable } from '@/ui/props-table';
 import { ResourceLink, ResourceLinks } from '@/ui/resource-links';
 import { SanityContent } from '@/ui/sanity-content';
 import { TableOfContentsNav } from '@/ui/table-of-contents-nav';
-import { Child, CircusTent } from '@obosbbl/grunnmuren-icons-react';
+import { ArrowUp, Child, CircusTent } from '@obosbbl/grunnmuren-icons-react';
 import { Alertbox, Content } from '@obosbbl/grunnmuren-react';
 import { createFileRoute, notFound } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
 import type * as props from 'component-props';
 import { defineQuery } from 'groq';
 
@@ -45,6 +46,25 @@ export const Route = createFileRoute('/_docs/komponenter/$slug')({
 
 function Page() {
   const { data } = Route.useLoaderData();
+  const [showScrollToTop, setShowScrollToTop] = useState(false);
+
+  // Show/hide scroll to top button based on scroll position
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY || document.documentElement.scrollTop;
+      setShowScrollToTop(scrollTop > 300); // Show after scrolling 300px
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
 
   const ghLink = data.resourceLinks?.find(
     (link) => link.linkType === 'github',
@@ -134,6 +154,21 @@ function Page() {
           ))}
         </div>
       </div>
+
+      {/* Scroll to top button */}
+      {showScrollToTop && (
+        <div className="fixed right-4 bottom-4 z-50 flex flex-col items-center md:right-16 md:bottom-16">
+          <button
+            onClick={scrollToTop}
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-dark transition-all duration-300 hover:animate-spin focus-visible:outline-focus"
+            aria-label="Scroll to top"
+            type="button"
+          >
+            <ArrowUp className="h-6 w-6 text-white" />
+          </button>
+          <span className="mt-2 font-medium">Til tops</span>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/docs/src/routes/_docs/profil/ikoner.tsx
+++ b/apps/docs/src/routes/_docs/profil/ikoner.tsx
@@ -1,4 +1,5 @@
 import { ResourceLink, ResourceLinks } from '@/ui/resource-links';
+import { ScrollToTop } from '@/ui/scroll-to-top';
 import * as icons from '@obosbbl/grunnmuren-icons-react';
 import { Download } from '@obosbbl/grunnmuren-icons-react';
 import { Button, Card } from '@obosbbl/grunnmuren-react';
@@ -58,6 +59,7 @@ function Page() {
         />
       </ResourceLinks>
       <IconsGrid />
+      <ScrollToTop />
     </>
   );
 }

--- a/apps/docs/src/ui/props-table.tsx
+++ b/apps/docs/src/ui/props-table.tsx
@@ -9,7 +9,7 @@ interface PropsTableProps {
 export const PropsTable = ({ componentName }: PropsTableProps) => {
   const headingId = `${componentName.toLowerCase()}-props`;
   return (
-    <>
+    <div className="overflow-x-auto">
       <AnchorHeading className="heading-s my-2" level={2} id={headingId}>
         {componentName}
       </AnchorHeading>
@@ -36,6 +36,6 @@ export const PropsTable = ({ componentName }: PropsTableProps) => {
           ))}
         </TableBody>
       </Table>
-    </>
+    </div>
   );
 };

--- a/apps/docs/src/ui/scroll-to-top.tsx
+++ b/apps/docs/src/ui/scroll-to-top.tsx
@@ -42,11 +42,17 @@ interface ScrollToTopButtonProps {
  * Scroll to top button component
  * Displays a floating button with "Til tops" text that scrolls to the top of the page
  */
-export function ScrollToTopButton({ show, onClick, className }: ScrollToTopButtonProps) {
+export function ScrollToTopButton({
+  show,
+  onClick,
+  className,
+}: ScrollToTopButtonProps) {
   if (!show) return null;
 
   return (
-    <div className={`fixed right-4 bottom-4 z-50 flex flex-col items-center md:right-16 md:bottom-16 ${className || ''}`}>
+    <div
+      className={`fixed right-4 bottom-4 z-50 flex flex-col items-center md:right-16 md:bottom-16 ${className || ''}`}
+    >
       <button
         onClick={onClick}
         className="hover:-translate-y-1 flex h-12 w-12 items-center justify-center rounded-full bg-blue-dark transition-all duration-300 focus-visible:outline-focus"
@@ -64,8 +70,17 @@ export function ScrollToTopButton({ show, onClick, className }: ScrollToTopButto
  * Combined scroll-to-top component that includes both the hook and button
  * Easy to use - just drop it into any page component
  */
-export function ScrollToTop({ threshold = 300, className }: { threshold?: number; className?: string }) {
+export function ScrollToTop({
+  threshold = 300,
+  className,
+}: { threshold?: number; className?: string }) {
   const { showButton, scrollToTop } = useScrollToTop(threshold);
-  
-  return <ScrollToTopButton show={showButton} onClick={scrollToTop} className={className} />;
+
+  return (
+    <ScrollToTopButton
+      show={showButton}
+      onClick={scrollToTop}
+      className={className}
+    />
+  );
 }

--- a/apps/docs/src/ui/scroll-to-top.tsx
+++ b/apps/docs/src/ui/scroll-to-top.tsx
@@ -1,5 +1,6 @@
 import { ArrowUp } from '@obosbbl/grunnmuren-icons-react';
 import { useEffect, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
 
 /**
  * Custom hook for scroll-to-top functionality
@@ -9,15 +10,16 @@ import { useEffect, useState } from 'react';
 export function useScrollToTop(threshold = 300) {
   const [showButton, setShowButton] = useState(false);
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const scrollTop = window.scrollY || document.documentElement.scrollTop;
-      setShowButton(scrollTop > threshold);
-    };
+  // Debounce the scroll handler to avoid performance issues with frequent scroll events
+  const debouncedScrollHandler = useDebouncedCallback(() => {
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    setShowButton(scrollTop > threshold);
+  }, 100);
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [threshold]);
+  useEffect(() => {
+    window.addEventListener('scroll', debouncedScrollHandler);
+    return () => window.removeEventListener('scroll', debouncedScrollHandler);
+  }, [debouncedScrollHandler]);
 
   const scrollToTop = () => {
     window.scrollTo({

--- a/apps/docs/src/ui/scroll-to-top.tsx
+++ b/apps/docs/src/ui/scroll-to-top.tsx
@@ -1,0 +1,71 @@
+import { ArrowUp } from '@obosbbl/grunnmuren-icons-react';
+import { useEffect, useState } from 'react';
+
+/**
+ * Custom hook for scroll-to-top functionality
+ * @param threshold - The scroll position (in pixels) after which the button should appear
+ * @returns Object with showButton state and scrollToTop function
+ */
+export function useScrollToTop(threshold = 300) {
+  const [showButton, setShowButton] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY || document.documentElement.scrollTop;
+      setShowButton(scrollTop > threshold);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [threshold]);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return { showButton, scrollToTop };
+}
+
+interface ScrollToTopButtonProps {
+  /** Whether the button should be visible */
+  show: boolean;
+  /** Function to call when button is clicked */
+  onClick: () => void;
+  /** Custom className for the container */
+  className?: string;
+}
+
+/**
+ * Scroll to top button component
+ * Displays a floating button with "Til tops" text that scrolls to the top of the page
+ */
+export function ScrollToTopButton({ show, onClick, className }: ScrollToTopButtonProps) {
+  if (!show) return null;
+
+  return (
+    <div className={`fixed right-4 bottom-4 z-50 flex flex-col items-center md:right-16 md:bottom-16 ${className || ''}`}>
+      <button
+        onClick={onClick}
+        className="hover:-translate-y-1 flex h-12 w-12 items-center justify-center rounded-full bg-blue-dark transition-all duration-300 focus-visible:outline-focus"
+        aria-label="Scroll to top"
+        type="button"
+      >
+        <ArrowUp className="h-6 w-6 text-white" />
+      </button>
+      <span className="mt-2 font-medium">Til tops</span>
+    </div>
+  );
+}
+
+/**
+ * Combined scroll-to-top component that includes both the hook and button
+ * Easy to use - just drop it into any page component
+ */
+export function ScrollToTop({ threshold = 300, className }: { threshold?: number; className?: string }) {
+  const { showButton, scrollToTop } = useScrollToTop(threshold);
+  
+  return <ScrollToTopButton show={showButton} onClick={scrollToTop} className={className} />;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       sanity:
         specifier: 3.92.0
         version: 3.92.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.0)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(tsx@4.19.2)(typescript@5.8.3)(yaml@2.7.0)
+      use-debounce:
+        specifier: 10.0.4
+        version: 10.0.4(react@19.0.0)
     devDependencies:
       '@obosbbl/grunnmuren-tailwind':
         specifier: workspace:*


### PR DESCRIPTION
Because we have very long articles on the grunnmuren docs, we thought it would be nice with a "scroll to top"- button! 

* Added a "scroll to top" button that appears after scrolling down 300px, using the `ArrowUp` icon. The button is fixed to the bottom-right corner and smoothly scrolls the page to the top when clicked.

**Fixes not related:**

* Wrapped the props table in a horizontally scrollable container to improve usability on smaller screens.
* Simplified the main documentation page layout by removing the unnecessary `grid` class from the container, relying on `flex` for layout.

<img width="1397" height="840" alt="image" src="https://github.com/user-attachments/assets/5e7a8320-f569-4dd5-ae92-bce8676a05f7" />
