### PR TITLE
Ignorer .claude/settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ next-env.d.ts
 
 # editors
 .idea/
+.claude/settings.json
 
 *.log
 *.swp


### PR DESCRIPTION
### Oppsummering

Legger `.claude/settings.json` i `.gitignore` slik at lokale Claude Code-innstillinger ikke havner i versjonskontroll inntil videre.

### Endringer

- La til `.claude/settings.json` under `# editors`-seksjonen i `.gitignore`.

---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).