### PR TITLE
New LinkList component

### DIFF
--- a/.changeset/sad-rabbits-nail.md
+++ b/.changeset/sad-rabbits-nail.md
@@ -4,7 +4,7 @@
 
 # LinkList
 
-New `LinkList` component in beta. Use it to display a set of releated links. You can choose between rendering regular, download or external links on each `LinkListItem`. The `LinkListItem` uses `Link` from react aria components under the hood. Which means that you can use it with `routerOptions`. Refer to [https://react-spectrum.adobe.com/react-aria/routing.html](https://react-spectrum.adobe.com/react-aria/routing.html) for more.
+New `LinkList` component in beta. Use it to display a set of related links. You can choose between rendering regular, download or external links on each `LinkListItem`. The `LinkListItem` uses `Link` from react aria components under the hood. Which means that you can use it with `routerOptions`. Refer to [https://react-spectrum.adobe.com/react-aria/routing.html](https://react-spectrum.adobe.com/react-aria/routing.html) for more.
 
 ## Usage
 

--- a/.changeset/sad-rabbits-nail.md
+++ b/.changeset/sad-rabbits-nail.md
@@ -1,0 +1,52 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+# LinkList
+
+New `LinkList` component in beta. Use it to display a set of releated links. You can choose between rendering regular, download or external links on each `LinkListItem`. The `LinkListItem` uses `Link` from react aria components under the hood. Which means that you can use it with `routerOptions`. Refer to [https://react-spectrum.adobe.com/react-aria/routing.html](https://react-spectrum.adobe.com/react-aria/routing.html) for more.
+
+## Usage
+
+### Import
+``` tsx
+import {
+  UNSAFE_LinkList as LinkList,
+  UNSAFE_LinkListItem as LinkListItem,
+} from './link-list';
+```
+
+### Standard links
+``` tsx
+  <LinkList>
+    <LinkListItem href="/bolig">Bolig</LinkListItem>
+    <LinkListItem href="/bank">Bank</LinkListItem>
+    <LinkListItem href="/medlem">Medlem</LinkListItem>
+  </LinkList>
+```
+
+### Download
+``` tsx
+  <LinkList>
+    <LinkListItem download href="/">
+      Medlemsvilkår
+    </LinkListItem>
+    <LinkListItem download href="/about">
+      Samtykke
+    </LinkListItem>
+  </LinkList>
+```
+
+### External
+``` tsx
+  <LinkList>
+    <LinkListItem href="/forsikring">Forsikring</LinkListItem>
+    <LinkListItem
+      href="https://www.tryg.no/forsikringer/fordeler-hos-tryg/bruk-medlemsfordelene-dine/obos/index.html?cmpid=obos_tryggjennomlivet"
+      isExternal
+      target="_blank"
+    >
+      Les mer om trygg forsikring
+    </LinkListItem>
+  </LinkList>
+```

--- a/packages/react/src/link-list/link-list.stories.tsx
+++ b/packages/react/src/link-list/link-list.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta } from '@storybook/react';
+import {
+  UNSAFE_LinkList as LinkList,
+  UNSAFE_LinkListItem as LinkListItem,
+} from './link-list';
+
+const meta: Meta<typeof LinkList> = {
+  title: 'LinkListItemList',
+  component: LinkList,
+
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const Default = () => (
+  <LinkList>
+    <LinkListItem href="/">Home</LinkListItem>
+    <LinkListItem href="/about">About</LinkListItem>
+    <LinkListItem href="/services">Services</LinkListItem>
+  </LinkList>
+);
+
+export const Download = () => (
+  <LinkList>
+    <LinkListItem download href="/">
+      Medlemsvilkår
+    </LinkListItem>
+    <LinkListItem download href="/about">
+      Samtykke
+    </LinkListItem>
+  </LinkList>
+);
+export const ExternalLinkListItems = () => (
+  <LinkList>
+    <LinkListItem href="https://www.example.com" isExternal>
+      External LinkListItem
+    </LinkListItem>
+    <LinkListItem href="/internal-page">Internal LinkListItem</LinkListItem>
+  </LinkList>
+);
+
+export const InMultipleColumns = () => (
+  <LinkList className="md:grid-cols-2 lg:grid-cols-3">
+    <LinkListItem href="/">Home</LinkListItem>
+    <LinkListItem href="/about">About</LinkListItem>
+    <LinkListItem href="/services">Services</LinkListItem>
+    <LinkListItem href="/">Home</LinkListItem>
+    <LinkListItem href="/about">About</LinkListItem>
+    <LinkListItem href="/services">Services</LinkListItem>
+    <LinkListItem href="/">Home</LinkListItem>
+    <LinkListItem href="/about">About</LinkListItem>
+    <LinkListItem href="/services">Services</LinkListItem>
+  </LinkList>
+);

--- a/packages/react/src/link-list/link-list.stories.tsx
+++ b/packages/react/src/link-list/link-list.stories.tsx
@@ -41,7 +41,7 @@ export const ExternalLinkListItems = () => (
 );
 
 export const InMultipleColumns = () => (
-  <LinkList className="md:grid-cols-2 lg:grid-cols-3">
+  <LinkList>
     <LinkListItem href="/">Home</LinkListItem>
     <LinkListItem href="/about">About</LinkListItem>
     <LinkListItem href="/services">Services</LinkListItem>
@@ -49,6 +49,8 @@ export const InMultipleColumns = () => (
     <LinkListItem href="/about">About</LinkListItem>
     <LinkListItem href="/services">Services</LinkListItem>
     <LinkListItem href="/">Home</LinkListItem>
+    <LinkListItem href="/about">About</LinkListItem>
+    <LinkListItem href="/services">Services</LinkListItem>
     <LinkListItem href="/about">About</LinkListItem>
     <LinkListItem href="/services">Services</LinkListItem>
   </LinkList>

--- a/packages/react/src/link-list/link-list.stories.tsx
+++ b/packages/react/src/link-list/link-list.stories.tsx
@@ -15,9 +15,9 @@ export default meta;
 
 export const Default = () => (
   <LinkList>
-    <LinkListItem href="/">Home</LinkListItem>
-    <LinkListItem href="/about">About</LinkListItem>
-    <LinkListItem href="/services">Services</LinkListItem>
+    <LinkListItem href="/bolig">Bolig</LinkListItem>
+    <LinkListItem href="/bank">Bank</LinkListItem>
+    <LinkListItem href="/medlem">Medlem</LinkListItem>
   </LinkList>
 );
 
@@ -33,25 +33,41 @@ export const Download = () => (
 );
 export const ExternalLinkListItems = () => (
   <LinkList>
-    <LinkListItem href="https://www.example.com" isExternal>
-      External LinkListItem
+    <LinkListItem href="/forsikring">Forsikring</LinkListItem>
+    <LinkListItem
+      href="https://www.tryg.no/forsikringer/fordeler-hos-tryg/bruk-medlemsfordelene-dine/obos/index.html?cmpid=obos_tryggjennomlivet"
+      isExternal
+      target="_blank"
+    >
+      Les mer om trygg forsikring
     </LinkListItem>
-    <LinkListItem href="/internal-page">Internal LinkListItem</LinkListItem>
   </LinkList>
 );
 
-export const InMultipleColumns = () => (
+export const AutoResponsive = () => (
   <LinkList>
-    <LinkListItem href="/">Home</LinkListItem>
-    <LinkListItem href="/about">About</LinkListItem>
-    <LinkListItem href="/services">Services</LinkListItem>
-    <LinkListItem href="/">Home</LinkListItem>
-    <LinkListItem href="/about">About</LinkListItem>
-    <LinkListItem href="/services">Services</LinkListItem>
-    <LinkListItem href="/">Home</LinkListItem>
-    <LinkListItem href="/about">About</LinkListItem>
-    <LinkListItem href="/services">Services</LinkListItem>
-    <LinkListItem href="/about">About</LinkListItem>
-    <LinkListItem href="/services">Services</LinkListItem>
+    <LinkListItem href="/konsernledelsen">Konsernledelsen</LinkListItem>
+    <LinkListItem href="/styret">Styret</LinkListItem>
+    <LinkListItem href="/representantskapet">Representantskapet</LinkListItem>
+    <LinkListItem href="/boligpriser-og-statistikk">
+      Boligpriser og statistikk
+    </LinkListItem>
+    <LinkListItem href="/investor-relations">Investor Relations</LinkListItem>
+    <LinkListItem href="/digital-arsrapport">Digital årsrapport</LinkListItem>
+    <LinkListItem href="/jobb-i-obos">Jobb i OBOS</LinkListItem>
+    <LinkListItem href="/presse">Presse</LinkListItem>
+    <LinkListItem href="/logoer">Logoer</LinkListItem>
+    <LinkListItem href="/obos-boligkonferanse">
+      OBOS Boligkonferanse
+    </LinkListItem>
+    <LinkListItem href="/obos-ligaen">OBOS-ligaen</LinkListItem>
+    <LinkListItem href="/datterselskaper">Datterselskaper</LinkListItem>
+    <LinkListItem href="/vedtekter">Vedtekter</LinkListItem>
+    <LinkListItem href="/generalforsamlingen-i-obos">
+      Generalforsamlingen i OBOS
+    </LinkListItem>
+    <LinkListItem href="/strategi-og-styrende-dokumenter">
+      Strategi og styrende dokumenter
+    </LinkListItem>
   </LinkList>
 );

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -55,7 +55,7 @@ const LinkListItem = ({
     >
       <Link
         className={cx(
-          'group paragraph flex cursor-pointer justify-between gap-x-3.5 py-3.5 font-medium no-underline focus-visible:outline-focus',
+          'group paragraph flex cursor-pointer justify-between gap-x-2 py-3.5 font-medium no-underline focus-visible:outline-focus',
         )}
         {...restProps}
       >

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -23,7 +23,7 @@ const LinkList = ({ className, children, ...restProps }: _LinkListProps) => {
           'overflow-hidden',
           // Add a small gap between items that fits the divider lines (this way the divider line don't take up any space in each item)
           'grid gap-y-0.25',
-          // Add a gap between items if the list is displayed in multiple columns
+          // Gaps for when the list is displayed in multiple columns
           '@lg:gap-x-12 @md:gap-x-9 @sm:gap-x-4 @xl:gap-x-16',
           numberofLinks > 5 && [
             '@md:grid-cols-2',
@@ -59,7 +59,7 @@ const LinkListItem = ({
   }
   return (
     <li
-      // Creates divider lines that works in any grid layout and the focus ring
+      // Creates divider lines that works in any grid layout and with the focus ring
       className="after:-top-0.25 relative p-0.75 after:absolute after:right-0 after:left-0 after:h-0.25 after:w-full after:bg-gray-light"
     >
       <Link

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -4,16 +4,17 @@ import {
   LinkExternal,
 } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import type { HTMLProps, JSX, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, JSX, ReactNode } from 'react';
 import { Link, type LinkProps } from 'react-aria-components';
 
-type _LinkListProps = HTMLProps<HTMLUListElement> & {
+type _LinkListProps = ComponentPropsWithoutRef<'ul'> & {
   children: JSX.Element | JSX.Element[];
+  ref?: React.Ref<HTMLUListElement>;
 };
 
 const LinkList = ({ className, children, ...restProps }: _LinkListProps) => (
   <ul
-    // {...restProps}
+    {...restProps}
     className={cx(
       className,
       // Hide dividers at the top of the list (overflow-y) and prevents arrow icon from overflowing container when animated to the right (overflow-x)

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -26,8 +26,8 @@ const LinkList = ({ className, children, ...restProps }: _LinkListProps) => {
           // Gaps for when the list is displayed in multiple columns
           '@lg:gap-x-12 @md:gap-x-9 @sm:gap-x-4 @xl:gap-x-16',
           numberofLinks > 5 && [
-            '@md:grid-cols-2',
-            numberofLinks > 10 && '@4xl:grid-cols-3 @xl:grid-cols-2',
+            '@xl:grid-cols-2',
+            numberofLinks > 10 && '@4xl:grid-cols-3',
           ],
         )}
       >

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -4,12 +4,11 @@ import {
   LinkExternal,
 } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import type { ComponentPropsWithoutRef, JSX, ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { Link, type LinkProps } from 'react-aria-components';
 
-type _LinkListProps = ComponentPropsWithoutRef<'ul'> & {
+type _LinkListProps = React.HTMLProps<HTMLUListElement> & {
   children: JSX.Element | JSX.Element[];
-  ref?: React.Ref<HTMLUListElement>;
 };
 
 const LinkList = ({ className, children, ...restProps }: _LinkListProps) => (

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -27,7 +27,7 @@ const LinkList = ({ className, children, ...restProps }: _LinkListProps) => {
           '@lg:gap-x-12 @md:gap-x-9 @sm:gap-x-4 @xl:gap-x-16',
           numberofLinks > 5 && [
             '@md:grid-cols-2',
-            numberofLinks > 10 && '@2xl:grid-cols-3 @xl:grid-cols-2',
+            numberofLinks > 10 && '@4xl:grid-cols-3 @xl:grid-cols-2',
           ],
         )}
       >

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -1,0 +1,79 @@
+import {
+  ArrowRight,
+  Download,
+  LinkExternal,
+} from '@obosbbl/grunnmuren-icons-react';
+import { cx } from 'cva';
+import type { HTMLProps, JSX, ReactNode } from 'react';
+import { Link, type LinkProps } from 'react-aria-components';
+
+type _LinkListProps = HTMLProps<HTMLUListElement> & {
+  children: JSX.Element | JSX.Element[];
+};
+
+const LinkList = ({ className, children, ...restProps }: _LinkListProps) => (
+  <ul
+    // {...restProps}
+    className={cx(
+      className,
+      // Hide dividers at the top of the list (overflow-y) and prevents arrow icon from overflowing container when animated to the right (overflow-x)
+      'overflow-hidden',
+      // Add a small gap between items that fits the divider lines (this way the divider line don't take up any space in each item)
+      'grid gap-y-0.25',
+      // Add a gap between items if the list is displayed in multiple columns
+      'sm:gap-x-4 md:gap-x-9 lg:gap-x-12 xl:gap-x-16',
+    )}
+  >
+    {children}
+  </ul>
+);
+
+type LinkListItemProps = LinkProps & {
+  children: ReactNode;
+  isExternal?: boolean;
+};
+
+const LinkListItem = ({
+  children,
+  isExternal,
+  ...restProps
+}: LinkListItemProps) => {
+  let Icon = ArrowRight;
+  let iconTransition = 'group-hover:motion-safe:translate-x-1';
+  if (restProps.download) {
+    Icon = Download;
+    iconTransition = 'group-hover:motion-safe:translate-y-1';
+  } else if (isExternal) {
+    iconTransition =
+      'group-hover:motion-safe:-translate-y-0.5 group-hover:motion-safe:translate-x-0.5';
+    Icon = LinkExternal;
+  }
+  return (
+    <li
+      // Creates divider lines that works in any grid layout and the focus ring
+      className="after:-top-0.25 relative p-0.75 after:absolute after:right-0 after:left-0 after:h-0.25 after:w-full after:bg-gray-light"
+    >
+      <Link
+        className={cx(
+          'group paragraph flex cursor-pointer justify-between gap-x-3.5 py-3.5 font-medium no-underline focus-visible:outline-focus',
+        )}
+        {...restProps}
+      >
+        <span>{children}</span>
+        <Icon
+          className={cx(
+            'shrink-0 motion-safe:transition-transform',
+            iconTransition,
+          )}
+        />
+      </Link>
+    </li>
+  );
+};
+
+export {
+  LinkList as UNSAFE_LinkList,
+  type _LinkListProps as UNSAFE__LinkListProps,
+  LinkListItem as UNSAFE_LinkListItem,
+  type LinkListItemProps as UNSAFE_LinkListItemProps,
+};

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -4,29 +4,38 @@ import {
   LinkExternal,
 } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import type { JSX, ReactNode } from 'react';
+import { Children, type JSX, type ReactNode } from 'react';
 import { Link, type LinkProps } from 'react-aria-components';
 
 type _LinkListProps = React.HTMLProps<HTMLUListElement> & {
   children: JSX.Element | JSX.Element[];
 };
 
-const LinkList = ({ className, children, ...restProps }: _LinkListProps) => (
-  <ul
-    {...restProps}
-    className={cx(
-      className,
-      // Hide dividers at the top of the list (overflow-y) and prevents arrow icon from overflowing container when animated to the right (overflow-x)
-      'overflow-hidden',
-      // Add a small gap between items that fits the divider lines (this way the divider line don't take up any space in each item)
-      'grid gap-y-0.25',
-      // Add a gap between items if the list is displayed in multiple columns
-      'sm:gap-x-4 md:gap-x-9 lg:gap-x-12 xl:gap-x-16',
-    )}
-  >
-    {children}
-  </ul>
-);
+const LinkList = ({ className, children, ...restProps }: _LinkListProps) => {
+  const numberofLinks = Children.count(children);
+  return (
+    <div className="@container">
+      <ul
+        {...restProps}
+        className={cx(
+          className,
+          // Hide dividers at the top of the list (overflow-y) and prevents arrow icon from overflowing container when animated to the right (overflow-x)
+          'overflow-hidden',
+          // Add a small gap between items that fits the divider lines (this way the divider line don't take up any space in each item)
+          'grid gap-y-0.25',
+          // Add a gap between items if the list is displayed in multiple columns
+          '@lg:gap-x-12 @md:gap-x-9 @sm:gap-x-4 @xl:gap-x-16',
+          numberofLinks > 5 && [
+            '@md:grid-cols-2',
+            numberofLinks > 10 && '@2xl:grid-cols-3 @xl:grid-cols-2',
+          ],
+        )}
+      >
+        {children}
+      </ul>
+    </div>
+  );
+};
 
 type LinkListItemProps = LinkProps & {
   children: ReactNode;


### PR DESCRIPTION
# LinkList

New `LinkList` component. Can be used to display a set of releated links where it is possible to choose between rendering regular, download or external links on each `LinkListItem`. The `LinkListItem` uses `Link` from react aria components under the hood. Which means it aslo supports `routerOptions`. Refer to [https://react-spectrum.adobe.com/react-aria/routing.html](https://react-spectrum.adobe.com/react-aria/routing.html).

## Usage

### Import
``` tsx
import {
  UNSAFE_LinkList as LinkList,
  UNSAFE_LinkListItem as LinkListItem,
} from './link-list';
```

### Standard links
``` tsx
  <LinkList>
    <LinkListItem href="/bolig">Bolig</LinkListItem>
    <LinkListItem href="/bank">Bank</LinkListItem>
    <LinkListItem href="/medlem">Medlem</LinkListItem>
  </LinkList>
```

### Download
``` tsx
  <LinkList>
    <LinkListItem download href="/">
      Medlemsvilkår
    </LinkListItem>
    <LinkListItem download href="/about">
      Samtykke
    </LinkListItem>
  </LinkList>
```

### External
``` tsx
  <LinkList>
    <LinkListItem href="/forsikring">Forsikring</LinkListItem>
    <LinkListItem
      href="https://www.tryg.no/forsikringer/fordeler-hos-tryg/bruk-medlemsfordelene-dine/obos/index.html?cmpid=obos_tryggjennomlivet"
      isExternal
      target="_blank"
    >
      Les mer om trygg forsikring
    </LinkListItem>
  </LinkList>
```

In this first release the LinkList is auto-responsive, meaning that it will place it's content over several columns based on available space and the number of items:

https://github.com/user-attachments/assets/7300a4e1-e518-46da-a795-9f5187512dd0

We might need to extend the `LinkList` API to support control of the responsive column layout down the line. But hopefully this auto-approach is enough.