### PR TITLE
Gjenbruk blockquote-utility i prose

### DIFF
--- a/.changeset/prose-blockquote-shared-style.md
+++ b/.changeset/prose-blockquote-shared-style.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": patch
+---
+
+Prose: reuse `blockquote` utility for `<blockquote>` inside `prose` so both share the same typography

--- a/packages/tailwind/tailwind-typography.css
+++ b/packages/tailwind/tailwind-typography.css
@@ -195,7 +195,7 @@
     }
 
     &:where(blockquote) {
-      @apply before:font-display grid grid-cols-[2.25rem_1fr] pt-4 text-[1rem]/[1.625rem] font-medium italic before:text-[3rem]/[1.375rem] before:not-italic before:content-["“"] lg:text-[1rem]/[1.6875rem];
+      @apply blockquote;
       margin-top: 1.6em;
       margin-bottom: 1.6em;
     }


### PR DESCRIPTION
### Oppsummering

Vi ble enige i et internt teammøte om å bruke samme typografiske stil på `blockquote` i både `prose` og som frittstående `blockquote`-utility. PR-en lar `<blockquote>` inne i `prose` gjenbruke `@apply blockquote`, så typografi vedlikeholdes ett sted. Løser [AB#140510](https://dev.azure.com/obosbbl/Content%20hub/_workitems/edit/140510).

### Endringer

- `packages/tailwind/tailwind-typography.css`: `<blockquote>` inne i `prose` bytter ut egne `@apply`-styles med `@apply blockquote`. Margins (`margin-top`/`margin-bottom`) beholdes som før.
- Changeset for `@obosbbl/grunnmuren-tailwind` (patch).

---

> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).
