### PR TITLE
Highlight selected tags with more than just color

### DIFF
--- a/.changeset/loud-showers-walk.md
+++ b/.changeset/loud-showers-walk.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": patch
 ---
 
-Make selected `Tags` visible not only through color. The visual style of a selected `Tag` is now enhanced with increased `font-weight` and `stroke-width` for icons.
+Make selected `Tags` visible not only through color. The visual style of a selected/removable `Tag` is now enhanced with a reversed contrast.

--- a/.changeset/loud-showers-walk.md
+++ b/.changeset/loud-showers-walk.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Make selected `Tags` visible not only through color. The visual style of a selected `Tag` is now enhanced with increased `font-weight` and `stroke-width` for icons.

--- a/packages/react/src/tag-group/tag-group.tsx
+++ b/packages/react/src/tag-group/tag-group.tsx
@@ -21,8 +21,18 @@ const tagVariants = cva({
     // Hover
     ' data-hovered:bg-sky',
     // Selected
-    'data-allows-removing:border-blue-dark data-allows-removing:not-data-hovered:bg-sky-light data-allows-removing:font-bold data-allows-removing:text-blue-dark data-allows-removing:**:stroke-[2.5]',
-    'aria-selected:border-blue-dark aria-selected:not-data-hovered:bg-sky-light aria-selected:font-bold aria-selected:text-blue-dark aria-selected:**:stroke-[2.5]',
+    // Allows removing: border, background, font, text, icon
+    'data-allows-removing:border-blue-dark',
+    'data-allows-removing:not-data-hovered:bg-sky-light',
+    'data-allows-removing:font-bold',
+    'data-allows-removing:text-blue-dark',
+    'data-allows-removing:**:stroke-[2.5]',
+    // Selected: border, background, font, text, icon
+    'aria-selected:border-blue-dark',
+    'aria-selected:not-data-hovered:bg-sky-light',
+    'aria-selected:font-bold',
+    'aria-selected:text-blue-dark',
+    'aria-selected:**:stroke-[2.5]',
     //Icons
     '[&_svg]:h-4 [&_svg]:w-4',
   ],

--- a/packages/react/src/tag-group/tag-group.tsx
+++ b/packages/react/src/tag-group/tag-group.tsx
@@ -118,7 +118,6 @@ function Tag(props: TagProps) {
         className,
       })}
       textValue={textValue}
-      data-text={textValue}
       {...restProps}
     >
       {({ allowsRemoving }) =>

--- a/packages/react/src/tag-group/tag-group.tsx
+++ b/packages/react/src/tag-group/tag-group.tsx
@@ -1,7 +1,6 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx } from 'cva';
 import type { RefAttributes } from 'react';
-import { useEffect } from 'react';
 import {
   Button,
   Tag as RACTag,
@@ -11,7 +10,6 @@ import {
   type TagListProps as RACTagListProps,
   type TagProps as RACTagProps,
 } from 'react-aria-components';
-import { useDebouncedCallback } from 'use-debounce';
 
 const tagVariants = cva({
   base: [
@@ -121,12 +119,6 @@ function Tag(props: TagProps) {
   const { className, children, ...restProps } = props;
 
   const textValue = typeof children === 'string' ? children : undefined;
-
-  const myFunction = useDebouncedCallback(() => console.log('debounce'), 100);
-
-  useEffect(() => {
-    myFunction();
-  }, [myFunction]);
 
   return (
     <RACTag

--- a/packages/react/src/tag-group/tag-group.tsx
+++ b/packages/react/src/tag-group/tag-group.tsx
@@ -30,7 +30,7 @@ const tagVariants = cva({
     // Selected: border, background, font, text, icon
     'aria-selected:border-blue-dark',
     'aria-selected:not-data-hovered:bg-sky-light',
-    'aria-selected:font-bold',
+    'aria-selected:font-semibold',
     'aria-selected:text-blue-dark',
     'aria-selected:**:stroke-[2.5]',
     //Icons

--- a/packages/react/src/tag-group/tag-group.tsx
+++ b/packages/react/src/tag-group/tag-group.tsx
@@ -1,6 +1,7 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx } from 'cva';
 import type { RefAttributes } from 'react';
+import { useEffect } from 'react';
 import {
   Button,
   Tag as RACTag,
@@ -10,6 +11,7 @@ import {
   type TagListProps as RACTagListProps,
   type TagProps as RACTagProps,
 } from 'react-aria-components';
+import { useDebouncedCallback } from 'use-debounce';
 
 const tagVariants = cva({
   base: [
@@ -21,18 +23,16 @@ const tagVariants = cva({
     // Hover
     ' data-hovered:bg-sky',
     // Selected
-    // Allows removing: border, background, font, text, icon
-    'data-allows-removing:border-blue-dark',
-    'data-allows-removing:not-data-hovered:bg-sky-light',
-    'data-allows-removing:font-bold',
-    'data-allows-removing:text-blue-dark',
-    'data-allows-removing:**:stroke-[2.5]',
-    // Selected: border, background, font, text, icon
-    'aria-selected:border-blue-dark',
-    'aria-selected:not-data-hovered:bg-sky-light',
-    'aria-selected:font-semibold',
-    'aria-selected:text-blue-dark',
-    'aria-selected:**:stroke-[2.5]',
+    // Allows removing
+    'data-allows-removing:border-transparent',
+    'data-allows-removing:bg-blue',
+    'data-allows-removing:data-hovered:bg-blue-dark',
+    'data-allows-removing:text-white',
+    // Selected
+    'aria-selected:border-transparent',
+    'aria-selected:bg-blue',
+    'aria-selected:data-hovered:bg-blue-dark',
+    'aria-selected:text-white',
     //Icons
     '[&_svg]:h-4 [&_svg]:w-4',
   ],
@@ -121,6 +121,12 @@ function Tag(props: TagProps) {
   const { className, children, ...restProps } = props;
 
   const textValue = typeof children === 'string' ? children : undefined;
+
+  const myFunction = useDebouncedCallback(() => console.log('debounce'), 100);
+
+  useEffect(() => {
+    myFunction();
+  }, [myFunction]);
 
   return (
     <RACTag

--- a/packages/react/src/tag-group/tag-group.tsx
+++ b/packages/react/src/tag-group/tag-group.tsx
@@ -14,12 +14,15 @@ import {
 const tagVariants = cva({
   base: [
     'relative flex cursor-pointer items-center gap-1 rounded-lg px-2 py-1 font-medium text-sm transition-colors duration-200',
+    // Resting
+    'border-2 border-black bg-white text-black',
     //Focus
     'focus-visible:outline-focus-offset',
-    //Border
-    'border-2 border-blue-dark',
-    //Backgrounds
-    'data-hovered:!bg-sky bg-white text-black aria-selected:bg-sky-light data-allows-removing:bg-sky-light',
+    // Hover
+    ' data-hovered:bg-sky',
+    // Selected
+    'data-allows-removing:border-blue-dark data-allows-removing:not-data-hovered:bg-sky-light data-allows-removing:font-bold data-allows-removing:text-blue-dark data-allows-removing:**:stroke-[2.5]',
+    'aria-selected:border-blue-dark aria-selected:not-data-hovered:bg-sky-light aria-selected:font-bold aria-selected:text-blue-dark aria-selected:**:stroke-[2.5]',
     //Icons
     '[&_svg]:h-4 [&_svg]:w-4',
   ],
@@ -115,6 +118,7 @@ function Tag(props: TagProps) {
         className,
       })}
       textValue={textValue}
+      data-text={textValue}
       {...restProps}
     >
       {({ allowsRemoving }) =>


### PR DESCRIPTION
## More accessible selection for Tags

Highlight selected tags with more than just color. This is to meet [WCAG SC 1.4.1](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)

A selected / removable `Tag` is now also highlighted with increased `font-weight` and `stroke-width` on it's icons:
<img width="435" height="699" alt="Screenshot 2025-08-05 at 15 39 34" src="https://github.com/user-attachments/assets/4c79c7ce-206c-41a2-8a60-305211f8b986" />

