### PR TITLE
Skru på type-aware linting og fjern separate tsc-steg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,9 +48,6 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
-      - name: Typecheck storybook
-        run: pnpm typecheck:storybook
-
       # It makes sense to do this on PRs to ensure the change didn't break the Storybook
       - name: Build storybook
         run: pnpm build:storybook

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build packages before lint so that type-aware linting can resolve
-      # workspace package types from their `dist` outputs.
+      # Build packages and generate docs artifacts before lint so that
+      # type-aware linting can resolve workspace package types and the
+      # generated `@/component-props` / `@/colors` modules used by docs.
       - name: Build packages
         run: pnpm run build
+
+      - name: Generate docs artifacts
+        run: pnpm --filter @obosbbl/grunnmuren-docs run build:props && pnpm --filter @obosbbl/grunnmuren-docs run build:colors
 
       - name: lint
         run: pnpm lint && pnpm fmt:check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: lint
-        run: pnpm lint && pnpm fmt:check
-
+      # Build packages before lint so that type-aware linting can resolve
+      # workspace package types from their `dist` outputs.
       - name: Build packages
         run: pnpm run build
+
+      - name: lint
+        run: pnpm lint && pnpm fmt:check
 
       # It makes sense to do this on PRs to ensure the change didn't break the Storybook
       - name: Build storybook

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,7 +16,8 @@
   "jsPlugins": ["eslint-plugin-better-tailwindcss"],
   "ignorePatterns": ["sanity.types.ts", "routeTree.gen.ts"],
   "options": {
-    "typeAware": true
+    "typeAware": true,
+    "typeCheck": true
   },
   "rules": {
     "unicorn/filename-case": [

--- a/.storybook/env.d.ts
+++ b/.storybook/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,12 +6,11 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm build:props && pnpm build:colors && pnpm build:tsc && pnpm build:assets && pnpm sanity:extract && pnpm build:app",
+    "build": "pnpm build:props && pnpm build:colors && pnpm build:assets && pnpm sanity:extract && pnpm build:app",
     "build:app": "vite build",
     "build:assets": "mkdir -p public/resources/icons && cp -r node_modules/@obosbbl/grunnmuren-icons-svg/src/* public/resources/icons/",
     "build:colors": "node extract-colors.ts && oxfmt colors.ts",
     "build:props": "node extract-component-props.ts && oxfmt component-props.ts",
-    "build:tsc": "tsc",
     "dev": "azure-env --env-filename=.env vite dev --port 3003",
     "dev:local-storybook": "VITE_STORYBOOK_BASE_URL=http://localhost:6006 pnpm dev",
     "sanity:extract": "sanity manifest extract --path public/studio/static",

--- a/apps/docs/sanity.config.ts
+++ b/apps/docs/sanity.config.ts
@@ -7,6 +7,8 @@ import { defineConfig } from 'sanity';
 import { presentationTool } from 'sanity/presentation';
 import { structureTool } from 'sanity/structure';
 
+import type { Category } from '@/sanity.types';
+
 import { presentationResolve } from './studio/lib/resolve';
 import { schemaTypes } from './studio/schema-types';
 import { API_VERSION, DATASET, PROJECT_ID } from './util/env';
@@ -22,7 +24,7 @@ export default defineConfig({
       structure: async (S, context) => {
         const CATEGORIES = await context
           .getClient({ apiVersion: API_VERSION })
-          .fetch(`(*[_type == "category"])`);
+          .fetch<Category[]>(`(*[_type == "category"])`);
 
         return S.list()
           .title('Content')
@@ -43,12 +45,13 @@ export default defineConfig({
                     ),
                     S.divider(),
                     ...CATEGORIES.map((category) => {
-                      return S.listItem().title(category.title).id(category._id).child(
+                      const title = category.title ?? category._id;
+                      return S.listItem().title(title).id(category._id).child(
                         // Instead of rendering a list of documents, we render a single
                         // document, specifying the `documentId` manually to ensure
                         // that we're editing the single instance of the document
                         S.document()
-                          .title(category.title)
+                          .title(title)
                           .schemaType(category._type)
                           .documentId(category._id),
                       );

--- a/apps/docs/src/routes/_docs/profil/ikoner.tsx
+++ b/apps/docs/src/routes/_docs/profil/ikoner.tsx
@@ -73,7 +73,13 @@ function IconsGrid() {
   );
 }
 
-function IconCard({ iconName, Icon }) {
+function IconCard({
+  iconName,
+  Icon,
+}: {
+  iconName: string;
+  Icon: (typeof icons)[keyof typeof icons];
+}) {
   const downloadSvgLink = `/resources/icons/${iconName}.svg`;
 
   return (

--- a/apps/docs/src/ui/sanity-content.tsx
+++ b/apps/docs/src/ui/sanity-content.tsx
@@ -1,4 +1,5 @@
 import { PortableText } from '@portabletext/react';
+import type { TableRow as SanityTableRow } from '@sanity/table';
 import { cx } from 'cva';
 
 import type { COMPONENT_QUERY_RESULT } from '@/sanity.types';
@@ -31,8 +32,8 @@ export function SanityContent({ content, className }: SanityContentProps) {
               <Code code={value.code.code} language={value.code.language} caption={value.caption} />
             ),
             'image-with-caption': ({ value }) => <ImageWithCaption asset={value} />,
-            table: ({ value: { rows } }) => {
-              const [firstRow, ...restRows] = rows;
+            table: ({ value }: { value: { rows: SanityTableRow[] } }) => {
+              const [firstRow, ...restRows] = value.rows;
               return (
                 <Table>
                   <TableHead>

--- a/apps/docs/studio/lib/resolve.ts
+++ b/apps/docs/studio/lib/resolve.ts
@@ -1,5 +1,16 @@
 import { defineLocations, type PresentationPluginOptions } from 'sanity/presentation';
 
+type ResolvedCategoryItem = {
+  _type?: string;
+  slug?: string;
+  name?: string;
+};
+
+type ResolvedCategory = {
+  title?: string;
+  categoryItems?: ResolvedCategoryItem[];
+};
+
 function getCategoryHref(title: string) {
   const normalized = title.trim().toLowerCase();
 
@@ -94,7 +105,7 @@ export const presentationResolve: PresentationPluginOptions['resolve'] = {
 
         const itemLocations = Array.isArray(doc?.categoryItems)
           ? doc.categoryItems
-              .map((item) => {
+              .map((item: ResolvedCategoryItem) => {
                 const href = getCategoryItemHref(title, {
                   slug: typeof item?.slug === 'string' ? item.slug : null,
                   type: typeof item?._type === 'string' ? item._type : null,
@@ -109,7 +120,11 @@ export const presentationResolve: PresentationPluginOptions['resolve'] = {
                   href,
                 };
               })
-              .filter((location): location is { title: string; href: string } => location !== null)
+              .filter(
+                (
+                  location: { title: string; href: string } | null,
+                ): location is { title: string; href: string } => location !== null,
+              )
           : [];
 
         return {
@@ -134,13 +149,13 @@ export const presentationResolve: PresentationPluginOptions['resolve'] = {
       resolve: (doc) => {
         const categoryLocations = Array.isArray(doc?.categories)
           ? doc.categories
-              .flatMap((category) => {
+              .flatMap((category: ResolvedCategory) => {
                 const categoryTitle = typeof category?.title === 'string' ? category.title : '';
                 const categoryIndexHref = categoryTitle ? getCategoryHref(categoryTitle) : null;
 
                 const items = Array.isArray(category?.categoryItems)
                   ? category.categoryItems
-                      .map((item) => {
+                      .map((item: ResolvedCategoryItem) => {
                         const href = getCategoryItemHref(categoryTitle, {
                           slug: typeof item?.slug === 'string' ? item.slug : null,
                           type: typeof item?._type === 'string' ? item._type : null,
@@ -159,8 +174,9 @@ export const presentationResolve: PresentationPluginOptions['resolve'] = {
                         };
                       })
                       .filter(
-                        (location): location is { title: string; href: string } =>
-                          location !== null,
+                        (
+                          location: { title: string; href: string } | null,
+                        ): location is { title: string; href: string } => location !== null,
                       )
                   : [];
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "pnpm --filter './packages/**' build",
     "build:docs": "pnpm --filter @obosbbl/grunnmuren-docs build",
-    "build:storybook": "pnpm typecheck:storybook && storybook build -o ./apps/docs/public/storybook",
+    "build:storybook": "storybook build -o ./apps/docs/public/storybook",
     "ci:publish": "pnpm build && changeset publish",
     "ci:version": "changeset version",
     "dev": "storybook dev -p 6006 --ci --initial-path=/story/home--page",
@@ -20,8 +20,7 @@
     "lint:fix": "oxlint --fix",
     "sanity:schema:deploy": "pnpm --filter @obosbbl/grunnmuren-docs sanity:schema:deploy",
     "serve-storybook": "http-server ./apps/docs/public/storybook -p 6006 --silent",
-    "test": "test-storybook",
-    "typecheck:storybook": "tsc --noEmit -p packages/react/tsconfig.storybook.json"
+    "test": "test-storybook"
   },
   "dependencies": {
     "@changesets/cli": "2.31.0",

--- a/packages/react/tsconfig.storybook.json
+++ b/packages/react/tsconfig.storybook.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*.stories.*", "src/**/*.mdx", "src/**/__stories__/**/*"]
-}


### PR DESCRIPTION
### Oppsummering

Skrur på oxlint sin `typeCheck`-option slik at TypeScript-compiler-diagnostics fanges opp av linteren via ts-go. Fjerner deretter `tsc`-invokasjonene i `apps/docs` og root-scriptet `typecheck:storybook`, så vi ikke gjør typesjekkingen to ganger. Får dermed raskere bygg og typesjekking over hele kodebasen i samme pass. Løser [AB#135361](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/135361).

### Endringer

- Aktiverer `"typeCheck": true` i `.oxlintrc.json` (i tillegg til eksisterende `typeAware`)
- Fjerner `build:tsc` fra `apps/docs/package.json` og kallet i `build`-scriptet
- Fjerner `typecheck:storybook` fra root `package.json` + kallet i `build:storybook`, og tilhørende CI-steg i `.github/workflows/main.yml`
- I CI: bygger packages og genererer docs-artefakter (`build:props` + `build:colors`) før `lint` kjører, slik at type-aware linting kan slå opp typene fra `dist`-mappene og de genererte `@/component-props` / `@/colors`-modulene
- Sletter ubrukt `packages/react/tsconfig.storybook.json`
- Legger til `.storybook/env.d.ts` med `vite/client`-referanse for CSS-import-typer
- Fikser typefeil som dukket opp da typesjekkingen ble aktivert over hele kodebasen:
  - `apps/docs/src/routes/_docs/profil/ikoner.tsx`: typer `IconCard`-props
  - `apps/docs/src/ui/sanity-content.tsx`: bruker `TableRow` fra `@sanity/table`
  - `apps/docs/sanity.config.ts`: typer `fetch<Category[]>(...)` og legger til fallback for `title`
  - `apps/docs/studio/lib/resolve.ts`: legger til lokale typer for sanity-resolver-callbacks

> **Merknad om CI:** root sin `pnpm build` filtrerer kun på `./packages/**` og inkluderer ikke `apps/docs`. De nye CI-stegene `Build packages` og `Generate docs artifacts` kjører derfor `build:props` / `build:colors` kun én gang — det er ingen overlapp med root-buildet, og full `apps/docs/build` kjøres ikke i CI.