### PR TITLE
Render LinkList with 9 items over 3 columns

### DIFF
--- a/.changeset/three-ties-follow.md
+++ b/.changeset/three-ties-follow.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Render `<LinkList>` with 9 items over three columns on large screens

--- a/packages/react/src/link-list/link-list.tsx
+++ b/packages/react/src/link-list/link-list.tsx
@@ -27,7 +27,7 @@ const LinkList = ({ className, children, ...restProps }: LinkListProps) => {
           '@lg:gap-x-12 @md:gap-x-9 @sm:gap-x-4 @xl:gap-x-16',
           numberofLinks > 5 && [
             '@xl:grid-cols-2',
-            numberofLinks > 10 && '@4xl:grid-cols-3',
+            (numberofLinks === 9 || numberofLinks > 10) && '@4xl:grid-cols-3',
           ],
         )}
       >


### PR DESCRIPTION
## Refine LinkList columns autolayout

Render `<LinkList>` with 9 items over three columns on large screens:

<img width="1098" height="1270" alt="Screenshot 2025-09-09 at 13 53 24" src="https://github.com/user-attachments/assets/625a4388-3b18-410f-af65-495efcab66e8" />
