### PR TITLE
Skjul deaktiverte Tab-er i stedet for å vise dem nedtonet

### DIFF
--- a/.changeset/quiet-tabs-rest.md
+++ b/.changeset/quiet-tabs-rest.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Hide disabled `Tab`s instead of rendering them with reduced opacity and a `not-allowed` cursor. This aligns with the design system's [disabled state guidance](https://grunnmuren.obos.no/disabled-state), which recommends removing unavailable options rather than showing them in a disabled state.

--- a/packages/react/src/tabs/tabs.tsx
+++ b/packages/react/src/tabs/tabs.tsx
@@ -234,8 +234,8 @@ function Tab(props: TabProps) {
         'description h-11 cursor-pointer border-transparent px-4 py-[0.71875rem] font-light',
         // Transition
         'transition-colors duration-150 ease-out',
-        // TODO: Should disabled tabs just be hidden?
-        'data-disabled:cursor-not-allowed data-disabled:opacity-50',
+        // Hide disabled tabs entirely — the design system avoids disabled states (see https://grunnmuren.obos.no/disabled-state)
+        'data-disabled:hidden',
         // Selection
         'data-selected:text-blue-dark data-selected:font-medium',
         // Hover with layout shift prevention using pseudo-element


### PR DESCRIPTION
### Oppsummering

Erstatter `data-disabled:cursor-not-allowed data-disabled:opacity-50` med `data-disabled:hidden` på `Tab`, i tråd med [designsystemets retningslinjer for disabled state](https://grunnmuren.obos.no/disabled-state) som anbefaler å fjerne utilgjengelige valg fremfor å vise dem nedtonet.