### PR TITLE
Legg til UNSAFE_Pagination-komponent (beta)

### DIFF
--- a/.changeset/unsafe-pagination-component.md
+++ b/.changeset/unsafe-pagination-component.md
@@ -1,6 +1,6 @@
 ---
-'@obosbbl/grunnmuren-react': minor
-'@obosbbl/grunnmuren-tailwind': minor
+'@obosbbl/grunnmuren-react': patch
+'@obosbbl/grunnmuren-tailwind': patch
 ---
 
 Add `UNSAFE_Pagination` component (beta) and supporting `pagination` and `pagination-ellipsis` utility classes.

--- a/.changeset/unsafe-pagination-component.md
+++ b/.changeset/unsafe-pagination-component.md
@@ -1,0 +1,6 @@
+---
+'@obosbbl/grunnmuren-react': minor
+'@obosbbl/grunnmuren-tailwind': minor
+---
+
+Add `UNSAFE_Pagination` component (beta) and supporting `pagination` and `pagination-ellipsis` utility classes.

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -179,6 +179,7 @@ function Button({ ref = null, ...props }: ButtonProps) {
     <RACLink
       {...(restProps as RACLinkProps)}
       className={className}
+      data-slot="button"
       ref={ref as Ref<HTMLAnchorElement>}
     >
       {children}
@@ -187,6 +188,7 @@ function Button({ ref = null, ...props }: ButtonProps) {
     <RACButton
       {...(restProps as RACButtonProps)}
       className={className}
+      data-slot="button"
       isPending={isPending}
       ref={ref as Ref<HTMLButtonElement>}
     >

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -23,6 +23,7 @@ export * from './link';
 export * from './link-list';
 export * from './modal';
 export * from './numberfield';
+export { UNSAFE_Pagination, type UNSAFE_PaginationProps } from './pagination';
 export * from './radiogroup';
 export * from './select';
 export * from './stepper';

--- a/packages/react/src/pagination/index.ts
+++ b/packages/react/src/pagination/index.ts
@@ -1,0 +1,1 @@
+export { UNSAFE_Pagination, type UNSAFE_PaginationProps } from './pagination';

--- a/packages/react/src/pagination/pagination.stories.tsx
+++ b/packages/react/src/pagination/pagination.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta } from '@storybook/react-vite';
+import { useEffect, useState } from 'react';
+
+import { UNSAFE_Pagination as Pagination } from './pagination';
+
+const meta = {
+  title: 'Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    count: {
+      control: { type: 'number', min: 1, max: 30 },
+    },
+  },
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+
+/**
+ * Pagination renders real `<a>` links — `getItemHref` is required and the
+ * caller owns the `page` state. Two common patterns:
+ *
+ * **URL-driven** (recommended for real apps): read the current page from the
+ * URL, return matching hrefs. Browser/router navigation re-renders with the
+ * new page. `onChange` is not needed.
+ *
+ * ```tsx
+ * const page = Number(searchParams.get('page') ?? 1);
+ * <Pagination
+ *   page={page}
+ *   count={totalPages}
+ *   getItemHref={(p) => `?page=${p}`}
+ * />
+ * ```
+ *
+ * **Local state** (this demo): `useState` holds the page, `onChange` keeps it
+ * in sync with link clicks. The hash in `getItemHref` lets right-click → "Open
+ * in new tab" still land on the right page.
+ */
+export const Default = (props: { count: number }) => {
+  const [page, setPage] = useState(1);
+  return (
+    <Pagination count={props.count} getItemHref={(p) => `#${p}`} onChange={setPage} page={page} />
+  );
+};
+
+Default.args = {
+  count: 10,
+};
+
+/**
+ * Mirrors the URL-driven pattern using the location hash: clicking a link
+ * navigates (updating the hash), a `hashchange` listener feeds the new page
+ * back into state, and no `onChange` is needed. Swap `window.location.hash`
+ * for `useSearchParams()` (Next.js) or your router's equivalent in a real app
+ * — the `<Pagination>` API stays the same.
+ *
+ * ```tsx
+ * const [page, setPage] = useState(() =>
+ *   Number(window.location.hash.slice(1)) || 1,
+ * );
+ * useEffect(() => {
+ *   const handler = () => setPage(Number(window.location.hash.slice(1)) || 1);
+ *   window.addEventListener('hashchange', handler);
+ *   return () => window.removeEventListener('hashchange', handler);
+ * }, []);
+ * return <Pagination count={10} getItemHref={(p) => `#${p}`} page={page} />;
+ * ```
+ */
+export const URLDrivenState = () => {
+  const [page, setPage] = useState(() => Number(window.location.hash.slice(1)) || 1);
+
+  useEffect(() => {
+    const handler = () => setPage(Number(window.location.hash.slice(1)) || 1);
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
+  }, []);
+
+  return <Pagination count={10} getItemHref={(p) => `#${p}`} page={page} />;
+};
+
+/** With currentPage past the sibling threshold, the left ellipsis appears. */
+export const WithEllipsis = () => {
+  const [page, setPage] = useState(8);
+  return <Pagination count={20} getItemHref={(p) => `#${p}`} onChange={setPage} page={page} />;
+};
+
+/** Few pages: no ellipsis and no truncation. */
+export const FewPages = () => {
+  const [page, setPage] = useState(2);
+  return <Pagination count={4} getItemHref={(p) => `#${p}`} onChange={setPage} page={page} />;
+};
+
+/** First page disables the previous-button. */
+export const FirstPage = () => <Pagination count={10} getItemHref={(p) => `#${p}`} page={1} />;
+
+/** Last page disables the next-button. */
+export const LastPage = () => <Pagination count={10} getItemHref={(p) => `#${p}`} page={10} />;

--- a/packages/react/src/pagination/pagination.tsx
+++ b/packages/react/src/pagination/pagination.tsx
@@ -1,0 +1,212 @@
+import { ChevronLeft, ChevronRight } from '@obosbbl/grunnmuren-icons-react';
+import { cx } from 'cva';
+import { useLayoutEffect, useRef } from 'react';
+
+import { Button } from '../button';
+import { translations } from '../translations';
+import { type Locale, useLocale } from '../use-locale';
+
+// Lives here, not in `translations`, because it interpolates the hidden range
+// — the static-string `translations` map doesn't support function values.
+const HIDDEN_PAGES_LABEL: Record<Locale, (start: number, end: number) => string> = {
+  nb: (start, end) =>
+    start === end ? `Skjuler side ${start}` : `Skjuler side ${start} til ${end}`,
+  sv: (start, end) => (start === end ? `Döljer sida ${start}` : `Döljer sida ${start} till ${end}`),
+  en: (start, end) => (start === end ? `Hides page ${start}` : `Hides pages ${start} to ${end}`),
+};
+
+// Number of pages shown on each side of the current page on desktop. On
+// narrow containers, CSS hides the outermost visible pages via the
+// `data-outer` attribute so the entire pagination fits a 320px viewport
+// without changing the rendered DOM.
+const SIBLING_COUNT = 2;
+
+type PaginationProps = {
+  /** The current page (1-indexed). */
+  page: number;
+  /** The total number of pages. */
+  count: number;
+  /** Given a page number, returns the href for navigating to that page. The
+   * value is set as the `href` attribute on the rendered link, enabling
+   * right-click, middle-click and SEO. Client-side routing is set up via
+   * `routerOptions` on `<GrunnmurenProvider />`. */
+  getItemHref: (page: number) => string;
+  /** Optional callback fired when the user activates a page link. Useful for
+   * keeping local state in sync with the URL. Navigation still happens via
+   * the link's href. */
+  onChange?: (page: number) => void;
+  /** Additional class name for the root `<ol>`. */
+  className?: string;
+};
+
+/**
+ * Returns the page numbers (1-indexed) that should be rendered between the
+ * always-visible first page and the next/prev buttons. Mirrors v1's ellipsis
+ * behaviour: only a single (left) ellipsis is ever shown, and the last page
+ * is not guaranteed to be rendered.
+ *
+ * Page 1 is filtered out because it's rendered separately as a fixed slot —
+ * keeping it here would duplicate when the special-case extension lands the
+ * window on it.
+ */
+function getVisiblePages(currentPage: number, pageCount: number): number[] {
+  const end = Math.min(Math.max(2 + SIBLING_COUNT * 2, currentPage + SIBLING_COUNT), pageCount);
+  let start = Math.max(Math.min(currentPage - SIBLING_COUNT, end - SIBLING_COUNT * 2), 1);
+  // When `start` lands exactly SIBLING_COUNT pages past page 1, we have room
+  // to render one extra page to the left without needing an ellipsis.
+  if (start - SIBLING_COUNT === 0) {
+    start = start - 1;
+  }
+  const pages = Array.from({ length: end - start }, (_, i) => start + i + 1);
+  return pages.filter((p) => p > 1);
+}
+
+/**
+ * Returns the indices of the two visible pages farthest from `currentPage`.
+ * These get marked with `data-outer` so the CSS container query can hide them
+ * on narrow viewports, dropping the slot count from 8 to 6 without changing
+ * the rendered DOM. Returns an empty set when there's nothing to gain.
+ */
+function getOuterIndices(visiblePages: number[], currentPage: number): Set<number> {
+  if (visiblePages.length <= 3) {
+    return new Set();
+  }
+  return new Set(
+    visiblePages
+      .map((p, i) => ({ i, distance: Math.abs(p - currentPage) }))
+      .sort((a, b) => b.distance - a.distance)
+      .slice(0, 2)
+      .map((entry) => entry.i),
+  );
+}
+
+const Pagination = (props: PaginationProps) => {
+  const { page, count, getItemHref, onChange, className } = props;
+  const locale = useLocale();
+
+  const currentPage = Math.max(1, Math.min(page, Math.max(1, count)));
+  const pageCount = Math.max(1, count);
+
+  const visiblePages = getVisiblePages(currentPage, pageCount);
+  const outerIndices = getOuterIndices(visiblePages, currentPage);
+  // Show the left ellipsis whenever there's a gap between page 1 and the
+  // first visible page. This matches v1 for SIBLING_COUNT=2.
+  const showLeftEllipsis = visiblePages.length > 0 && visiblePages[0] > 2;
+  const canGoPrev = currentPage > 1;
+  const canGoNext = currentPage < pageCount;
+
+  // Prev/next switches element type (<a> with href ↔ <button> without) when
+  // crossing a boundary. React replaces the DOM node, so the browser blurs
+  // the focused element — restore it manually after the re-render.
+  const prevButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const restoreFocusToRef = useRef<'prev' | 'next' | null>(null);
+
+  useLayoutEffect(() => {
+    if (restoreFocusToRef.current === 'prev') {
+      prevButtonRef.current?.focus();
+    } else if (restoreFocusToRef.current === 'next') {
+      nextButtonRef.current?.focus();
+    }
+    restoreFocusToRef.current = null;
+  }, [currentPage]);
+
+  return (
+    <ol aria-label={translations.pagination[locale]} className={cx('pagination', className)}>
+      <li className="pagination-item">
+        {/* Active: <a href>. Boundary: <button aria-disabled>. We use manual
+            aria-disabled (not RAC's isDisabled) so the boundary state keeps
+            HTML focusability — isDisabled on a button sets the HTML disabled
+            attribute, and on a link makes RAC render a non-focusable span. */}
+        <Button
+          aria-disabled={!canGoPrev}
+          aria-label={translations.previousPage[locale]}
+          className="pagination-arrow"
+          color="white"
+          href={canGoPrev ? getItemHref(currentPage - 1) : undefined}
+          isIconOnly
+          onPress={
+            canGoPrev
+              ? () => {
+                  restoreFocusToRef.current = 'prev';
+                  onChange?.(currentPage - 1);
+                }
+              : undefined
+          }
+          ref={prevButtonRef}
+        >
+          <ChevronLeft />
+        </Button>
+      </li>
+      <PageItem
+        getItemHref={getItemHref}
+        isActive={currentPage === 1}
+        onChange={onChange}
+        page={1}
+      />
+      {showLeftEllipsis && (
+        <li className="pagination-ellipsis">
+          <span aria-hidden="true">…</span>
+          <span className="sr-only">{HIDDEN_PAGES_LABEL[locale](2, visiblePages[0] - 1)}</span>
+        </li>
+      )}
+      {visiblePages.map((p, i) => (
+        <PageItem
+          getItemHref={getItemHref}
+          isActive={p === currentPage}
+          isOuter={outerIndices.has(i)}
+          key={p}
+          onChange={onChange}
+          page={p}
+        />
+      ))}
+      <li className="pagination-item">
+        <Button
+          aria-disabled={!canGoNext}
+          aria-label={translations.nextPage[locale]}
+          className="pagination-arrow"
+          color="white"
+          href={canGoNext ? getItemHref(currentPage + 1) : undefined}
+          isIconOnly
+          onPress={
+            canGoNext
+              ? () => {
+                  restoreFocusToRef.current = 'next';
+                  onChange?.(currentPage + 1);
+                }
+              : undefined
+          }
+          ref={nextButtonRef}
+        >
+          <ChevronRight />
+        </Button>
+      </li>
+    </ol>
+  );
+};
+
+type PageItemProps = {
+  page: number;
+  isActive: boolean;
+  isOuter?: boolean;
+  getItemHref: (page: number) => string;
+  onChange?: (page: number) => void;
+};
+
+const PageItem = ({ page, isActive, isOuter, getItemHref, onChange }: PageItemProps) => {
+  return (
+    <li className="pagination-item" data-outer={isOuter || undefined}>
+      <Button
+        aria-current={isActive ? 'page' : undefined}
+        className="pagination-button"
+        color={isActive ? 'blue' : 'white'}
+        href={getItemHref(page)}
+        onPress={() => onChange?.(page)}
+      >
+        {page}
+      </Button>
+    </li>
+  );
+};
+
+export { Pagination as UNSAFE_Pagination, type PaginationProps as UNSAFE_PaginationProps };

--- a/packages/react/src/pagination/pagination.tsx
+++ b/packages/react/src/pagination/pagination.tsx
@@ -112,8 +112,8 @@ const Pagination = (props: PaginationProps) => {
   }, [currentPage]);
 
   return (
-    <ol aria-label={translations.pagination[locale]} className={cx('pagination', className)}>
-      <li className="pagination-item">
+    <ol aria-label={translations.pagination[locale]} className={cx('gm-pagination', className)}>
+      <li className="gm-pagination-item">
         {/* Active: <a href>. Boundary: <button aria-disabled>. We use manual
             aria-disabled (not RAC's isDisabled) so the boundary state keeps
             HTML focusability — isDisabled on a button sets the HTML disabled
@@ -121,7 +121,7 @@ const Pagination = (props: PaginationProps) => {
         <Button
           aria-disabled={!canGoPrev}
           aria-label={translations.previousPage[locale]}
-          className="pagination-arrow"
+          className="gm-pagination-arrow"
           color="white"
           href={canGoPrev ? getItemHref(currentPage - 1) : undefined}
           isIconOnly
@@ -145,9 +145,9 @@ const Pagination = (props: PaginationProps) => {
         page={1}
       />
       {showLeftEllipsis && (
-        <li className="pagination-ellipsis">
+        <li className="gm-pagination-ellipsis">
           <span aria-hidden="true">…</span>
-          <span className="pagination-ellipsis-label">
+          <span className="gm-pagination-ellipsis-label">
             {HIDDEN_PAGES_LABEL[locale](2, visiblePages[0] - 1)}
           </span>
         </li>
@@ -162,11 +162,11 @@ const Pagination = (props: PaginationProps) => {
           page={p}
         />
       ))}
-      <li className="pagination-item">
+      <li className="gm-pagination-item">
         <Button
           aria-disabled={!canGoNext}
           aria-label={translations.nextPage[locale]}
-          className="pagination-arrow"
+          className="gm-pagination-arrow"
           color="white"
           href={canGoNext ? getItemHref(currentPage + 1) : undefined}
           isIconOnly
@@ -197,10 +197,10 @@ type PageItemProps = {
 
 const PageItem = ({ page, isActive, isOuter, getItemHref, onChange }: PageItemProps) => {
   return (
-    <li className="pagination-item" data-outer={isOuter || undefined}>
+    <li className="gm-pagination-item" data-outer={isOuter || undefined}>
       <Button
         aria-current={isActive ? 'page' : undefined}
-        className="pagination-button"
+        className="gm-pagination-button"
         color={isActive ? 'blue' : 'white'}
         href={getItemHref(page)}
         onPress={() => onChange?.(page)}

--- a/packages/react/src/pagination/pagination.tsx
+++ b/packages/react/src/pagination/pagination.tsx
@@ -147,7 +147,9 @@ const Pagination = (props: PaginationProps) => {
       {showLeftEllipsis && (
         <li className="pagination-ellipsis">
           <span aria-hidden="true">…</span>
-          <span className="sr-only">{HIDDEN_PAGES_LABEL[locale](2, visiblePages[0] - 1)}</span>
+          <span className="pagination-ellipsis-label">
+            {HIDDEN_PAGES_LABEL[locale](2, visiblePages[0] - 1)}
+          </span>
         </li>
       )}
       {visiblePages.map((p, i) => (

--- a/packages/react/src/pagination/pagination.tsx
+++ b/packages/react/src/pagination/pagination.tsx
@@ -113,7 +113,7 @@ const Pagination = (props: PaginationProps) => {
 
   return (
     <ol aria-label={translations.pagination[locale]} className={cx('gm-pagination', className)}>
-      <li className="gm-pagination-item">
+      <li>
         {/* Active: <a href>. Boundary: <button aria-disabled>. We use manual
             aria-disabled (not RAC's isDisabled) so the boundary state keeps
             HTML focusability — isDisabled on a button sets the HTML disabled
@@ -121,7 +121,6 @@ const Pagination = (props: PaginationProps) => {
         <Button
           aria-disabled={!canGoPrev}
           aria-label={translations.previousPage[locale]}
-          className="gm-pagination-arrow"
           color="white"
           href={canGoPrev ? getItemHref(currentPage - 1) : undefined}
           isIconOnly
@@ -145,11 +144,9 @@ const Pagination = (props: PaginationProps) => {
         page={1}
       />
       {showLeftEllipsis && (
-        <li className="gm-pagination-ellipsis">
+        <li data-slot="ellipsis">
           <span aria-hidden="true">…</span>
-          <span className="gm-pagination-ellipsis-label">
-            {HIDDEN_PAGES_LABEL[locale](2, visiblePages[0] - 1)}
-          </span>
+          <span>{HIDDEN_PAGES_LABEL[locale](2, visiblePages[0] - 1)}</span>
         </li>
       )}
       {visiblePages.map((p, i) => (
@@ -162,11 +159,10 @@ const Pagination = (props: PaginationProps) => {
           page={p}
         />
       ))}
-      <li className="gm-pagination-item">
+      <li>
         <Button
           aria-disabled={!canGoNext}
           aria-label={translations.nextPage[locale]}
-          className="gm-pagination-arrow"
           color="white"
           href={canGoNext ? getItemHref(currentPage + 1) : undefined}
           isIconOnly
@@ -197,10 +193,9 @@ type PageItemProps = {
 
 const PageItem = ({ page, isActive, isOuter, getItemHref, onChange }: PageItemProps) => {
   return (
-    <li className="gm-pagination-item" data-outer={isOuter || undefined}>
+    <li data-outer={isOuter || undefined}>
       <Button
         aria-current={isActive ? 'page' : undefined}
-        className="gm-pagination-button"
         color={isActive ? 'blue' : 'white'}
         href={getItemHref(page)}
         onPress={() => onChange?.(page)}

--- a/packages/react/src/translations.ts
+++ b/packages/react/src/translations.ts
@@ -39,6 +39,21 @@ const translations: Translations = {
     sv: 'Nästa',
     en: 'Next',
   },
+  pagination: {
+    nb: 'Paginering',
+    sv: 'Paginering',
+    en: 'Pagination',
+  },
+  previousPage: {
+    nb: 'Forrige side',
+    sv: 'Föregående sida',
+    en: 'Previous page',
+  },
+  nextPage: {
+    nb: 'Neste side',
+    sv: 'Nästa sida',
+    en: 'Next page',
+  },
   carousel: {
     nb: 'Karusell',
     sv: 'Karusell',

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -300,6 +300,61 @@
   @apply ring-focus ring-offset-2;
 }
 
+/*** Pagination component styles
+ *
+ * These have to sit in the utilities layer (not `@layer components`) because
+ * they override Button's cva-generated utility classes — `.transition-colors`
+ * and `.outline-white`. Rules in the components layer are emitted before
+ * utilities and always lose the cascade regardless of selector specificity. */
+@utility pagination {
+  @apply flex items-center justify-center gap-2;
+  /* The list is the container that drives the responsive hide of the
+     outermost page slots — see `[data-outer]` below. */
+  container-type: inline-size;
+
+  /* Nested under `&` so
+     the specificity beats Button's own. */
+  & .pagination-button {
+    @apply size-11 transition-none;
+  }
+
+  /* color="white" sets outline-white for focus — invisible on white page
+     backgrounds. Force black via these higher-specificity selectors so we
+     don't fight cva ordering inside Button. */
+  & .pagination-button:focus-visible,
+  & .pagination-arrow:focus-visible {
+    @apply outline-black;
+  }
+
+  /* At a boundary, prev/next is rendered as a `<button>` (no href in JSX),
+     and our manual aria-disabled passes through (RACButton's useButton
+     forwards it, unlike RACLink which strips it). */
+  & .pagination-arrow[aria-disabled='true'] {
+    @apply cursor-default opacity-30;
+
+    &:hover {
+      @apply bg-white;
+    }
+  }
+
+  /* When the list is narrower than its full 8-slot width (~408px), hide the
+     two outermost page items — `data-outer` is set in JS on the visiblePages
+     entries farthest from the current page. */
+  @container (max-width: 27rem) {
+    & [data-outer] {
+      display: none;
+    }
+  }
+}
+
+@utility pagination-item {
+  @apply w-11 shrink-0;
+}
+
+@utility pagination-ellipsis {
+  @apply flex size-11 shrink-0 items-center justify-center;
+}
+
 /** Hides the scrollbar visually */
 @utility scrollbar-hidden {
   /* For IE, Edge and Firefox */

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -306,7 +306,7 @@
  * they override Button's cva-generated utility classes — `.transition-colors`
  * and `.outline-white`. Rules in the components layer are emitted before
  * utilities and always lose the cascade regardless of selector specificity. */
-@utility pagination {
+@utility gm-pagination {
   @apply flex items-center justify-center gap-2;
   /* The list is the container that drives the responsive hide of the
      outermost page slots — see `[data-outer]` below. */
@@ -314,22 +314,22 @@
 
   /* Nested under `&` so
      the specificity beats Button's own. */
-  & .pagination-button {
+  & .gm-pagination-button {
     @apply size-11 transition-none;
   }
 
   /* color="white" sets outline-white for focus — invisible on white page
      backgrounds. Force black via these higher-specificity selectors so we
      don't fight cva ordering inside Button. */
-  & .pagination-button:focus-visible,
-  & .pagination-arrow:focus-visible {
+  & .gm-pagination-button:focus-visible,
+  & .gm-pagination-arrow:focus-visible {
     @apply outline-black;
   }
 
   /* At a boundary, prev/next is rendered as a `<button>` (no href in JSX),
      and our manual aria-disabled passes through (RACButton's useButton
      forwards it, unlike RACLink which strips it). */
-  & .pagination-arrow[aria-disabled='true'] {
+  & .gm-pagination-arrow[aria-disabled='true'] {
     @apply cursor-default opacity-30;
 
     &:hover {
@@ -347,17 +347,17 @@
   }
 }
 
-@utility pagination-item {
+@utility gm-pagination-item {
   @apply w-11 shrink-0;
 }
 
-@utility pagination-ellipsis {
+@utility gm-pagination-ellipsis {
   @apply flex size-11 shrink-0 items-center justify-center;
 }
 
-/* Visually-hidden label inside `.pagination-ellipsis` — describes the
+/* Visually-hidden label inside `.gm-pagination-ellipsis` — describes the
    skipped page range to screen readers (e.g. "Skjuler side 2 til 6"). */
-@utility pagination-ellipsis-label {
+@utility gm-pagination-ellipsis-label {
   @apply sr-only;
 }
 

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -333,21 +333,21 @@
      prevents the hover-colour transition from flickering when rapid clicks
      change which button is active. `:not(:has(svg))` distinguishes them
      from prev/next which contain a chevron icon. */
-  & button[data-slot='button']:not(:has(svg)) {
+  & [data-slot='button']:not(:has(svg)) {
     @apply size-11 transition-none;
   }
 
   /* color="white" sets outline-white for focus — invisible on white page
      backgrounds. Force black via this higher-specificity selector so we
      don't fight cva ordering inside Button. */
-  & button[data-slot='button']:focus-visible {
+  & [data-slot='button']:focus-visible {
     @apply outline-black;
   }
 
   /* At a boundary, prev/next is rendered as a `<button>` (no href in JSX),
      and our manual aria-disabled passes through (RACButton's useButton
      forwards it, unlike RACLink which strips it). */
-  & button[data-slot='button'][aria-disabled='true'] {
+  & [data-slot='button'][aria-disabled='true'] {
     @apply cursor-default opacity-30;
 
     &:hover {

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -355,6 +355,12 @@
   @apply flex size-11 shrink-0 items-center justify-center;
 }
 
+/* Visually-hidden label inside `.pagination-ellipsis` — describes the
+   skipped page range to screen readers (e.g. "Skjuler side 2 til 6"). */
+@utility pagination-ellipsis-label {
+  @apply sr-only;
+}
+
 /** Hides the scrollbar visually */
 @utility scrollbar-hidden {
   /* For IE, Edge and Firefox */

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -312,24 +312,42 @@
      outermost page slots — see `[data-outer]` below. */
   container-type: inline-size;
 
-  /* Nested under `&` so
-     the specificity beats Button's own. */
-  & .gm-pagination-button {
+  /* Every <li> slot is fixed 44px wide and doesn't shrink — keeps the layout
+     stable when an ellipsis is swapped in for a page number. */
+  & > li {
+    @apply w-11 shrink-0;
+  }
+
+  /* Ellipsis slot — flex-centered "…" with an sr-only label describing the
+     skipped range. The label is the second span (the first has aria-hidden). */
+  & > li[data-slot='ellipsis'] {
+    @apply flex size-11 items-center justify-center;
+
+    & > span:not([aria-hidden]) {
+      @apply sr-only;
+    }
+  }
+
+  /* Page-number buttons hold text, not an icon — force a square 44×44
+     (the Button `isIconOnly` variant is for icons). `transition-none`
+     prevents the hover-colour transition from flickering when rapid clicks
+     change which button is active. `:not(:has(svg))` distinguishes them
+     from prev/next which contain a chevron icon. */
+  & button[data-slot='button']:not(:has(svg)) {
     @apply size-11 transition-none;
   }
 
   /* color="white" sets outline-white for focus — invisible on white page
-     backgrounds. Force black via these higher-specificity selectors so we
+     backgrounds. Force black via this higher-specificity selector so we
      don't fight cva ordering inside Button. */
-  & .gm-pagination-button:focus-visible,
-  & .gm-pagination-arrow:focus-visible {
+  & button[data-slot='button']:focus-visible {
     @apply outline-black;
   }
 
   /* At a boundary, prev/next is rendered as a `<button>` (no href in JSX),
      and our manual aria-disabled passes through (RACButton's useButton
      forwards it, unlike RACLink which strips it). */
-  & .gm-pagination-arrow[aria-disabled='true'] {
+  & button[data-slot='button'][aria-disabled='true'] {
     @apply cursor-default opacity-30;
 
     &:hover {
@@ -345,20 +363,6 @@
       display: none;
     }
   }
-}
-
-@utility gm-pagination-item {
-  @apply w-11 shrink-0;
-}
-
-@utility gm-pagination-ellipsis {
-  @apply flex size-11 shrink-0 items-center justify-center;
-}
-
-/* Visually-hidden label inside `.gm-pagination-ellipsis` — describes the
-   skipped page range to screen readers (e.g. "Skjuler side 2 til 6"). */
-@utility gm-pagination-ellipsis-label {
-  @apply sr-only;
 }
 
 /** Hides the scrollbar visually */

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -319,10 +319,12 @@
   }
 
   /* Ellipsis slot — flex-centered "…" with an sr-only label describing the
-     skipped range. The label is the second span (the first has aria-hidden). */
+     skipped range. */
   & > li[data-slot='ellipsis'] {
     @apply flex size-11 items-center justify-center;
 
+    /* The label span is the one without `aria-hidden` (the visible "…" has
+       it). Selecting via the attribute absence avoids adding another marker. */
     & > span:not([aria-hidden]) {
       @apply sr-only;
     }


### PR DESCRIPTION
### Oppsummering

Implementerer `UNSAFE_Pagination` per [AB#105098](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/105098) — første komponent under det nye styling-mønsteret (komponent-klasser i `@obosbbl/grunnmuren-tailwind`, ikke `cva`). Page numbers er ekte ``-lenker (riktig navigasjons-semantikk, right-click, SEO). Prev/next krever en del a11y-trade-offs som er forklart nedenfor.

Løser [AB#105098](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/105098).

### Endringer

#### Komponent
- Ny `packages/react/src/pagination/pagination.tsx` eksportert som `UNSAFE_Pagination` (beta-prefiks per komponent-lifecycle)
- `getItemHref` påkrevd (lenker per WCAG), `onChange` valgfri (callback for state-synk)
- Aktiv side: `aria-current="page"`
- Rotelement: `<ol>` (ikke ``), per AC
- 6 stories — `Default` og `URLDrivenState` har JSDoc med kode-eksempler som dekker to bruksmønstre (lokal state vs URL-drevet)
- Tre nye translations: `pagination`, `previousPage`, `nextPage`

#### Button
- `Button` setter nå `data-slot="button"` på det renderte ``/``-elementet (matcher mønsteret fra Stepper og Link-list som har sine egne `data-slot`-identifikatorer)

#### Tailwind-pakke
Én ny `@utility` i `packages/tailwind/tailwind-base.css`:
- `.gm-pagination` — root container med container-query-setup. Alle slot-styles ligger nestet inni denne og målrettes via element-selectors (`& > li`) og `data-slot`-attributter (`& > li[data-slot='ellipsis']`, `& [data-slot='button']`).

I tråd med teamets nye konvensjon: ingen egne utility-klasser per element for generiske komponenter — bruk `data-slot` + element-selectors istedenfor. Skiller page-number-knapper fra prev/next via `:not(:has(svg))` (sidetall = tekst, prev/next = chevron-ikon).

Utility-en ligger i `@utility`-laget (ikke `@layer components`) fordi reglene må overstyre Button's cva-genererte utility-klasser (`.transition-colors`, `.outline-white`). I components-laget ville de tapt mot utility-laget uavhengig av spesifisitet.

### A11y-valg som krever forklaring

Dette er gjennomtenkte trade-offs etter en lang prosess hvor vi prøvde flere alternativer:

**Prev/next bytter element-type på boundary (`` ↔ ``).** Aktiv: `` → ``. `` uten href → ``. Vi bruker manual `aria-disabled` (ikke RAC's `isDisabled`-prop) fordi:
- RAC's `useLink` overstyrer `aria-disabled`
- RAC's `Button` _forwarder_ `aria-disabled` korrekt når vi ikke bruker `href`
- RAC's `isDisabled` på Link rendrer som `` uten tabindex → ikke fokuserbar - mister fokus når den blir disabled.
- RAC's `isDisabled` på Button setter HTML `disabled` → heller ikke fokuserbar - mister fokus

Manuell `aria-disabled` på `` gir oss en disabled-knapp som beholder fokuserbarhet — viktig for keyboard-brukere.

**`useLayoutEffect` for å restore fokus etter element-bytte.** Når brukeren klikker prev fra side 2 til side 1, bytter element-typen `` → ``. React replacer DOM-noden, browseren blur-er den fokuserte (nå-fjernede) ``. Vi setter et flag i `onPress` og restorer fokus til riktig slot etter re-render.

**Skjermleser-opplesing:** "Forrige side, button, disabled" istedenfor "link, disabled". Akseptabelt — disabled = ikke-interaktiv uansett.

**Ellipsis-tekst for AT:** `"Skjuler side 2 til 6"` inni ellipsis-li-en så skjermlesere annonserer skipped pages konkret (dynamisk basert på `visiblePages[0]`). En `…`-glyph alene gir ingen indikasjon på hvilke sider som er hoppet over.

### Responsivt design uten useEffect

For å passe en 320px-viewports uten å krympe knappene under 44×44-touch-target:
- Render alltid med `siblingCount=2` (maks 8 slots = 408px)
- JS markerer outermost-fra-current items med `data-outer`-attributt
- CSS `@container (max-width: 27rem)` skjuler dem på smale viewports → 6 slots = 304px

### Avvik fra AC

- **"Prev/next fjernes fra DOM når ikke relevant"** — vi beholder dem i DOM som ``. Fjerning fra DOM ville ha gjort fokus-bevaringen umulig. Ved å beholde dem i DOM-en får vi også enklere Layout-stabilitet på tvers av state-endringer.

### Demo

https://github.com/user-attachments/assets/00c7ee13-c62c-4591-8365-97cb4789dece

<img width="316" height="186" alt="Screenshot 2026-06-08 at 10 25 42" src="https://github.com/user-attachments/assets/9859f652-a6a3-4bdb-af43-e87d33723c28"/>
<img width="703" height="278" alt="Screenshot 2026-06-08 at 10 25 50" src="https://github.com/user-attachments/assets/ff3caf88-7889-46c0-be79-f2a6af955098"/>


---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).