### PR TITLE
Fix className passing

### DIFF
--- a/.changeset/tangy-dragons-hide.md
+++ b/.changeset/tangy-dragons-hide.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fixes the `className` passing for the `<Card>` component. This was previously passed to the inner container, the "card" itself. It is now passed to the newly added outer container, used for container queries. This avoids some layout bugs where the cards have an implicit width.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -14,7 +14,8 @@ type CardProps = VariantProps<typeof cardVariants> & {
 const cardVariants = cva({
   base: [
     'group/card',
-    'rounded-2xl border p-3',
+    'rounded-[inherit]', // Inherits rounded corners from the parent container
+    'border p-3',
     'flex flex-col gap-y-4', // y-gap ensures a vertical spacing for both vertical layout and responsive horizontal layout
     'relative', // Needed for positiong of the clickable pseudo-element (and can also be used for other absolute positioned elements the consumer might add)
 
@@ -140,19 +141,20 @@ const cardVariants = cva({
 
 const Card = ({
   children,
-  className: _className,
+  className,
   variant,
   layout,
   ...restProps
 }: CardProps) => {
-  const className = cardVariants({
-    className: _className,
+  const cardClassName = cardVariants({
     variant,
     layout,
   });
   return (
-    <div className="@container">
-      <div className={className} {...restProps}>
+    // The border-radius is set on the outer container to make it act as an invisible wrapper, only used for container queries
+    // Since passing the className prop to this container is necessary to make custom styles behave as expected, we need to apply the border-radius here incase the consumer passes a custom background color
+    <div {...restProps} className={cx(className, '@container rounded-2xl')}>
+      <div className={cardClassName}>
         <Provider
           values={[
             [


### PR DESCRIPTION
## Fix `className` prop passing for  `Card`

Fixes the `className` passing for the `<Card>` component. This was previously passed to the inner container, the "card" itself. It is now passed to the newly added outer container, used for container queries. This avoids some layout bugs where the cards have an implicit width:


https://github.com/user-attachments/assets/0d8a16ae-e736-4ab9-b8b3-97d571115488

With this fix:


https://github.com/user-attachments/assets/bdbfa5e4-ae68-4303-942b-ff4d089cd24d

