### PR TITLE
Update link styles in prose to match Link component

### DIFF
--- a/.changeset/common-spoons-reply.md
+++ b/.changeset/common-spoons-reply.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+Use same styles for links in prose as the `<Link>` component in grunnmuren-react.

--- a/packages/tailwind/tailwind-typography.css
+++ b/packages/tailwind/tailwind-typography.css
@@ -70,7 +70,8 @@
     &:where(a) {
       color: var(--tw-prose-links);
       text-decoration: underline;
-      font-weight: 500;
+      /** Copied from the Link component:  **/
+      @apply inline-flex cursor-pointer items-center gap-1 font-medium hover:no-underline focus-visible:outline-current focus-visible:outline-focus-offset [&>svg]:shrink-0;
     }
 
     &:where(strong) {


### PR DESCRIPTION
Align link styles in prose with the `<Link>` component from grunnmuren-react for consistency.