### PR TITLE
Forenkle badge-posisjonering i Card og depreker auto-styling

### DIFF
--- a/.changeset/pink-queens-hammer.md
+++ b/.changeset/pink-queens-hammer.md
@@ -38,3 +38,17 @@ Even though the auto-overlay will persist for now for backward compatibility, we
   </Content>
 </Card>
 ```
+
+It might still make sense to render the `<Badge>` in the `<Media>` tag sometimes, for instance if the `<Badge>` is strictly related to the image inside it, and the image itself is hidden from screen readers (`alt=""` or `aria-hidden="true"`), but then also make sure to hide the badge from screen readers:
+
+``` tsx
+<Card>
+  <Media>
+    <img alt="" src="..." />
+    <Badge aria-hidden color="blue-dark">KI-generert</Badge>
+  </Media>
+  <Content>
+    <Heading level={3}>...</Heading>
+  </Content>
+</Card>
+```

--- a/.changeset/pink-queens-hammer.md
+++ b/.changeset/pink-queens-hammer.md
@@ -1,0 +1,40 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+## Deprecating automatic `<Badge>` overlay positioning inside `<Card>`
+
+Removes the custom border radius and edge bleeding that was previously added to `<Badge>` when rendered in a `<Media>` inside a `<Card>`. This simplifies styling when a consumer wants to have multiple badges overlaid on the `<Media>` of `<Card>`.
+
+The automatic absolute positioning of `<Badge>` inside `<Media>` in `<Card>` will be removed in future releases. The reason for this change is flexibility and accessibility:
+
+- By removing the auto-overlay effect, it is up to the consumer to define the position of the `<Badge>`.
+- By not assuming that the `<Badge>` should go in the `<Media>` tag, it is possible to render the `<Badge>` after the `<Heading>` element, which is the semantically correct place for it.
+
+Even though the auto-overlay will persist for now for backward compatibility, we strongly advise everyone to rewrite their rendering of `<Badge>` inside `<Media>`. Render the `<Badge>` after the `<Heading>` inside `<Content>` with explicit positioning instead, which ensures the HTML is read correctly by screen readers:
+
+```tsx
+// Before (still backward compatible for now, with minor style changes)
+<Card>
+  <Media>
+    <Badge color="blue-dark">Meldefrist</Badge>
+    <img alt="" src="..." />
+  </Media>
+  <Content>
+    <Heading level={3}>...</Heading>
+  </Content>
+</Card>
+
+// After (correct semantic HTML with minimal custom styles)
+<Card>
+  <Media>
+    <img alt="" src="..." />
+  </Media>
+  <Content>
+    <Heading level={3}>...</Heading>
+    <Badge color="blue-dark" size="small" className="absolute top-3.5 left-3.5">
+      Meldefrist
+    </Badge>
+  </Content>
+</Card>
+```

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -351,10 +351,6 @@ export const ClickableWithOtherClickableElementsAndBackgroundColor = () => (
 export const ClickableWithBadge = () => (
   <Card variant="outlined" className="bg-blue-dark text-mint w-72">
     <Media>
-      <Badge color="blue-dark">
-        <InfoCircle />
-        Meldefrist
-      </Badge>
       <img
         alt=""
         src="https://cdn.sanity.io/media-libraries/mln4u7f3Hc8r/images/410001cfde5211194e0072bf39abd3214befb1c2-1920x1080.jpg?auto=format"
@@ -365,6 +361,10 @@ export const ClickableWithBadge = () => (
         <Heading level={3}>
           <CardLink href="#card">Rødbergvn 88C</CardLink>
         </Heading>
+        <Badge color="blue-dark" size="small" className="absolute top-3.5 left-3.5">
+          <InfoCircle />
+          Frist for forkjøp 21. apr., 09:00
+        </Badge>
         <small className="description">Bjerke - Oslo</small>
       </div>
       <small className="description -order-1">Forhåndsvarsling - Saksnr. F0347565</small>
@@ -399,16 +399,16 @@ export const ClickableWithBadgeRight = () => (
         alt=""
         src="https://cdn.sanity.io/media-libraries/mln4u7f3Hc8r/images/410001cfde5211194e0072bf39abd3214befb1c2-1920x1080.jpg?auto=format"
       />
-      <Badge color="blue-dark">
-        <InfoCircle />
-        Meldefrist
-      </Badge>
     </Media>
     <Content>
       <div className="grid gap-1">
         <Heading level={3}>
           <CardLink href="#card">Rødbergvn 88C</CardLink>
         </Heading>
+        <Badge color="blue-dark" size="small" className="absolute top-3.5 right-3.5">
+          <InfoCircle />
+          Meldefrist
+        </Badge>
         <small className="description">Bjerke - Oslo</small>
       </div>
       <small className="description -order-1">Forhåndsvarsling - Saksnr. F0347565</small>

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -50,21 +50,11 @@ const cardVariants = cva({
     '[&_a:not([data-slot="card-link"])]:z-[1] [&_button]:z-[1] [&_input]:z-[1]',
 
     // **** Badge ****
-    '[&_[data-slot="media"]_[data-slot="badge"]]:absolute [&_[data-slot="media"]_[data-slot="badge"]]:top-0',
+    '*:data-[slot=media]:*:data-[slot=badge]:absolute',
+    '*:data-[slot=media]:*:data-[slot=badge]:first:top-3.5 *:data-[slot=media]:*:data-[slot=badge]:first:left-3.5',
     // Increasing z-index Preserves badge position when media content is hovered (the transform scale effect might otherwise move the badge behind the other media content)
-    '[&_[data-slot="media"]_[data-slot="badge"]]:z-[1]',
-    // Left aligned - override default corner radius of the badge
-    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tl-2xl',
-    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-br-2xl',
-    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-tr-none',
-    '[&_[data-slot="media"]_[data-slot="badge"]:first-child]:rounded-bl-none',
-    // Right aligned - override default corner radius of the badge
-    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-tl-none',
-    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-br-none',
-    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-tr-2xl',
-    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:rounded-bl-2xl',
-    // ... and position the badge at the right edge of the media content
-    '[&_[data-slot="media"]_[data-slot="badge"]:last-child]:right-0',
+    '*:data-[slot=media]:*:data-[slot=badge]:z-[1]',
+    '*:data-[slot=media]:*:data-[slot=badge]:last:top-3.5 *:data-[slot=media]:*:data-[slot=badge]:last:right-3.5',
   ],
   variants: {
     /**


### PR DESCRIPTION
### Oppsummering

Eksisterende styling som automatisk plasserte og stylet `<Badge>` i `<Media>` inni `<Card>` er forenklet og delvis deprekert. Endringen gjør det enklere å løse problemer med DOM-rekkefølge og tilgjengelighet ved at `<Badge>` som regel bør plasseres etter `<Heading>` i `<Content>` i stedet for i `<Media>`. Løser [AB#138059](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/138059).

### Endringer

- `card.tsx`: Byttet ut legacy Tailwind arbitrary-value selectors med moderne variant-syntaks (`*:data-[slot=media]:*:data-[slot=badge]`). Fjernet automatiske border-radius-overrides for badge i media.
- `card.stories.tsx`: Oppdatert stories (`ClickableWithBadge`, `ClickableWithBadgeRight`) til å bruke nytt mønster — badge plassert etter `<Heading>` i `<Content>` med eksplisitt `absolute top-3.5 left/right-3.5`-klasser.
- `.changeset/pink-queens-hammer.md`: Lagt til changeset (patch) med deprecation-info og migreringsveiledning.