### PR TITLE
Ta Link ut av beta

### DIFF
--- a/.changeset/link-out-of-beta.md
+++ b/.changeset/link-out-of-beta.md
@@ -1,0 +1,17 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Link: out of BETA 🚀
+
+The `UNSAFE_` prefix has been removed from `Link` (and its props type). Update your imports:
+
+### Before
+``` tsx
+import { UNSAFE_Link as Link } from '@obosbbl/grunnmuren-react';
+```
+
+### Now
+``` tsx
+import { Link } from '@obosbbl/grunnmuren-react';
+```

--- a/apps/docs/src/routes/_docs/profil/layout.tsx
+++ b/apps/docs/src/routes/_docs/profil/layout.tsx
@@ -1,4 +1,4 @@
-import { UNSAFE_Link as Link } from '@obosbbl/grunnmuren-react';
+import { Link } from '@obosbbl/grunnmuren-react';
 import { createFileRoute } from '@tanstack/react-router';
 
 import { AnchorHeading } from '@/ui/anchor-heading';

--- a/apps/docs/src/routes/_docs/referanseskjema/-lib/display-step.tsx
+++ b/apps/docs/src/routes/_docs/referanseskjema/-lib/display-step.tsx
@@ -2,7 +2,7 @@ import {
   Alertbox,
   Button,
   Card,
-  UNSAFE_Link as Link,
+  Link,
   Content,
   Heading,
   Footer,

--- a/apps/docs/src/routes/_docs/referanseskjema/-lib/display-step.tsx
+++ b/apps/docs/src/routes/_docs/referanseskjema/-lib/display-step.tsx
@@ -1,12 +1,4 @@
-import {
-  Alertbox,
-  Button,
-  Card,
-  Link,
-  Content,
-  Heading,
-  Footer,
-} from '@obosbbl/grunnmuren-react';
+import { Alertbox, Button, Card, Link, Content, Heading, Footer } from '@obosbbl/grunnmuren-react';
 import { cx } from 'cva';
 
 import { Code } from '@/ui/code';

--- a/apps/docs/src/routes/_docs/referanseskjema/index.tsx
+++ b/apps/docs/src/routes/_docs/referanseskjema/index.tsx
@@ -1,8 +1,4 @@
-import {
-  Link,
-  UNSAFE_Step as Step,
-  UNSAFE_Stepper as Stepper,
-} from '@obosbbl/grunnmuren-react';
+import { Link, UNSAFE_Step as Step, UNSAFE_Stepper as Stepper } from '@obosbbl/grunnmuren-react';
 import { createFileRoute } from '@tanstack/react-router';
 import type { ComponentType } from 'react';
 import { useState } from 'react';

--- a/apps/docs/src/routes/_docs/referanseskjema/index.tsx
+++ b/apps/docs/src/routes/_docs/referanseskjema/index.tsx
@@ -1,5 +1,5 @@
 import {
-  UNSAFE_Link as Link,
+  Link,
   UNSAFE_Step as Step,
   UNSAFE_Stepper as Stepper,
 } from '@obosbbl/grunnmuren-react';

--- a/packages/react/src/breadcrumbs/breadcrumb.tsx
+++ b/packages/react/src/breadcrumbs/breadcrumb.tsx
@@ -6,7 +6,7 @@ import {
   type BreadcrumbProps as RACBreadcrumbProps,
 } from 'react-aria-components/Breadcrumbs';
 
-import { UNSAFE_Link as Link, type UNSAFE_LinkProps as LinkProps } from '../link';
+import { Link, type LinkProps } from '../link';
 
 type BreadcrumbProps = {
   /** Additional CSS className for the element. */

--- a/packages/react/src/link-list/link-list.stories.tsx
+++ b/packages/react/src/link-list/link-list.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from '@storybook/react-vite';
 
 import { Heading } from '../content';
-import { UNSAFE_Link as Link } from '../link';
+import { Link } from '../link';
 import { LinkList, LinkListContainer, LinkListItem } from './link-list';
 
 const meta = {

--- a/packages/react/src/link/link.stories.tsx
+++ b/packages/react/src/link/link.stories.tsx
@@ -2,7 +2,7 @@ import { Download, LinkExternal } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
-import { UNSAFE_Link as Link } from './link';
+import { Link } from './link';
 
 const meta = {
   title: 'Link',

--- a/packages/react/src/link/link.stories.tsx
+++ b/packages/react/src/link/link.stories.tsx
@@ -1,4 +1,4 @@
-import { Download, LinkExternal } from '@obosbbl/grunnmuren-icons-react';
+import { ArrowRight, Download, LinkExternal } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
@@ -24,6 +24,19 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const LinkWithIcon: Story = {
+  args: {
+    href: '/my-href',
+    animateIcon: 'right',
+  },
+  render: (args) => (
+    <Link {...args}>
+      Les mer
+      <ArrowRight />
+    </Link>
+  ),
+};
 
 export const ExternalLink: Story = {
   args: {

--- a/packages/react/src/link/link.tsx
+++ b/packages/react/src/link/link.tsx
@@ -59,4 +59,4 @@ const Link = ({ animateIcon, children, className, ...props }: LinkProps) => {
   );
 };
 
-export { Link as UNSAFE_Link, type LinkProps as UNSAFE_LinkProps };
+export { Link, type LinkProps };

--- a/packages/react/src/stepper/stepper.stories.tsx
+++ b/packages/react/src/stepper/stepper.stories.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps } from 'react';
 import { useArgs } from 'storybook/preview-api';
 import { fn } from 'storybook/test';
 
-import { UNSAFE_Link as Link } from '../link';
+import { Link } from '../link';
 import { UNSAFE_Step as Step, UNSAFE_Stepper as Stepper } from './stepper';
 
 const meta: Meta<typeof Stepper> = {


### PR DESCRIPTION
### Oppsummering

Tar `Link`-komponenten ut av beta ved å fjerne `UNSAFE_`-prefikset fra `Link` (og `LinkProps`-typen). Løser [AB#130234](https://dev.azure.com/obosbbl/Content%20hub/_workitems/edit/130234).

### Endringer

- Fjernet `UNSAFE_`-prefikset fra eksportene i `packages/react/src/link/link.tsx`.
- Oppdaterte interne imports i `breadcrumb.tsx`, `link.stories.tsx`, `link-list.stories.tsx` og `stepper.stories.tsx`.
- Oppdaterte imports i `apps/docs` (`profil/layout.tsx`, `referanseskjema/index.tsx`, `referanseskjema/-lib/display-step.tsx`).
- La til changeset (`minor`) med migreringseksempel for konsumenter.

### Gjenstår

- Markere Link som `Stable` i Sanity Studio (dokumentasjonen på grunnmuren.obos.no) samt oppdatere kode-eksempler. Utkast klart, må bare publiseres