### PR TITLE
Juster typografi og proporsjoner for blockquote

### DIFF
--- a/.changeset/blockquote-typography-tweaks.md
+++ b/.changeset/blockquote-typography-tweaks.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+Blockquote: adjust font-size, line-height and quote mark proportions

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -264,7 +264,7 @@
 }
 
 @utility blockquote {
-  @apply before:font-display grid grid-cols-[3rem_1fr] gap-x-[0.4375rem] pt-4 text-[1.625rem]/[2.5625rem] font-medium italic before:text-[4.6875rem]/[1.6875rem] before:not-italic before:content-["“"] lg:text-[1.4375rem]/[2.25rem];
+  @apply before:font-display grid grid-cols-[2.6875rem_1fr] pt-4 text-[1.1875rem]/[1.875rem] font-medium italic before:text-[3.5625rem]/[1.5625rem] before:not-italic before:content-["“"] lg:grid-cols-[2.9375rem_1fr] lg:gap-x-[0.375rem] lg:text-[1.3125rem]/[2.125rem] lg:before:text-[3.9375rem]/[1.8125rem];
 }
 
 @utility description {

--- a/packages/tailwind/tailwind-typography.css
+++ b/packages/tailwind/tailwind-typography.css
@@ -195,7 +195,7 @@
     }
 
     &:where(blockquote) {
-      @apply before:font-display grid grid-cols-[3rem_1fr] gap-x-[0.4375rem] pt-4 text-[1.4375rem]/[2.25rem] font-medium italic before:text-[4.6875rem]/[1.6875rem] before:not-italic before:content-["“"] lg:text-[1.625rem]/[2.5625rem];
+      @apply before:font-display grid grid-cols-[2.25rem_1fr] pt-4 text-[1rem]/[1.625rem] font-medium italic before:text-[3rem]/[1.375rem] before:not-italic before:content-["“"] lg:text-[1rem]/[1.6875rem];
       margin-top: 1.6em;
       margin-bottom: 1.6em;
     }


### PR DESCRIPTION
### Oppsummering

Justerer font-størrelse, linjehøyde og proporsjoner på anførselstegnet for `blockquote`-utility og `<blockquote>` inne i `prose`. Løser [AB#138554](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/138554).

### Endringer

- `tailwind-base.css`: `blockquote`-utility får ny mobile-first-størrelse (`1.1875rem`/`1.875rem`) med proporsjonalt skalert `before`-anførselstegn, `grid-cols` og `gap-x` for mobil og `lg`+.
- `tailwind-typography.css`: `<blockquote>` inne i `prose` justert til mindre størrelser med tilsvarende skalert anførselstegn.
- Changeset for `@obosbbl/grunnmuren-tailwind` (patch).