### PR TITLE
Drawer

### DIFF
--- a/.changeset/drawer-component.md
+++ b/.changeset/drawer-component.md
@@ -1,0 +1,46 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+## Add `UNSAFE_Drawer` component
+
+A side-anchored overlay built on the same react-aria-components and `HeadingContext` pattern as `UNSAFE_Modal`. Reuses `UNSAFE_Dialog` and `UNSAFE_DialogTrigger`. `placement` (`'right'` | `'left'` | `'top'` | `'bottom'`) controls which edge the drawer slides in from. `isDismissable`, `zIndex` and `className` work the same as in `UNSAFE_Modal`.
+
+### Usage
+
+Basic uncontrolled drawer with auto-rendered close button:
+
+```tsx
+<UNSAFE_DialogTrigger>
+  <Button>Open</Button>
+  <UNSAFE_Drawer>
+    <UNSAFE_Dialog>
+      <Heading slot="title" level={2}>
+        Title
+      </Heading>
+      <p>Content…</p>
+      <Button slot="close">Close</Button>
+    </UNSAFE_Dialog>
+  </UNSAFE_Drawer>
+</UNSAFE_DialogTrigger>
+```
+
+Slide in from another edge:
+
+```tsx
+<UNSAFE_Drawer placement="bottom">…</UNSAFE_Drawer>
+```
+
+Controlled:
+
+```tsx
+<UNSAFE_Drawer isOpen={isOpen} onOpenChange={setIsOpen}>
+  …
+</UNSAFE_Drawer>
+```
+
+Not dismissable — no close button, `Escape` and outside-click disabled:
+
+```tsx
+<UNSAFE_Drawer isDismissable={false}>…</UNSAFE_Drawer>
+```

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -1,0 +1,227 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '../button';
+import { Footer, Heading } from '../content';
+import { UNSAFE_Dialog as Dialog, UNSAFE_DialogTrigger as DialogTrigger } from '../modal';
+import { UNSAFE_Drawer as Drawer } from './drawer';
+
+const meta = {
+  title: 'Drawer',
+  component: Drawer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne</Button>
+        <Drawer>
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Hvitevarer
+            </Heading>
+            <p>
+              Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
+              tørketrommel, oppvaskmaskin eller å avstå dette tilbudet.
+            </p>
+            <Heading level={3} className="heading-xs">
+              Andre tilvalg
+            </Heading>
+            <p>
+              Vi er opptatt av at du skal bli fornøyd og kan skape ditt drømmehjem med tilvalg. Det
+              er viktig å huske at når vi gjør endringer i standarden på boligen, kommer blant annet
+              montering, tilpasninger og transport som en tilleggskostnad.
+            </p>
+            <Button slot="close">Lukk</Button>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+} satisfies Meta<typeof Drawer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const DrawerStory: Story = {};
+
+export const Left: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne fra venstre</Button>
+        <Drawer placement="left">
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Filter
+            </Heading>
+            <p>Drawer fra venstre side. Vanlig brukt for navigasjon eller filtre.</p>
+            <Button slot="close">Lukk</Button>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};
+
+export const Top: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne fra toppen</Button>
+        <Drawer placement="top">
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Varsel
+            </Heading>
+            <p>Drawer fra toppen, for eksempel for varsler eller hurtigvalg.</p>
+            <Button slot="close">Lukk</Button>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};
+
+export const Bottom: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne fra bunnen</Button>
+        <Drawer placement="bottom">
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Detaljer
+            </Heading>
+            <p>Drawer fra bunnen — fungerer godt på mobil for sekundære handlinger.</p>
+            <Footer>
+              <Button slot="close">Lagre</Button>
+              <Button variant="tertiary" slot="close">
+                Avbryt
+              </Button>
+            </Footer>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};
+
+export const MultipleActions: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne</Button>
+        <Drawer>
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Hvitevarer
+            </Heading>
+            <p>
+              Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
+              tørketrommel, oppvaskmaskin eller å avstå dette tilbudet.
+            </p>
+            <Footer>
+              <Button onPress={() => console.log('SAVED!')} slot="close">
+                Lagre
+              </Button>
+              <Button variant="tertiary" slot="close">
+                Avbryt
+              </Button>
+            </Footer>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <div className="p-4">
+        <Button onPress={() => setIsOpen(true)}>Åpne Drawer</Button>
+        <Drawer isOpen={isOpen} onOpenChange={setIsOpen}>
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Tittel
+            </Heading>
+            <p>Denne drawer er controlled.</p>
+            <Button onPress={() => setIsOpen(false)} slot="close">
+              Lukk
+            </Button>
+          </Dialog>
+        </Drawer>
+      </div>
+    );
+  },
+};
+
+export const NotDismissable: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <div className="p-4">
+        <Button onPress={() => setIsOpen(true)}>Åpne</Button>
+        <Drawer isOpen={isOpen} onOpenChange={setIsOpen} isDismissable={false}>
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Bekreft handlingen
+            </Heading>
+            <p>
+              Klikk utenfor og <kbd>Escape</kbd> lukker ikke denne drawer, og close-knappen vises
+              ikke automatisk i headeren.
+            </p>
+            <Button onPress={() => setIsOpen(false)}>Bekreft</Button>
+          </Dialog>
+        </Drawer>
+      </div>
+    );
+  },
+};
+
+export const CustomBackground: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne</Button>
+        <Drawer className="bg-blue-dark! text-mint-light">
+          <Dialog>
+            <Heading slot="title" level={2} className="text-mint">
+              Mørk drawer
+            </Heading>
+            <p>
+              Bakgrunnsfargen kan inntil videre overstyres med `!`-prefiks, og innholdsfarger settes
+              på `Heading` og tekstelementer etter behov.
+            </p>
+            <Button slot="close" color="mint">
+              Lukk
+            </Button>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};
+
+export const CustomZIndex: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne</Button>
+        <Drawer zIndex={50}>
+          <Dialog>
+            <Heading slot="title" level={2}>
+              Custom z-index
+            </Heading>
+            <p>Drawer med z-index 50.</p>
+            <Button slot="close">Lukk</Button>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -183,37 +183,6 @@ export const NotDismissable: Story = {
   },
 };
 
-/**
- * TODO – diskuteres i teamet:
- *
- * `bg-X!`-override fungerer, men er litt klønete. En mer elegant løsning er en
- * dedikert `color`-prop på `UNSAFE_Drawer`, med default `'white'` og en
- * hvitliste over støttede bakgrunner. Da kan vi bake inn riktig kombinasjon
- * av bakgrunn og tekstfarge per variant, og utvide listen ved behov.
- * Konsumenter kan fortsatt overstyre med `!`-prefiks for helt spesielle
- * tilfeller.
- *
- * Skisse av API-et:
- *
- * ```tsx
- * // Inside drawer.tsx:
- * const drawerVariants = cva({
- *   variants: {
- *     color: {
- *       white: 'bg-white text-black',
- *       'blue-dark': 'bg-blue-dark text-mint-light',
- *     },
- *   },
- *   defaultVariants: { color: 'white' },
- * });
- *
- * // Usage:
- * <UNSAFE_Drawer color="blue-dark">…</UNSAFE_Drawer>
- *
- * // Escape hatch fortsatt mulig:
- * <UNSAFE_Drawer className="bg-yellow! text-black">…</UNSAFE_Drawer>
- * ```
- */
 export const CustomBackground: Story = {
   render: () => (
     <div className="p-4">

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -183,6 +183,37 @@ export const NotDismissable: Story = {
   },
 };
 
+/**
+ * TODO – diskuteres i teamet:
+ *
+ * `bg-X!`-override fungerer, men er litt klønete. En mer elegant løsning er en
+ * dedikert `color`-prop på `UNSAFE_Drawer`, med default `'white'` og en
+ * hvitliste over støttede bakgrunner. Da kan vi bake inn riktig kombinasjon
+ * av bakgrunn og tekstfarge per variant, og utvide listen ved behov.
+ * Konsumenter kan fortsatt overstyre med `!`-prefiks for helt spesielle
+ * tilfeller.
+ *
+ * Skisse av API-et:
+ *
+ * ```tsx
+ * // Inside drawer.tsx:
+ * const drawerVariants = cva({
+ *   variants: {
+ *     color: {
+ *       white: 'bg-white text-black',
+ *       'blue-dark': 'bg-blue-dark text-mint-light',
+ *     },
+ *   },
+ *   defaultVariants: { color: 'white' },
+ * });
+ *
+ * // Usage:
+ * <UNSAFE_Drawer color="blue-dark">…</UNSAFE_Drawer>
+ *
+ * // Escape hatch fortsatt mulig:
+ * <UNSAFE_Drawer className="bg-yellow! text-black">…</UNSAFE_Drawer>
+ * ```
+ */
 export const CustomBackground: Story = {
   render: () => (
     <div className="p-4">

--- a/packages/react/src/drawer/drawer.tsx
+++ b/packages/react/src/drawer/drawer.tsx
@@ -1,0 +1,125 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
+import { cva, cx, type VariantProps } from 'cva';
+import {
+  Modal as RACModal,
+  ModalOverlay as RACModalOverlay,
+  type ModalOverlayProps as RACModalOverlayProps,
+} from 'react-aria-components/Modal';
+import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
+
+import { Button } from '../button';
+import { HeadingContext } from '../content';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
+
+const drawerVariants = cva({
+  base: ['fixed overflow-auto bg-white text-left shadow-xl', 'motion-reduce:animate-none'],
+  variants: {
+    placement: {
+      right: 'top-0 right-0 h-dvh w-full max-w-md rounded-l-2xl p-4',
+      left: 'top-0 left-0 h-dvh w-full max-w-md rounded-r-2xl p-4',
+      top: 'inset-x-0 top-0 max-h-[80dvh] w-full rounded-b-2xl p-4',
+      bottom: 'inset-x-0 bottom-0 max-h-[80dvh] w-full rounded-t-2xl p-4',
+    },
+    isEntering: {
+      true: 'animate-in duration-300 ease-out',
+    },
+    isExiting: {
+      true: 'animate-out duration-200 ease-in',
+    },
+  },
+  compoundVariants: [
+    { placement: 'right', isEntering: true, className: 'slide-in-from-right' },
+    { placement: 'right', isExiting: true, className: 'slide-out-to-right' },
+    { placement: 'left', isEntering: true, className: 'slide-in-from-left' },
+    { placement: 'left', isExiting: true, className: 'slide-out-to-left' },
+    { placement: 'top', isEntering: true, className: 'slide-in-from-top' },
+    { placement: 'top', isExiting: true, className: 'slide-out-to-top' },
+    { placement: 'bottom', isEntering: true, className: 'slide-in-from-bottom' },
+    { placement: 'bottom', isExiting: true, className: 'slide-out-to-bottom' },
+  ],
+});
+
+type DrawerProps = Omit<RACModalOverlayProps, 'isDismissable' | 'style'> &
+  Pick<VariantProps<typeof drawerVariants>, 'placement'> & {
+    /** Additional style properties for the element. */
+    style?: React.CSSProperties;
+    /** @default 10 Controls the z-index of the drawer overlay */
+    zIndex?: number;
+    /** @default true Makes the drawer dismissable */
+    isDismissable?: boolean;
+  };
+
+const Drawer = ({
+  isDismissable = true,
+  isOpen,
+  onOpenChange,
+  defaultOpen,
+  className,
+  zIndex = 10,
+  placement = 'right',
+  style = {},
+  ...restProps
+}: DrawerProps) => {
+  const locale = useLocale();
+  return (
+    <Provider
+      values={[
+        [
+          HeadingContext,
+          {
+            slots: {
+              [DEFAULT_SLOT]: {}, // RAC requires a default slot in order to support non-slotted components
+              title: {
+                className: 'heading-s',
+                _outerWrapper: (children) => (
+                  <div className="flex items-center justify-between gap-x-2">
+                    {children}
+                    {isDismissable && (
+                      <Button
+                        slot="close" // RAC Dialog supports one close button out of the box, so we utilize that here
+                        variant="tertiary"
+                        className="data-focus-visible:outline-focus-inset px-2.5!"
+                        aria-label={translations.close[locale]}
+                        onPress={() => onOpenChange?.(false)}
+                      >
+                        <Close />
+                      </Button>
+                    )}
+                  </div>
+                ),
+              },
+            },
+          },
+        ],
+      ]}
+    >
+      <RACModalOverlay
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        defaultOpen={defaultOpen}
+        isDismissable={isDismissable}
+        isKeyboardDismissDisabled={!isDismissable}
+        style={{ zIndex, ...style }}
+        className={({ isEntering, isExiting }) =>
+          cx(
+            'fixed inset-0 bg-black/25 backdrop-blur-sm',
+            isEntering && 'fade-in animate-in duration-300 ease-out',
+            isExiting && 'fade-out animate-out duration-200 ease-in',
+            // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
+            'motion-reduce:animate-none',
+          )
+        }
+      >
+        <RACModal
+          {...restProps}
+          className={({ isEntering, isExiting }) =>
+            drawerVariants({ placement, isEntering, isExiting, className })
+          }
+        />
+      </RACModalOverlay>
+    </Provider>
+  );
+};
+
+export { Drawer as UNSAFE_Drawer, type DrawerProps as UNSAFE_DrawerProps };

--- a/packages/react/src/drawer/index.tsx
+++ b/packages/react/src/drawer/index.tsx
@@ -1,0 +1,1 @@
+export { UNSAFE_Drawer, type UNSAFE_DrawerProps } from './drawer';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,6 +14,7 @@ export * from './combobox';
 export * from './content';
 export * from './date-formatter';
 export * from './disclosure';
+export * from './drawer';
 export * from './file-upload';
 export * from './grunnmuren-provider';
 export * from './hero';


### PR DESCRIPTION
### Oppsummering

Ny `UNSAFE_Drawer`-komponent — en side-forankret overlay som glir inn fra valgt kant av skjermen. Bygger på samme arkitektur som `UNSAFE_Modal` (react-aria-components + `HeadingContext` + `Provider`-trikset for auto-rendret close-knapp), og gjenbruker `UNSAFE_Dialog` og `UNSAFE_DialogTrigger`. Ingen nye avhengigheter. Løser [AB#120868](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/120868).

### Endringer

- Ny komponent: [packages/react/src/drawer/drawer.tsx](packages/react/src/drawer/drawer.tsx) med `placement`-prop (`right` | `left` | `top` | `bottom`), `isDismissable`, `zIndex` og `className`. Slide-animasjon via `tw-animate-css` med `motion-reduce:animate-none`, fade + backdrop-blur på overlay matcher `UNSAFE_Modal`.
- `isDismissable={false}` deaktiverer både klikk-utenfor og `Escape`, og skjuler auto-close-knappen i headeren.
- Storybook-eksempler i [drawer.stories.tsx](packages/react/src/drawer/drawer.stories.tsx) dekker default høyre, `Left` / `Top` / `Bottom`, `MultipleActions` (Footer), `Controlled`, `NotDismissable`, `CustomBackground` (bg-overstyring med `!`-prefiks) og `CustomZIndex`.
- Eksport fra pakkens [index.ts](packages/react/src/index.ts).

### Til diskusjon

`bg-X!`-overstyring fungerer, men er litt klønete. Et alternativ er en `color`-prop med default `'white'` og en liste med andre tillatte farger som `blue-dark` osv, og som vi kan utvide ved behov (og fortsatt mulig å overstyre med `!`-prefiks for spesialtilfeller):

```tsx
…
```

Bør diskuteres i teamet før vi tar inn.

### Gjenstår

- Modal har samme inkonsistens som ble fikset her — `isDismissable={false}` deaktiverer ikke `Escape`. Tatt i oppfølgings-PR: [#1791](https://github.com/code-obos/grunnmuren/pull/1791).

---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).