### PR TITLE
Ta Tabs ut av beta

### DIFF
--- a/.changeset/tabs-out-of-beta.md
+++ b/.changeset/tabs-out-of-beta.md
@@ -1,0 +1,22 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Tabs: out of BETA 🚀
+
+The `UNSAFE_` prefix has been removed from `Tabs`, `TabList`, `Tab` and `TabPanel` (and their props types). Update your imports:
+
+### Before
+``` tsx
+import {
+  UNSAFE_Tab as Tab,
+  UNSAFE_TabList as TabList,
+  UNSAFE_TabPanel as TabPanel,
+  UNSAFE_Tabs as Tabs,
+} from '@obosbbl/grunnmuren-react';
+```
+
+### Now
+``` tsx
+import { Tab, TabList, TabPanel, Tabs } from '@obosbbl/grunnmuren-react';
+```

--- a/apps/docs/src/ui/storybook-embed.tsx
+++ b/apps/docs/src/ui/storybook-embed.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  UNSAFE_Tab as Tab,
-  UNSAFE_TabList as TabList,
-  UNSAFE_TabPanel as TabPanel,
-  UNSAFE_Tabs as Tabs,
-} from '@obosbbl/grunnmuren-react';
+import { Button, Tab, TabList, TabPanel, Tabs } from '@obosbbl/grunnmuren-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { MenuItemProps } from 'react-aria-components';
 import { Menu, MenuItem, MenuTrigger, Popover } from 'react-aria-components';

--- a/packages/react/src/carousel/carousel.stories.tsx
+++ b/packages/react/src/carousel/carousel.stories.tsx
@@ -14,12 +14,7 @@ import {
   type UNSAFE_CarouselRef as CarouselElement,
 } from '../carousel';
 import { Media } from '../content';
-import {
-  UNSAFE_Tabs as Tabs,
-  UNSAFE_TabList as TabList,
-  UNSAFE_Tab as Tab,
-  UNSAFE_TabPanel as TabPanel,
-} from '../tabs';
+import { Tab, TabList, TabPanel, Tabs } from '../tabs';
 
 const meta = {
   title: 'Carousel',

--- a/packages/react/src/tabs/tabs.stories.tsx
+++ b/packages/react/src/tabs/tabs.stories.tsx
@@ -1,11 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import {
-  UNSAFE_Tab as Tab,
-  UNSAFE_TabList as TabList,
-  UNSAFE_TabPanel as TabPanel,
-  UNSAFE_Tabs as Tabs,
-} from './tabs';
+import { Tab, TabList, TabPanel, Tabs } from './tabs';
 
 const meta = {
   title: 'Tabs',

--- a/packages/react/src/tabs/tabs.tsx
+++ b/packages/react/src/tabs/tabs.tsx
@@ -269,12 +269,12 @@ function TabPanel(props: TabPanelProps) {
 }
 
 export {
-  Tab as UNSAFE_Tab,
-  TabList as UNSAFE_TabList,
-  TabPanel as UNSAFE_TabPanel,
-  Tabs as UNSAFE_Tabs,
-  type TabListProps as UNSAFE_TabListProps,
-  type TabPanelProps as UNSAFE_TabPanelProps,
-  type TabProps as UNSAFE_TabProps,
-  type TabsProps as UNSAFE_TabsProps,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  type TabListProps,
+  type TabPanelProps,
+  type TabProps,
+  type TabsProps,
 };


### PR DESCRIPTION
### Oppsummering

Tar `Tabs`-komponenten ut av beta ved å fjerne `UNSAFE_`-prefikset fra `Tabs`, `TabList`, `Tab` og `TabPanel` (samt tilhørende props-typer). Løser [AB#130238](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/130238).

### Endringer

- Fjernet `UNSAFE_`-prefikset fra alle Tabs-eksporter i `packages/react/src/tabs/tabs.tsx`.
- Oppdaterte imports i `tabs.stories.tsx`, `carousel.stories.tsx` og `apps/docs/src/ui/storybook-embed.tsx`.
- La til changeset (`minor`) med migreringseksempel for konsumenter.

### Gjenstår

- Markere Tabs som `Stable` i Sanity Studio (dokumentasjonen på grunnmuren.obos.no).