### PR TITLE
Add missing semicolon in usage instructions

### DIFF
--- a/packages/tailwind/README.md
+++ b/packages/tailwind/README.md
@@ -25,7 +25,7 @@ Configure Tailwind to use the preset
 
 /** Add any auto excluded sources (typically residing in node_modules) */
 @source "../../node_modules/@obosbbl/grunnmuren-react/dist";
-@source "../../node_modules/@code-obos/obos-layout/dist"
+@source "../../node_modules/@code-obos/obos-layout/dist";
 ```
 
 ## Fonts


### PR DESCRIPTION
Etter 4 mnd med en navbar som ikke har lastet helt riktig så fant vi et manglende semikolon... Og tipper vi bare kopierte herfra 🙈