### PR TITLE
Gjør grunnmuren-tailwind til peerDependency for grunnmuren-react

### DIFF
--- a/.changeset/grunnmuren-tailwind-peer-dep.md
+++ b/.changeset/grunnmuren-tailwind-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': minor
+---
+
+Declare `@obosbbl/grunnmuren-tailwind` as a peer dependency. Consumers must install both packages.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,13 +6,27 @@ Grunnmuren React components.
 
 ## Install
 
+`@obosbbl/grunnmuren-react` declares `@obosbbl/grunnmuren-tailwind` as a peer dependency — the components rely on Tailwind tokens and utilities defined in that package. Install both:
+
 ```sh
 # npm
-npm install @obosbbl/grunnmuren-react@canary
+npm install @obosbbl/grunnmuren-react@canary @obosbbl/grunnmuren-tailwind@canary
 
 # pnpm
-pnpm add @obosbbl/grunnmuren-react@canary
+pnpm add @obosbbl/grunnmuren-react@canary @obosbbl/grunnmuren-tailwind@canary
 ```
+
+Then import the Tailwind preset in your global stylesheet:
+
+```css
+/* globals.css */
+@import '@obosbbl/grunnmuren-tailwind';
+
+/* Register the React package as a Tailwind source so the utilities used by the components are emitted. */
+@source "../../node_modules/@obosbbl/grunnmuren-react/dist";
+```
+
+See [`@obosbbl/grunnmuren-tailwind`](../tailwind/) for the full preset documentation.
 
 ## Setup
 
@@ -199,8 +213,6 @@ module.exports = {
 The plugin works with several different bundlers. See [React Aria's bundle size optimization docs](https://react-spectrum.adobe.com/react-aria/internationalization.html#optimizing-bundle-size) for more information.
 
 ## Usage
-
-Before you start using the components you need to configure the [Tailwind preset](../tailwind/). Remember to add this package to the content scan.
 
 ```js
 import { Button } from '@obosbbl/grunnmuren-react';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -16,7 +16,7 @@ npm install @obosbbl/grunnmuren-react @obosbbl/grunnmuren-tailwind
 pnpm add @obosbbl/grunnmuren-react @obosbbl/grunnmuren-tailwind
 ```
 
-Then import the Tailwind preset in your global stylesheet:
+Then import the Tailwind preset in your global stylesheet. The preset already does `@import 'tailwindcss';` internally, so you should **not** import Tailwind separately:
 
 ```css
 /* globals.css */

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 # @obosbbl/grunnmuren-react
 
-[![npm canary version](https://img.shields.io/npm/v/@obosbbl%2Fgrunnmuren-react/canary.svg)](https://www.npmjs.com/package/@obosbbl/grunnmuren-react)
+[![npm version](https://img.shields.io/npm/v/@obosbbl%2Fgrunnmuren-react.svg)](https://www.npmjs.com/package/@obosbbl/grunnmuren-react)
 
 Grunnmuren React components.
 
@@ -10,10 +10,10 @@ Grunnmuren React components.
 
 ```sh
 # npm
-npm install @obosbbl/grunnmuren-react@canary @obosbbl/grunnmuren-tailwind@canary
+npm install @obosbbl/grunnmuren-react @obosbbl/grunnmuren-tailwind
 
 # pnpm
-pnpm add @obosbbl/grunnmuren-react@canary @obosbbl/grunnmuren-tailwind@canary
+pnpm add @obosbbl/grunnmuren-react @obosbbl/grunnmuren-tailwind
 ```
 
 Then import the Tailwind preset in your global stylesheet:

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,7 @@
     "tailwindcss": "catalog:"
   },
   "peerDependencies": {
+    "@obosbbl/grunnmuren-tailwind": "workspace:^",
     "react": "^19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       '@obosbbl/grunnmuren-icons-react':
         specifier: workspace:^
         version: link:../icons-react
+      '@obosbbl/grunnmuren-tailwind':
+        specifier: workspace:^
+        version: link:../tailwind
       cva:
         specifier: ^1.0.0-0
         version: 1.0.0-beta.4(typescript@5.9.3)
@@ -285,10 +288,10 @@ importers:
         version: 19.2.3
       react-aria:
         specifier: ^3.48.0
-        version: 3.48.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 3.48.0(react-dom@19.2.5(react@19.2.3))(react@19.2.3)
       react-aria-components:
         specifier: ^1.17.0
-        version: 1.17.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.17.0(react-dom@19.2.5(react@19.2.3))(react@19.2.3)
       react-stately:
         specifier: ^3.46.0
         version: 3.46.0(react@19.2.3)
@@ -1241,6 +1244,11 @@ packages:
     peerDependencies:
       pino-opentelemetry-transport: ^3.0.0
       pino-pretty: ^13.0.0
+    peerDependenciesMeta:
+      pino-opentelemetry-transport:
+        optional: true
+      pino-pretty:
+        optional: true
 
   '@code-obos/sanity-auth@1.4.4':
     resolution: {integrity: sha512-rwGxeXsoRdiuy8pQ/x1YQ0BJUR5o1gxbIS9ya8sHEiISUwBmogxzaF1wa1o+oJgKmSeX3GIOUk6WOXjsSFdogw==, tarball: https://npm.pkg.github.com/download/@code-obos/sanity-auth/1.4.4/50f8b663583878958b97b4e21911b72048753985}
@@ -11332,6 +11340,7 @@ snapshots:
   '@code-obos/logger@4.0.0-20260421111144(pino-opentelemetry-transport@3.0.0(@opentelemetry/api@1.9.1)(pino@10.3.1))(pino-pretty@13.1.3)':
     dependencies:
       pino: 10.3.1
+    optionalDependencies:
       pino-opentelemetry-transport: 3.0.0(@opentelemetry/api@1.9.1)(pino@10.3.1)
       pino-pretty: 13.1.3
 
@@ -15838,7 +15847,8 @@ snapshots:
 
   color2k@2.0.3: {}
 
-  colorette@2.0.20: {}
+  colorette@2.0.20:
+    optional: true
 
   combined-stream@1.0.8:
     dependencies:
@@ -16038,7 +16048,8 @@ snapshots:
 
   date-fns@4.1.0: {}
 
-  dateformat@4.6.3: {}
+  dateformat@4.6.3:
+    optional: true
 
   db0@0.3.4: {}
 
@@ -16488,7 +16499,8 @@ snapshots:
 
   fast-content-type-parse@3.0.0: {}
 
-  fast-copy@4.0.3: {}
+  fast-copy@4.0.3:
+    optional: true
 
   fast-deep-equal@3.1.3: {}
 
@@ -16508,7 +16520,8 @@ snapshots:
     dependencies:
       fastest-levenshtein: 1.0.16
 
-  fast-safe-stringify@2.1.1: {}
+  fast-safe-stringify@2.1.1:
+    optional: true
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -16951,7 +16964,8 @@ snapshots:
 
   he@1.2.0: {}
 
-  help-me@5.0.0: {}
+  help-me@5.0.0:
+    optional: true
 
   history@5.3.0:
     dependencies:
@@ -17719,7 +17733,8 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
-  joycon@3.1.1: {}
+  joycon@3.1.1:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -19079,6 +19094,7 @@ snapshots:
       secure-json-parse: 4.1.0
       sonic-boom: 4.2.1
       strip-json-comments: 5.0.3
+    optional: true
 
   pino-std-serializers@7.1.0: {}
 
@@ -19320,6 +19336,17 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-stately: 3.46.0(react@19.2.3)
 
+  react-aria-components@1.17.0(react-dom@19.2.5(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@react-types/shared': 3.34.0(react@19.2.3)
+      '@swc/helpers': 0.5.18
+      client-only: 0.0.1
+      react: 19.2.3
+      react-aria: 3.48.0(react-dom@19.2.5(react@19.2.3))(react@19.2.3)
+      react-dom: 19.2.5(react@19.2.3)
+      react-stately: 3.46.0(react@19.2.3)
+
   react-aria@3.48.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@internationalized/date': 3.12.1
@@ -19331,6 +19358,20 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+      react-stately: 3.46.0(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+
+  react-aria@3.48.0(react-dom@19.2.5(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@19.2.3)
+      '@swc/helpers': 0.5.18
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.3
+      react-dom: 19.2.5(react@19.2.3)
       react-stately: 3.46.0(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
@@ -19367,6 +19408,11 @@ snapshots:
       - supports-color
 
   react-dom@19.2.3(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      scheduler: 0.27.0
+
+  react-dom@19.2.5(react@19.2.3):
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
@@ -19955,7 +20001,8 @@ snapshots:
 
   secure-compare@3.0.1: {}
 
-  secure-json-parse@4.1.0: {}
+  secure-json-parse@4.1.0:
+    optional: true
 
   semver@5.7.2: {}
 
@@ -20293,7 +20340,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-json-comments@5.0.3: {}
+  strip-json-comments@5.0.3:
+    optional: true
 
   strip-literal@3.1.0:
     dependencies:


### PR DESCRIPTION
### Oppsummering

`@obosbbl/grunnmuren-react`-komponentene bruker Tailwind-tokens og utilities som kun finnes i `@obosbbl/grunnmuren-tailwind`. Avhengigheten har vært implisitt — nå deklarerer vi den som `peerDependencies` slik at konsumenter får en pnpm-warning hvis de glemmer å installere tailwind-pakken. Endringen er også en forutsetning for å flytte komponent-styling fra `cva` i React-pakken til komponent-klasser i tailwind-pakken (starter med Pagination i [AB#105098](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/105098)).

Løser [AB#141067](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/141067).

### Endringer

- `packages/react/package.json`: lagt til `@obosbbl/grunnmuren-tailwind` under `peerDependencies` med `workspace:^` (publiseres som `^2.x` siden tailwind-pakken er på 2.4.10).
- `packages/react/README.md`: skrevet om install-seksjonen til å si eksplisitt at begge pakkene må installeres, og vist CSS-importen `@import '@obosbbl/grunnmuren-tailwind';` samt `@source`-direktivet for React-pakken. Presisert at Tailwind ikke skal importeres separat — preset-en gjør `@import 'tailwindcss';` internt. Fjernet redundant Tailwind-omtale i Usage-seksjonen og utdatert `@canary`-tag fra både install-kommandoene og npm-version-badgen på toppen.
- `.changeset/grunnmuren-tailwind-peer-dep.md`: minor changeset for `@obosbbl/grunnmuren-react`.
- `pnpm-lock.yaml`: oppdatert ved `pnpm install` — peer-linken til `packages/tailwind` legges inn under `packages/react`. Resten av diffen er metadata-churn (`optionalDependencies`-flagging for noen indirekte avhengigheter) som ikke er trigget av denne PR-en.

---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).