### PR TITLE
feat: add Badge to FullBleedWithCarousel hero story

### DIFF
--- a/packages/react/src/hero/hero.stories.tsx
+++ b/packages/react/src/hero/hero.stories.tsx
@@ -231,6 +231,9 @@ export const FullBleedWithCarousel = () => (
         <Heading level={1}>Ulven</Heading>
         <Description>– et nytt nabolag i Oslo</Description>
       </Content>
+      <Badge color="sky">
+        <InfoCircle />I salg
+      </Badge>
       <Carousel>
         <CarouselItemsContainer>
           <CarouselItems>


### PR DESCRIPTION
## Legg til Badge i FullBleedWithCarousel hero story

### Oppsummering

FullBleedWithCarousel-storyen manglet et eksempel på Badge-bruk i kombinasjon med Hero-karusellen. Denne endringen legger til en Badge-komponent med ikon og tekst for å vise hvordan Badge kan brukes i en fullbleed Hero med karusell.

### Endringer

- Lagt til `Badge` med `InfoCircle`-ikon og teksten "I salg" i `FullBleedWithCarousel`-storyen i `hero.stories.tsx`