### PR TITLE
Fiks at download-knappen for ikoner lastet ned HTML i stedet for SVG

### DIFF
--- a/apps/docs/src/routes/_docs.tsx
+++ b/apps/docs/src/routes/_docs.tsx
@@ -111,15 +111,27 @@ function RootLayout() {
         // This integrates RAC/Grunnmuren with TanStack router
         // Giving us typesafe routes
         // See https://react-spectrum.adobe.com/react-aria/routing.html#tanstack-router
-        navigate={(href, options) =>
-          router.navigate({
+        navigate={(href, options) => {
+          // String hrefs (absolute URLs or static asset paths like /resources/...) must
+          // bypass TanStack — spreading a string into navigate options silently falls back
+          // to the current location.
+          if (typeof href === 'string') {
+            if (URL.canParse(href)) {
+              window.location.href = href;
+              return;
+            }
+            void router.navigate({ to: href, ...options });
+            return;
+          }
+          void router.navigate({
             ...href,
             ...options,
-          })
-        }
+          });
+        }}
         useHref={(href) => {
-          // If it's an absolute URL, return it as it is instead of building a tanstack link
-          if (typeof href === 'string' && URL.canParse(href)) {
+          // String hrefs (absolute URLs, static asset paths) are passed through unchanged;
+          // only the ToOptions object form should be resolved via TanStack.
+          if (typeof href === 'string') {
             return href;
           }
           return router.buildLocation({ ...href }).href;


### PR DESCRIPTION
### Oppsummering

Download-knappen på `/profil/ikoner` lagret HTML-en for selve ikon-siden (med SVG-filnavn) i stedet for ikonet. Årsaken lå i `GrunnmurenProvider`-bridgen mot TanStack: `useHref` spredde en string-href inn i `router.buildLocation({ ...href })`, og spread på en streng gir et objekt med tegnene som tall-keys — TanStack falt da tilbake til gjeldende URL og rendret `<a href="/profil/ikoner" download>`. Nettleseren respekterte `download` og lagret den HTML-en med ikonets filnavn.

Løser [AB#142721](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/142721).

### Endringer

- `apps/docs/src/routes/_docs.tsx`: `useHref` og `navigate` i `GrunnmurenProvider` håndterer nå string-hrefs riktig. String-hrefs sendes uendret videre — kun objekt-formen (TanStack `ToOptions`) går gjennom `router.buildLocation` / `router.navigate({ ...href })`. Absolutte URL-er i `navigate` bruker `window.location.href` i stedet for TanStack.

### Test

Verifisert lokalt: ikon-kortene rendrer nå `<a href="/resources/icons/Airplane.svg" download>` (i prod står det `href="/profil/ikoner"`), og statiske SVG-er serveres med `Content-Type: image/svg+xml`.

---

> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).