### PR TITLE
Deaktiver Escape-lukking når UNSAFE_Modal ikke er dismissable

### DIFF
--- a/.changeset/modal-escape-dismiss.md
+++ b/.changeset/modal-escape-dismiss.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Fix `UNSAFE_Modal` so `isDismissable={false}` also disables closing via `Escape`. Previously only outside-click was disabled, while `Escape` still closed the modal — inconsistent with the prop's name.

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -108,6 +108,7 @@ const Modal = ({
         onOpenChange={onOpenChange}
         defaultOpen={defaultOpen}
         isDismissable={isDismissable}
+        isKeyboardDismissDisabled={!isDismissable}
         zIndex={zIndex}
         fullscreen={fullscreen}
       >


### PR DESCRIPTION
### Oppsummering

Oppfølger til [#1790](https://github.com/code-obos/grunnmuren/pull/1790). `UNSAFE_Modal` lukket fortsatt med `Escape` selv når `isDismissable={false}`, fordi react-aria-components har en egen `isKeyboardDismissDisabled`-prop for tastatur-dismissal. Setter den nå basert på `isDismissable` slik at både klikk-utenfor og `Escape` deaktiveres samtidig — i tråd med hva prop-navnet tilsier.

### Endringer

- [packages/react/src/modal/modal.tsx](packages/react/src/modal/modal.tsx): legg til `isKeyboardDismissDisabled={!isDismissable}` på `_ModalOverlay`.

---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).