### PR TITLE
Fiks tom Kode-tab i StorybookEmbed

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -95,7 +95,14 @@ const preview: Preview = {
   ],
   tags: ['autodocs'],
   parameters: {
-    docs: { codePanel: true },
+    docs: {
+      codePanel: true,
+      // Storybook's default jsxDecorator skips source-code emission for
+      // stories that use `render: () => …` instead of args. Forcing the
+      // dynamic source type makes it render JSX from the virtual DOM for
+      // every story, so the Kode-tab in <StorybookEmbed> stays populated.
+      source: { type: 'dynamic' },
+    },
 
     options: {
       storySort: {


### PR DESCRIPTION
### Oppsummering

Kode-tab i `StorybookEmbed` var tom for alle komponenter hvis stories bruker en `render`-funksjon i stedet for args — det vil si store deler av komponent-katalogen, inkludert Drawer som Morten flagget i Slack.

Løser [AB#141232](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/141232).

### Endringer

- `.storybook/preview.tsx`: setter `parameters.docs.source.type = 'dynamic'` globalt.

Hvorfor det er nødvendig: med default-innstillingen (`auto`) hopper Storybooks `jsxDecorator` over kildekode-emisjon for stories uten args. Da fyrer aldri `SNIPPET_RENDERED`-eventet, og `StorybookEmbed` mottar aldri kildekoden den lytter på via postMessage — så Kode-tab forblir tom. Med `'dynamic'` rendrer dekoratoren JSX fra det virtuelle DOM-treet for hver story og sender source-string via det eksisterende postMessage-flowet.

### Verifisering

A/B-testet med Playwright mot to parallelle Storybook-instanser (med og uten fiksen):

| Story                       | Uten fiks (`:6006`) | Med fiks (`:6008`) |
| --------------------------- | ------------------- | ------------------ |
| `drawer--drawer-story`      | kun STORY_HEIGHT    | + STORY_SOURCE     |
| `drawer--left`              | kun STORY_HEIGHT    | + STORY_SOURCE     |
| `drawer--multiple-actions`  | kun STORY_HEIGHT    | + STORY_SOURCE     |

Source-strengen er JSX rendret fra runtime (ikke selve story-filen), så komponentnavn er bevart (`<Drawer>`, `<DialogTrigger>` osv.), men spread og defaults vises slik komponenten faktisk monteres.

### Før
<img width="776" height="291" alt="Screenshot 2026-06-04 at 10 28 45" src="https://github.com/user-attachments/assets/8bc61f3b-1c92-4462-9fe4-c93b06b189ad" />


### Nå
<img width="768" height="785" alt="Screenshot 2026-06-04 at 10 27 06" src="https://github.com/user-attachments/assets/4435b469-3262-4f00-a511-d4e6ba7ee609" />


---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).