### PR TITLE
Flytt padding fra scroll-container til Dialog i Modal og Drawer

### DIFF
--- a/.changeset/modal-drawer-dialog-padding.md
+++ b/.changeset/modal-drawer-dialog-padding.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+`UNSAFE_Modal` / `UNSAFE_Drawer`: padding moved from the scroll container to `UNSAFE_Dialog`. Default appearance is unchanged, but consumers who used to override container padding can now drop that workaround. Fullscreen modals now get the same default padding as non-fullscreen.

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -1,3 +1,4 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
@@ -219,6 +220,33 @@ export const CustomZIndex: Story = {
             </Heading>
             <p>Drawer med z-index 50.</p>
             <Button slot="close">Lukk</Button>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};
+
+export const StickyHeader: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne lang liste</Button>
+        <Drawer>
+          <Dialog>
+            <div className="sticky top-0 z-10 -mx-4 -mt-4 flex items-center justify-between gap-x-2 bg-white px-4 pt-4 pb-3 shadow-sm">
+              <Heading level={2} className="heading-s">
+                Tilvalg
+              </Heading>
+              <Button slot="close" variant="tertiary" className="px-2.5!" aria-label="Lukk">
+                <Close />
+              </Button>
+            </div>
+            {Array.from({ length: 30 }, (_, i) => (
+              <p key={i}>
+                Tilvalg {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </p>
+            ))}
           </Dialog>
         </Drawer>
       </DialogTrigger>

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -1,4 +1,3 @@
-import { Close } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
@@ -220,33 +219,6 @@ export const CustomZIndex: Story = {
             </Heading>
             <p>Drawer med z-index 50.</p>
             <Button slot="close">Lukk</Button>
-          </Dialog>
-        </Drawer>
-      </DialogTrigger>
-    </div>
-  ),
-};
-
-export const StickyHeader: Story = {
-  render: () => (
-    <div className="p-4">
-      <DialogTrigger>
-        <Button>Åpne lang liste</Button>
-        <Drawer>
-          <Dialog>
-            <div className="sticky top-0 z-10 -mx-4 -mt-4 flex items-center justify-between gap-x-2 bg-white px-4 pt-4 pb-3 shadow-sm">
-              <Heading level={2} className="heading-s">
-                Tilvalg
-              </Heading>
-              <Button slot="close" variant="tertiary" className="px-2.5!" aria-label="Lukk">
-                <Close />
-              </Button>
-            </div>
-            {Array.from({ length: 30 }, (_, i) => (
-              <p key={i}>
-                Tilvalg {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              </p>
-            ))}
           </Dialog>
         </Drawer>
       </DialogTrigger>

--- a/packages/react/src/drawer/drawer.tsx
+++ b/packages/react/src/drawer/drawer.tsx
@@ -16,10 +16,10 @@ const drawerVariants = cva({
   base: ['fixed overflow-auto bg-white text-left shadow-xl', 'motion-reduce:animate-none'],
   variants: {
     placement: {
-      right: 'top-0 right-0 h-dvh w-full max-w-md rounded-l-2xl p-4',
-      left: 'top-0 left-0 h-dvh w-full max-w-md rounded-r-2xl p-4',
-      top: 'inset-x-0 top-0 max-h-[80dvh] w-full rounded-b-2xl p-4',
-      bottom: 'inset-x-0 bottom-0 max-h-[80dvh] w-full rounded-t-2xl p-4',
+      right: 'top-0 right-0 h-dvh w-full max-w-md rounded-l-2xl',
+      left: 'top-0 left-0 h-dvh w-full max-w-md rounded-r-2xl',
+      top: 'inset-x-0 top-0 max-h-[80dvh] w-full rounded-b-2xl',
+      bottom: 'inset-x-0 bottom-0 max-h-[80dvh] w-full rounded-t-2xl',
     },
     isEntering: {
       true: 'animate-in duration-300 ease-out',

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -197,7 +197,7 @@ export const Fullscreen: Story = {
       <DialogTrigger>
         <Button>Åpne fullskjerm</Button>
         <Modal fullscreen>
-          <Dialog className="p-4">
+          <Dialog>
             <Heading slot="title" level={2}>
               Fullskjerm modal
             </Heading>
@@ -216,7 +216,7 @@ export const ImageGalleryModal: Story = {
       <DialogTrigger>
         <Button>Åpne bildegalleri</Button>
         <Modal fullscreen>
-          <Dialog className="container h-full p-4">
+          <Dialog className="container h-full">
             <Heading slot="title" level={2}>
               Bildegalleri - Eksempel
             </Heading>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -118,7 +118,7 @@ const Modal = ({
             cx(
               className,
               'overflow-auto bg-white text-left shadow-xl',
-              fullscreen ? 'fixed inset-0' : 'w-full max-w-md rounded-2xl p-4 align-middle',
+              fullscreen ? 'fixed inset-0' : 'w-full max-w-md rounded-2xl align-middle',
               isEntering && 'zoom-in-95 animate-in duration-300 ease-out',
               isExiting && 'zoom-out-95 animate-out duration-200 ease-in',
               // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
@@ -140,7 +140,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
     {...restProps}
     className={cx(
       className,
-      'relative flex flex-col gap-y-5 outline-none',
+      'relative flex flex-col gap-y-5 p-4 outline-none',
       // Footer
       '**:data-[slot="footer"]:flex **:data-[slot="footer"]:gap-x-2',
     )}


### PR DESCRIPTION
### Oppsummering

`p-4` lå inkonsekvent på scroll-containeren til `UNSAFE_Modal` og `UNSAFE_Drawer` — Drawer hadde det alltid, Modal kun når `fullscreen={false}`. Team boligdrøm rapporterte at de måtte overstyre vår padding for å så sette egen `p-4` på Dialog-innholdet (typisk for sticky-headere og innhold som strekker seg ut til kantene). Løser [AB#142667](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/142667).

### Endringer

- `Drawer` (drawer.tsx): fjernet `p-4` fra alle fire placement-varianter på `RACModal`.
- `Modal` (modal.tsx): fjernet `p-4` fra non-fullscreen-grenen på `RACModal`.
- `Dialog` (modal.tsx): fått `p-4` på root-elementet. Default-utseendet er uforandret for vanlig bruk.
- `Modal` fullscreen: får nå samme default-padding som non-fullscreen (tidligere `0`). Det manuelle `className="p-4"`/`className="container h-full p-4"` på `Dialog` i `Fullscreen`- og `ImageGalleryModal`-stories er fjernet siden det nå er redundant.
- Changeset: `patch` på `@obosbbl/grunnmuren-react` (komponentene er fortsatt `UNSAFE_`/beta).

---

> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).