### PR TITLE
Bruk workspace:^ for icons-react-referanse i react-pakken

### DIFF
--- a/.changeset/workspace-caret-specifier.md
+++ b/.changeset/workspace-caret-specifier.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Changed the internal workspace specifier for `@obosbbl/grunnmuren-icons-react` from a pinned semver range to `workspace:^`. The published dependency range is unaffected, but this avoids a `pnpm-lock.yaml` mismatch when changesets bumps the icons-react version.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,7 @@
     "build": "bunchee"
   },
   "dependencies": {
-    "@obosbbl/grunnmuren-icons-react": "workspace:^2.1.2",
+    "@obosbbl/grunnmuren-icons-react": "workspace:^",
     "cva": "^1.0.0-0",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,7 +251,7 @@ importers:
   packages/react:
     dependencies:
       '@obosbbl/grunnmuren-icons-react':
-        specifier: workspace:^2.1.2
+        specifier: workspace:^
         version: link:../icons-react
       cva:
         specifier: ^1.0.0-0


### PR DESCRIPTION
### Oppsummering

Endrer den interne workspace-referansen til `@obosbbl/grunnmuren-icons-react` i `packages/react/package.json` fra den strikte `workspace:^2.1.2` til `workspace:^`. Dette skal løse rotårsaken til at `pnpm-lock.yaml` kommer ut av sync på `changeset-release/main`-PR-en hver gang changesets bumper icons-react: specifieren trenger ikke lenger å oppdateres ved versjonsbumper, fordi `workspace:^` refererer dynamisk til gjeldende workspace-versjon.

Publisert avhengighetsrange er uendret — pnpm rewriter `workspace:^` til `^<currentVersion>` ved publish, så konsumenter av pakken skal ikke bli påvirket.

### Endringer

- `packages/react/package.json`: specifier endret fra `workspace:^2.1.2` til `workspace:^`
- `pnpm-lock.yaml`: oppdatert tilsvarende
- Lagt til patch-changeset for `@obosbbl/grunnmuren-react` som dokumenterer endringen