### PR TITLE
Sett eksplisitt tekstfarge på badges med lys bakgrunn

### DIFF
--- a/.changeset/tasty-planes-raise.md
+++ b/.changeset/tasty-planes-raise.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Set explicit text colors on badges with light background to ensure sufficient contrast when other text colors than the standard body color (`black`) is inherited.

--- a/packages/react/src/badge/badge.tsx
+++ b/packages/react/src/badge/badge.tsx
@@ -14,9 +14,9 @@ const badgeVariants = cva({
   variants: {
     color: {
       'gray-dark': 'bg-gray-dark text-white',
-      mint: 'bg-mint',
-      sky: 'bg-sky',
-      white: 'bg-white',
+      mint: 'bg-mint text-black',
+      sky: 'bg-sky text-black',
+      white: 'bg-white text-black',
       'blue-dark': 'bg-blue-dark text-white',
       'green-dark': 'bg-green-dark text-white',
     },


### PR DESCRIPTION
### Oppsummering

Sikrer tilstrekkelig kontrast på badges med lys bakgrunn (`mint`, `sky`, `white`) når en annen tekstfarge enn standard (`black`) arves fra et overordnet element.

### Endringer

- Lagt til `text-black` på `mint`-, `sky`- og `white`-variantene i `packages/react/src/badge/badge.tsx`
- Changeset (patch) for `@obosbbl/grunnmuren-react`