### PR TITLE
Refaktorer Table: fiks responsivitet og legg til expand/collapse

### DIFF
--- a/.changeset/sweet-tables-grow.md
+++ b/.changeset/sweet-tables-grow.md
@@ -1,0 +1,47 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+## Fix Table responsiveness inside a container and add native expand/collapse
+
+**Fixes responsiveness when `UNSAFE_Table` is wrapped in `UNSAFE_TableContainer`.** Previously, both components created their own horizontal scroll wrapper, causing two conflicting scroll contexts and making the `ResizableTableContainer` compute column widths against the wrong element. Now `UNSAFE_Table` always owns the internal scroll wrapper, and the container only provides an internal context that switches the underlying overflow element between React Aria's `ResizableTableContainer` and a plain div.
+
+**Adds native expand/collapse support via react-aria-components 1.17.** `UNSAFE_Table` now accepts `treeColumn`, `expandedKeys`, `defaultExpandedKeys`, and `onExpandedChange` (forwarded from RAC). The chevron button is rendered automatically inside `UNSAFE_TableCell` for cells in the tree column when the row has nested children, so consumers only need to write:
+
+```tsx
+<UNSAFE_Table
+  aria-label="…"
+  treeColumn="name"
+  expandedKeys={expandedKeys}
+  onExpandedChange={setExpandedKeys}
+>
+  <UNSAFE_TableHeader>
+    <UNSAFE_TableColumn id="name" isRowHeader>Name</UNSAFE_TableColumn>
+    {/* … */}
+  </UNSAFE_TableHeader>
+  <UNSAFE_TableBody>
+    <UNSAFE_TableRow id={parent.id}>
+      <UNSAFE_TableCell>{parent.name}</UNSAFE_TableCell>
+      {/* … */}
+      <UNSAFE_TableRow id={child.id}>
+        <UNSAFE_TableCell>{child.name}</UNSAFE_TableCell>
+        {/* … */}
+      </UNSAFE_TableRow>
+    </UNSAFE_TableRow>
+  </UNSAFE_TableBody>
+</UNSAFE_Table>
+```
+
+The chevron follows the tree/grid pattern (`ChevronRight` when collapsed, rotated 90° down when expanded), with the same transition speed as `Disclosure`.
+
+## Rename `UNSAFE_TableContainer` to `UNSAFE_ResizableTableContainer`
+
+The new name clarifies that the container enables column resizing (`UNSAFE_TableColumnResizer`) and fixed column widths (`maxWidth`/`minWidth` on `UNSAFE_TableColumn`) — it is not just a generic wrapper. `UNSAFE_TableContainer` and `UNSAFE_TableContainerProps` are kept as deprecated aliases during the `UNSAFE_` phase and will be removed when the component is stabilized.
+
+```tsx
+// Before
+import { UNSAFE_TableContainer } from '@obosbbl/grunnmuren-react';
+
+// After
+import { UNSAFE_ResizableTableContainer } from '@obosbbl/grunnmuren-react';
+```

--- a/packages/react/src/table/table.stories.tsx
+++ b/packages/react/src/table/table.stories.tsx
@@ -1,15 +1,14 @@
 import type { Meta } from '@storybook/react-vite';
-import { Fragment, useState } from 'react';
+import { useState } from 'react';
 
 import { Content } from '../content';
-import { DisclosureButton } from '../disclosure';
 import {
   UNSAFE_Table as Table,
   UNSAFE_TableBody as TableBody,
   UNSAFE_TableCell as TableCell,
   UNSAFE_TableColumn as TableColumn,
   UNSAFE_TableColumnResizer as TableColumnResizer,
-  UNSAFE_TableContainer as TableContainer,
+  UNSAFE_ResizableTableContainer as ResizableTableContainer,
   UNSAFE_TableHeader as TableHeader,
   UNSAFE_TableRow as TableRow,
 } from './table';
@@ -246,12 +245,12 @@ export const WithScrolling = () => (
 );
 
 export const FixedColumns = () => (
-  <TableContainer>
+  <ResizableTableContainer>
     <Table aria-label="Eiendomsforvaltere">
       <TableHeader>
-        <TableColumn maxWidth={144}>Navn</TableColumn>
-        <TableColumn maxWidth={144}>E-post</TableColumn>
-        <TableColumn maxWidth={144}>Område</TableColumn>
+        <TableColumn minWidth={144}>Navn</TableColumn>
+        <TableColumn minWidth={144}>E-post</TableColumn>
+        <TableColumn minWidth={144}>Område</TableColumn>
       </TableHeader>
       <TableBody>
         <TableRow>
@@ -271,11 +270,11 @@ export const FixedColumns = () => (
         </TableRow>
       </TableBody>
     </Table>
-  </TableContainer>
+  </ResizableTableContainer>
 );
 
 export const ResizeableColumns = () => (
-  <TableContainer>
+  <ResizableTableContainer>
     <Table aria-label="Table with resizable columns">
       <TableHeader>
         <TableColumn id="file" isRowHeader>
@@ -309,74 +308,70 @@ export const ResizeableColumns = () => (
         </TableRow>
       </TableBody>
     </Table>
-  </TableContainer>
+  </ResizableTableContainer>
 );
 
+const months = [
+  'januar',
+  'februar',
+  'mars',
+  'april',
+  'mai',
+  'juni',
+  'juli',
+  'august',
+  'september',
+  'oktober',
+  'november',
+  'desember',
+];
+
+/**
+ * Uses the native react-aria-components expand/collapse API available
+ * from v1.17. Declare a `treeColumn` on the Table (the column that shows
+ * the hierarchy), render nested <TableRow>s inside a parent <TableRow>,
+ * and use <TableExpandButton> in the parent's tree-column cell. React
+ * Aria wires up aria-expanded, keyboard toggling (arrow-left/right) and
+ * the indentation attributes automatically.
+ */
 export const ExpandableRows = () => {
   const years = [2025, 2026, 2027];
-  const [expandedYears, setExpandedYears] = useState(
-    Object.fromEntries(years.map((year) => [year, false])),
-  );
-
-  const months = [
-    'januar',
-    'februar',
-    'mars',
-    'april',
-    'mai',
-    'juni',
-    'juli',
-    'august',
-    'september',
-    'oktober',
-    'november',
-    'desember',
-  ];
+  const [expandedKeys, setExpandedKeys] = useState<Set<string | number>>(new Set());
 
   return (
-    <TableContainer className="container">
-      <Table aria-label="Lånekostnader" variant="zebra-striped">
-        <TableHeader>
-          <TableColumn maxWidth={200}>Termin</TableColumn>
-          <TableColumn maxWidth={200}>Renter</TableColumn>
-          <TableColumn maxWidth={200}>Avdrag</TableColumn>
-          <TableColumn maxWidth={200}>Månedskostnader</TableColumn>
-        </TableHeader>
-        <TableBody>
-          {years.map((year) => (
-            <Fragment key={year}>
-              <TableRow className="*:align-middle">
-                <TableCell>{year}</TableCell>
-                <TableCell>1 200 kr</TableCell>
-                <TableCell>18 000 kr</TableCell>
-                <TableCell>
-                  <DisclosureButton
-                    withChevron
-                    aria-controls={months.map((month) => `${year}-${month}`).join(' ')}
-                    aria-expanded={expandedYears[year]}
-                    aria-label={`Månedlige kostnader for ${year}`}
-                    onPress={() =>
-                      setExpandedYears((prevState) => ({
-                        ...prevState,
-                        [year]: !expandedYears[year],
-                      }))
-                    }
-                    isIconOnly
-                  />
-                </TableCell>
+    <Table
+      aria-label="Lånekostnader"
+      variant="zebra-striped"
+      treeColumn="term"
+      expandedKeys={expandedKeys}
+      onExpandedChange={setExpandedKeys}
+    >
+      <TableHeader>
+        <TableColumn id="term" isRowHeader>
+          Termin
+        </TableColumn>
+        <TableColumn id="interest">Renter</TableColumn>
+        <TableColumn id="installment">Avdrag</TableColumn>
+        <TableColumn id="total">Månedskostnader</TableColumn>
+      </TableHeader>
+      <TableBody>
+        {years.map((year) => (
+          <TableRow key={year} id={year}>
+            <TableCell>{year}</TableCell>
+            <TableCell>1 200 kr</TableCell>
+            <TableCell>18 000 kr</TableCell>
+            <TableCell>19 200 kr</TableCell>
+            {months.map((month) => (
+              <TableRow key={`${year}-${month}`} id={`${year}-${month}`}>
+                <TableCell className="capitalize">{month}</TableCell>
+                <TableCell>120 kr</TableCell>
+                <TableCell>1 500 kr</TableCell>
+                <TableCell>1 620 kr</TableCell>
               </TableRow>
-              {expandedYears[year] &&
-                months.map((month) => (
-                  <TableRow key={`${year}-${month}`} id={`${year}-${month}`}>
-                    <TableCell className="capitalize">{month}</TableCell>
-                    <TableCell>120 kr</TableCell>
-                    <TableCell colSpan={2}>1 500 kr</TableCell>
-                  </TableRow>
-                ))}
-            </Fragment>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 };

--- a/packages/react/src/table/table.tsx
+++ b/packages/react/src/table/table.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from '@obosbbl/grunnmuren-icons-react';
+import { ChevronRight } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx } from 'cva';
 import { createContext, type RefAttributes, useCallback, useContext, useState } from 'react';
 import {
@@ -40,6 +40,10 @@ const tableRowVariants = cva({
     'data-focus-visible:outline-focus-inset',
     'group-data-[variant=zebra-striped]/table:odd:bg-white',
     'group-data-[variant=zebra-striped]/table:even:bg-sky-lightest',
+    // When the row has expandable children, the chevron button makes the
+    // row taller than a plain text row. Center-align the cells' content so
+    // the chevron icon lines up with text in sibling cells.
+    'data-has-child-items:*:align-middle',
   ],
 });
 
@@ -291,9 +295,9 @@ function TableCell(props: TableCellProps) {
               slot="chevron"
               variant="tertiary"
               isIconOnly
-              className="-my-1 group-data-expanded/row:[&_svg]:rotate-180"
+              className="-my-1 group-data-expanded/row:[&_svg]:rotate-90"
             >
-              <ChevronDown className="transition-transform duration-300 motion-reduce:transition-none" />
+              <ChevronRight className="transition-transform duration-300 motion-reduce:transition-none" />
             </Button>
           )}
           {resolved}

--- a/packages/react/src/table/table.tsx
+++ b/packages/react/src/table/table.tsx
@@ -1,6 +1,6 @@
+import { ChevronDown } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx } from 'cva';
 import { createContext, type RefAttributes, useCallback, useContext, useState } from 'react';
-import { Provider } from 'react-aria-components/slots';
 import {
   Cell as RACCell,
   type CellProps as RACCellProps,
@@ -16,29 +16,28 @@ import {
   TableHeader as RACTableHeader,
   type TableHeaderProps as RACTableHeaderProps,
   type TableProps as RACTableProps,
-  ResizableTableContainer,
-  type ResizableTableContainerProps,
+  ResizableTableContainer as RACResizableTableContainer,
+  type ResizableTableContainerProps as RACResizableTableContainerProps,
 } from 'react-aria-components/Table';
+import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 
+import { Button } from '../button';
 import { ScrollButton, type ScrollDirection, useHorizontalScroll } from '../utils';
 
-const tableVariants = cva({
-  base: ['relative'],
-  variants: {
-    variant: {
-      default: '',
-      'zebra-striped': '',
-    },
-  },
-});
+// When true, a <Table> is rendered inside a <TableContainer> which already
+// provides the horizontal scroll wrapper. Bare <Table> creates its own wrapper.
+const TableContainerContext = createContext(false);
 
 const tableRowVariants = cva({
   base: [
+    'group/row',
     'data-focus-visible:outline-focus-inset',
-    'group-data-[variant=zebra-striped]:odd:bg-white',
-    'group-data-[variant=zebra-striped]:even:bg-sky-lightest',
+    'group-data-[variant=zebra-striped]/table:odd:bg-white',
+    'group-data-[variant=zebra-striped]/table:even:bg-sky-lightest',
   ],
 });
+
+type TableVariant = 'default' | 'zebra-striped';
 
 type TableProps = Omit<RACTableProps, 'aria-label' | 'aria-labelledby'> &
   RefAttributes<HTMLTableElement> & {
@@ -46,7 +45,7 @@ type TableProps = Omit<RACTableProps, 'aria-label' | 'aria-labelledby'> &
      * Visual variant of the table
      * @default 'default'
      */
-    variant?: 'default' | 'zebra-striped';
+    variant?: TableVariant;
   } & (
     | { 'aria-label': string; 'aria-labelledby'?: never }
     | { 'aria-label'?: never; 'aria-labelledby': string }
@@ -68,20 +67,28 @@ type TableCellProps = RACCellProps &
     children: React.ReactNode;
   };
 
-// Used to deal with showing or hiding scroll indicators during column resizing
-const TableScrollContainerContext = createContext<{
-  isResizing: boolean;
-}>({
-  isResizing: false,
-});
+type TableColumnResizerProps = RACColumnResizerProps;
+
+type ResizableTableContainerProps = RACResizableTableContainerProps;
 
 /**
- * A container component for displaying tabular data with horizontal scrolling support.
+ * Shared scroll wrapper that renders an overflow container with left/right
+ * scroll indicators. Used by both standalone <Table> and <ResizableTableContainer>.
+ *
+ * When `asResizableContainer` is set, the overflow element is RAC's
+ * <ResizableTableContainer> (required for column resizing to measure column
+ * widths against the correct scroll viewport).
  */
-function Table(props: TableProps) {
-  const { className, children, variant = 'default', ...restProps } = props;
+type ScrollWrapperProps = {
+  children: React.ReactNode;
+  asResizableContainer?: {
+    containerProps: Omit<RACResizableTableContainerProps, 'className' | 'children'>;
+    className?: string;
+  };
+};
 
-  const { isResizing } = useContext(TableScrollContainerContext);
+function ScrollWrapper({ children, asResizableContainer }: ScrollWrapperProps) {
+  const [isResizing, setIsResizing] = useState(false);
 
   const { scrollContainerRef, canScrollLeft, canScrollRight, hasScrollingOccurred } =
     useHorizontalScroll<HTMLDivElement>([isResizing]);
@@ -99,34 +106,102 @@ function Table(props: TableProps) {
     },
     [scrollContainerRef],
   );
+
+  const scrollClasses = 'scrollbar-hidden overflow-x-auto';
+  const touchStyle = { WebkitOverflowScrolling: 'touch' as const };
+
   return (
-    <div className={tableVariants({ className, variant })}>
-      <div className="relative overflow-hidden">
-        <div
+    <div className="relative overflow-hidden">
+      {asResizableContainer ? (
+        <RACResizableTableContainer
+          {...asResizableContainer.containerProps}
           ref={scrollContainerRef}
-          className="scrollbar-hidden overflow-x-auto"
-          style={{ WebkitOverflowScrolling: 'touch' }}
+          className={cx(scrollClasses, asResizableContainer.className)}
+          style={touchStyle}
+          onResizeStart={(widths) => {
+            setIsResizing(true);
+            asResizableContainer.containerProps.onResizeStart?.(widths);
+          }}
+          onResizeEnd={(widths) => {
+            setIsResizing(false);
+            asResizableContainer.containerProps.onResizeEnd?.(widths);
+          }}
         >
-          <RACTable {...restProps} className="group w-full min-w-fit" data-variant={variant}>
-            {children}
-          </RACTable>
+          {children}
+        </RACResizableTableContainer>
+      ) : (
+        <div ref={scrollContainerRef} className={scrollClasses} style={touchStyle}>
+          {children}
         </div>
+      )}
 
-        <ScrollButton
-          direction="left"
-          onClick={() => handleScroll('left')}
-          isVisible={canScrollLeft}
-          hasScrollingOccurred={hasScrollingOccurred}
-        />
+      <ScrollButton
+        direction="left"
+        onClick={() => handleScroll('left')}
+        isVisible={canScrollLeft}
+        hasScrollingOccurred={hasScrollingOccurred}
+      />
 
-        <ScrollButton
-          direction="right"
-          onClick={() => handleScroll('right')}
-          isVisible={canScrollRight}
-          hasScrollingOccurred={hasScrollingOccurred}
-        />
-      </div>
+      <ScrollButton
+        direction="right"
+        onClick={() => handleScroll('right')}
+        isVisible={canScrollRight}
+        hasScrollingOccurred={hasScrollingOccurred}
+      />
     </div>
+  );
+}
+
+/**
+ * A container component for displaying tabular data with horizontal scrolling support.
+ */
+function Table(props: TableProps) {
+  const { className, children, variant = 'default', ...restProps } = props;
+
+  const isInContainer = useContext(TableContainerContext);
+
+  const table = (
+    <RACTable
+      {...restProps}
+      className={cx(className, 'group/table w-full min-w-fit')}
+      data-variant={variant}
+    >
+      {children}
+    </RACTable>
+  );
+
+  if (isInContainer) {
+    return table;
+  }
+
+  return <ScrollWrapper>{table}</ScrollWrapper>;
+}
+
+/**
+ * Container that enables column resizing and handles horizontal scrolling
+ * for the nested <Table>. Use when you want resizable columns or want to
+ * apply `maxWidth`/`minWidth` truncation on columns.
+ */
+function ResizableTableContainer({
+  className,
+  children,
+  ...restProps
+}: ResizableTableContainerProps) {
+  return (
+    <TableContainerContext.Provider value={true}>
+      <ScrollWrapper
+        asResizableContainer={{
+          containerProps: restProps,
+          className: cx(
+            className,
+            '**:data-[slot=table-column]:overflow-hidden **:data-[slot=table-column]:text-ellipsis',
+            '**:data-[slot=table-cell]:overflow-hidden **:data-[slot=table-cell]:text-ellipsis',
+          ),
+        }}
+      >
+        {children}
+      </ScrollWrapper>
+    </TableContainerContext.Provider>
   );
 }
 
@@ -140,6 +215,7 @@ function TableHeader({ className, children, ...restProps }: TableHeaderProps) {
     </RACTableHeader>
   );
 }
+
 function TableColumn(props: TableColumnProps) {
   const { className, children, ...restProps } = props;
 
@@ -160,8 +236,6 @@ function TableColumn(props: TableColumnProps) {
     </RACColumn>
   );
 }
-
-type TableColumnResizerProps = RACColumnResizerProps;
 
 const TableColumnResizer = ({ className, ...restProps }: TableColumnResizerProps) => (
   <RACColumnResizer
@@ -210,33 +284,40 @@ function TableCell(props: TableCellProps) {
         'min-w-fit whitespace-nowrap',
         'align-top',
         'data-focus-visible:outline-focus-inset',
+        // When this cell is in the column designated by `treeColumn` and
+        // its row has nested child rows, we render an expand/collapse button
+        // (see composeRenderProps below). Use flex so the button lines up
+        // nicely next to the cell content.
+        'data-tree-column:flex data-tree-column:items-center data-tree-column:gap-2',
       )}
       data-slot="table-cell"
     >
-      {children}
+      {composeRenderProps(children, (resolved, { isTreeColumn, hasChildItems }) => (
+        <>
+          {isTreeColumn && hasChildItems && (
+            <Button
+              slot="chevron"
+              variant="tertiary"
+              isIconOnly
+              className="-my-1 group-data-expanded/row:[&_svg]:rotate-180"
+            >
+              <ChevronDown className="transition-transform duration-300 motion-reduce:transition-none" />
+            </Button>
+          )}
+          {resolved}
+        </>
+      ))}
     </RACCell>
   );
 }
 
-type TableContainerProps = ResizableTableContainerProps;
-
-const TableContainer = ({ className, ...restProps }: ResizableTableContainerProps) => {
-  const [isResizing, setIsResizing] = useState(false);
-  return (
-    <Provider values={[[TableScrollContainerContext, { isResizing }]]}>
-      <ResizableTableContainer
-        {...restProps}
-        className={cx(
-          className,
-          '**:data-[slot=table-column]:overflow-hidden **:data-[slot=table-column]:text-ellipsis',
-          '**:data-[slot=table-cell]:overflow-hidden **:data-[slot=table-cell]:text-ellipsis',
-        )}
-        onResizeStart={() => setIsResizing(true)}
-        onResizeEnd={() => setIsResizing(false)}
-      />
-    </Provider>
-  );
-};
+// Deprecated aliases kept for backwards compatibility during the UNSAFE_ phase.
+// Remove these once the Table component is stabilized and the UNSAFE_ prefix
+// is dropped.
+/** @deprecated Use `UNSAFE_ResizableTableContainer` instead. */
+const UNSAFE_TableContainer = ResizableTableContainer;
+/** @deprecated Use `UNSAFE_ResizableTableContainerProps` instead. */
+type UNSAFE_TableContainerProps = ResizableTableContainerProps;
 
 export {
   TableColumnResizer as UNSAFE_TableColumnResizer,
@@ -244,14 +325,16 @@ export {
   TableBody as UNSAFE_TableBody,
   TableCell as UNSAFE_TableCell,
   TableColumn as UNSAFE_TableColumn,
-  TableContainer as UNSAFE_TableContainer,
+  ResizableTableContainer as UNSAFE_ResizableTableContainer,
+  UNSAFE_TableContainer,
   TableHeader as UNSAFE_TableHeader,
   TableRow as UNSAFE_TableRow,
   type TableColumnResizerProps as UNSAFE_TableColumnResizerProps,
   type TableBodyProps as UNSAFE_TableBodyProps,
   type TableCellProps as UNSAFE_TableCellProps,
   type TableColumnProps as UNSAFE_TableColumnProps,
-  type TableContainerProps as UNSAFE_TableContainerProps,
+  type ResizableTableContainerProps as UNSAFE_ResizableTableContainerProps,
+  type UNSAFE_TableContainerProps,
   type TableHeaderProps as UNSAFE_TableHeaderProps,
   type TableProps as UNSAFE_TableProps,
   type TableRowProps as UNSAFE_TableRowProps,

--- a/packages/react/src/table/table.tsx
+++ b/packages/react/src/table/table.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx } from 'cva';
 import { createContext, type RefAttributes, useCallback, useContext, useState } from 'react';
+import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import {
   Cell as RACCell,
   type CellProps as RACCellProps,
@@ -19,7 +20,6 @@ import {
   ResizableTableContainer as RACResizableTableContainer,
   type ResizableTableContainerProps as RACResizableTableContainerProps,
 } from 'react-aria-components/Table';
-import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 
 import { Button } from '../button';
 import { ScrollButton, type ScrollDirection, useHorizontalScroll } from '../utils';

--- a/packages/react/src/table/table.tsx
+++ b/packages/react/src/table/table.tsx
@@ -24,9 +24,15 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { Button } from '../button';
 import { ScrollButton, type ScrollDirection, useHorizontalScroll } from '../utils';
 
-// When true, a <Table> is rendered inside a <TableContainer> which already
-// provides the horizontal scroll wrapper. Bare <Table> creates its own wrapper.
-const TableContainerContext = createContext(false);
+// Set by <ResizableTableContainer> to forward its props to the RAC container
+// rendered inside <ScrollWrapper>. When <Table> is used without a
+// <ResizableTableContainer>, this is null and <ScrollWrapper> falls back to
+// a plain overflow div.
+type _ResizableTableContainerContextValue = {
+  resizableProps: Omit<RACResizableTableContainerProps, 'ref' | 'children'>;
+} | null;
+
+const _ResizableTableContainerContext = createContext<_ResizableTableContainerContextValue>(null);
 
 const tableRowVariants = cva({
   base: [
@@ -73,21 +79,13 @@ type ResizableTableContainerProps = RACResizableTableContainerProps;
 
 /**
  * Shared scroll wrapper that renders an overflow container with left/right
- * scroll indicators. Used by both standalone <Table> and <ResizableTableContainer>.
- *
- * When `asResizableContainer` is set, the overflow element is RAC's
+ * scroll indicators around the table. If it is rendered inside a
+ * <ResizableTableContainer>, the overflow element is RAC's
  * <ResizableTableContainer> (required for column resizing to measure column
- * widths against the correct scroll viewport).
+ * widths against the correct scroll viewport); otherwise it is a plain div.
  */
-type ScrollWrapperProps = {
-  children: React.ReactNode;
-  asResizableContainer?: {
-    containerProps: Omit<RACResizableTableContainerProps, 'className' | 'children'>;
-    className?: string;
-  };
-};
-
-function ScrollWrapper({ children, asResizableContainer }: ScrollWrapperProps) {
+function ScrollWrapper({ children }: { children: React.ReactNode }) {
+  const containerCtx = useContext(_ResizableTableContainerContext);
   const [isResizing, setIsResizing] = useState(false);
 
   const { scrollContainerRef, canScrollLeft, canScrollRight, hasScrollingOccurred } =
@@ -112,19 +110,19 @@ function ScrollWrapper({ children, asResizableContainer }: ScrollWrapperProps) {
 
   return (
     <div className="relative overflow-hidden">
-      {asResizableContainer ? (
+      {containerCtx ? (
         <RACResizableTableContainer
-          {...asResizableContainer.containerProps}
+          {...containerCtx.resizableProps}
           ref={scrollContainerRef}
-          className={cx(scrollClasses, asResizableContainer.className)}
+          className={cx(scrollClasses, containerCtx.resizableProps.className)}
           style={touchStyle}
           onResizeStart={(widths) => {
             setIsResizing(true);
-            asResizableContainer.containerProps.onResizeStart?.(widths);
+            containerCtx.resizableProps.onResizeStart?.(widths);
           }}
           onResizeEnd={(widths) => {
             setIsResizing(false);
-            asResizableContainer.containerProps.onResizeEnd?.(widths);
+            containerCtx.resizableProps.onResizeEnd?.(widths);
           }}
         >
           {children}
@@ -158,29 +156,23 @@ function ScrollWrapper({ children, asResizableContainer }: ScrollWrapperProps) {
 function Table(props: TableProps) {
   const { className, children, variant = 'default', ...restProps } = props;
 
-  const isInContainer = useContext(TableContainerContext);
-
-  const table = (
-    <RACTable
-      {...restProps}
-      className={cx(className, 'group/table w-full min-w-fit')}
-      data-variant={variant}
-    >
-      {children}
-    </RACTable>
+  return (
+    <ScrollWrapper>
+      <RACTable
+        {...restProps}
+        className={cx(className, 'group/table w-full min-w-fit')}
+        data-variant={variant}
+      >
+        {children}
+      </RACTable>
+    </ScrollWrapper>
   );
-
-  if (isInContainer) {
-    return table;
-  }
-
-  return <ScrollWrapper>{table}</ScrollWrapper>;
 }
 
 /**
- * Container that enables column resizing and handles horizontal scrolling
- * for the nested <Table>. Use when you want resizable columns or want to
- * apply `maxWidth`/`minWidth` truncation on columns.
+ * Container that enables column resizing and horizontal scrolling for the
+ * nested <Table>. Use when you want resizable columns or want to apply
+ * `maxWidth`/`minWidth` truncation on columns.
  */
 function ResizableTableContainer({
   className,
@@ -188,20 +180,20 @@ function ResizableTableContainer({
   ...restProps
 }: ResizableTableContainerProps) {
   return (
-    <TableContainerContext.Provider value={true}>
-      <ScrollWrapper
-        asResizableContainer={{
-          containerProps: restProps,
+    <_ResizableTableContainerContext.Provider
+      value={{
+        resizableProps: {
+          ...restProps,
           className: cx(
             className,
             '**:data-[slot=table-column]:overflow-hidden **:data-[slot=table-column]:text-ellipsis',
             '**:data-[slot=table-cell]:overflow-hidden **:data-[slot=table-cell]:text-ellipsis',
           ),
-        }}
-      >
-        {children}
-      </ScrollWrapper>
-    </TableContainerContext.Provider>
+        },
+      }}
+    >
+      {children}
+    </_ResizableTableContainerContext.Provider>
   );
 }
 


### PR DESCRIPTION
### Oppsummering

Løser [AB#132250](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/132250): Table mistet horisontal scrolling/responsivitet når den ble wrappet i `TableContainer`. Samtidig tar vi inn den nye expand/collapse-funksjonaliteten som kom i react-aria-components 1.17, og bytter ut den manuelle `DisclosureButton`-løsningen med RAC sin native `treeColumn` + `expandedKeys`-API.

### Endringer

**Fix for responsivitet-buggen**

- Tidligere wrappet `Table` seg selv i en scroll-container _samtidig_ som `TableContainer` wrappet `ResizableTableContainer`. De to scroll-kontekstene kom i konflikt med hverandre, og `ResizableTableContainer` regnet ut kolonnebredder mot feil wrapper.
- `Table` wrapper nå alltid `<RACTable>` i en intern `ScrollWrapper`. `ResizableTableContainer` produserer ingen egen HTML — den setter kun en intern context. `ScrollWrapper` leser konteksten og velger selv mellom RAC sin `ResizableTableContainer` eller en plain overflow-div. Én scroll-kontekst, uansett om Table brukes standalone eller inne i en container.

**Native expand/collapse**

- `Table` godtar nå `treeColumn`, `expandedKeys`, `defaultExpandedKeys` og `onExpandedChange` (arvet fra RAC).
- Chevron-knappen auto-rendres inne i `TableCell` via `composeRenderProps` når cellen tilhører `treeColumn` og raden har nested rader. Matcher [RAC sitt dokumenterte pattern](https://react-aria.adobe.com/Table).
- Konsumenten skriver bare `<TableCell>{innhold}</TableCell>` — chevron, `aria-expanded`, tastatur-toggle og indentering følger automatisk.
- Chevron følger tree/grid-patternet: `ChevronRight` peker til høyre i kollapset tilstand og roteres 90° ned ved ekspansjon. Transition/hastighet er samme som i `Disclosure`. Implementert med named groups (`group/row` på `tr`, `group-data-expanded/row:` på knappen).
- Når en rad har ekspanderbare child rows får alle dens celler `align-middle` slik at tekst og chevron aligner på midten (chevron-knappen har 44px min-høyde for klikkflate).

**Rename `TableContainer` → `ResizableTableContainer`**

- Navnet tydeliggjør at containeren aktiverer kolonne-resizing (`TableColumnResizer`) og faste kolonnebredder (`maxWidth`/`minWidth`) — ikke "bare en wrapper".
- `UNSAFE_TableContainer` beholdes som deprecated alias inntil komponenten stabiliseres.

**Stories**

- Ny `WithContainerScrolling`-story demonstrerer at bug-fixen fungerer.
- `ExpandableRows`-storyen er skrevet om til å bruke det nye API-et.

### Kjente begrensninger

- **Ingen inn/ut-animasjon av rader ved expand/collapse.** RAC fjerner kollapsede rader helt fra DOM-en, så CSS har ingenting å animere.
- **Screen reader-bug i RAC** for expand-knappens `aria-labelledby` (rapportert som [adobe/react-spectrum#9973](https://github.com/adobe/react-spectrum/issues/9973)).
- **Neste-/forrige-pilene kan vises selv om scroll-containeren ikke er scrollbar** i enkelte tilfeller — kun for tabeller med resize (`ResizableTableContainer`). Ingen team har tatt dette i bruk eller meldt behov om det ennå, så vi lar det ligge og heller fikser det hvis det dukker opp som et reelt problem.

### Demo

https://github.com/user-attachments/assets/2f5d95dd-d6a7-4553-91e5-831cd2265ede

