### PR TITLE
Legg til Toggletip-komponent (beta)

### DIFF
--- a/.changeset/unsafe-toggletip-component.md
+++ b/.changeset/unsafe-toggletip-component.md
@@ -1,5 +1,6 @@
 ---
 '@obosbbl/grunnmuren-react': patch
+'@obosbbl/grunnmuren-tailwind': patch
 ---
 
-Add `UNSAFE_Toggletip` component (beta).
+Add `UNSAFE_Toggletip` component (beta) and supporting `gm-toggletip` and `gm-toggletip-trigger` utility classes.

--- a/.changeset/unsafe-toggletip-component.md
+++ b/.changeset/unsafe-toggletip-component.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/grunnmuren-react': patch
+---
+
+Add `UNSAFE_Toggletip` component (beta).

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -32,5 +32,6 @@ export * from './tabs';
 export * from './tag-group';
 export * from './textarea';
 export * from './textfield';
+export * from './toggletip';
 export * from './use-locale';
 export * from './video-loop';

--- a/packages/react/src/toggletip/index.tsx
+++ b/packages/react/src/toggletip/index.tsx
@@ -1,0 +1,8 @@
+export {
+  UNSAFE_Toggletip,
+  UNSAFE_ToggletipContent,
+  UNSAFE_ToggletipTrigger,
+  type UNSAFE_ToggletipContentProps,
+  type UNSAFE_ToggletipProps,
+  type UNSAFE_ToggletipTriggerProps,
+} from './toggletip';

--- a/packages/react/src/toggletip/toggletip.stories.tsx
+++ b/packages/react/src/toggletip/toggletip.stories.tsx
@@ -56,28 +56,6 @@ export const IconTrigger = () => (
 );
 
 /**
- * Without a `variant`, `ToggletipTrigger` only carries the button behaviour and
- * focus ring — the children and styling are entirely up to you. Here the trigger
- * is a small custom-styled button.
- */
-export const CustomTrigger = () => (
-  <span className="inline-flex items-center gap-2 text-base">
-    Leveringstid
-    <Toggletip>
-      <ToggletipTrigger
-        aria-label="Mer om leveringstid"
-        className="bg-blue-dark rounded-full px-2 py-0.5 text-sm text-white"
-      >
-        Hva betyr dette?
-      </ToggletipTrigger>
-      <ToggletipContent aria-label="Mer om leveringstid">
-        Leveringstid er antall virkedager fra bestilling til boligen er klar for innflytting.
-      </ToggletipContent>
-    </Toggletip>
-  </span>
-);
-
-/**
  * The popover positions itself relative to the trigger and flips automatically
  * when there isn't room. Use the `placement` prop to set a preferred side.
  */

--- a/packages/react/src/toggletip/toggletip.stories.tsx
+++ b/packages/react/src/toggletip/toggletip.stories.tsx
@@ -1,0 +1,102 @@
+import { InfoCircle } from '@obosbbl/grunnmuren-icons-react';
+import type { Meta } from '@storybook/react-vite';
+
+import {
+  UNSAFE_Toggletip as Toggletip,
+  UNSAFE_ToggletipContent as ToggletipContent,
+  UNSAFE_ToggletipTrigger as ToggletipTrigger,
+} from './toggletip';
+
+const meta = {
+  title: 'Toggletip',
+  component: Toggletip,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Toggletip>;
+
+export default meta;
+
+/**
+ * The `definition` variant renders an inline term with a dashed underline. It is
+ * meant for explaining a word in running text — clicking the term opens a small
+ * dialog with the explanation. The term is highlighted yellow while open.
+ */
+export const Definition = () => (
+  <p className="max-w-prose text-base">
+    Boligen selges som et{' '}
+    <Toggletip>
+      <ToggletipTrigger variant="definition">borettslag</ToggletipTrigger>
+      <ToggletipContent aria-label="Forklaring av borettslag">
+        Et borettslag er et selskap som eier en eller flere boligeiendommer, der du kjøper en andel
+        som gir deg borett til en bestemt bolig.
+      </ToggletipContent>
+    </Toggletip>
+    , og du kjøper derfor en andel framfor en selveierbolig.
+  </p>
+);
+
+/**
+ * The `default` variant is an icon button (44x44 click area). Pass the icon as
+ * children and remember an `aria-label`, since the button has no visible text.
+ */
+export const IconTrigger = () => (
+  <span className="inline-flex items-center gap-1 text-base">
+    Felleskostnader
+    <Toggletip>
+      <ToggletipTrigger aria-label="Mer om felleskostnader">
+        <InfoCircle />
+      </ToggletipTrigger>
+      <ToggletipContent aria-label="Mer om felleskostnader">
+        Felleskostnader dekker borettslagets felles utgifter, som vedlikehold, forsikring,
+        renovasjon og eventuell felles gjeld.
+      </ToggletipContent>
+    </Toggletip>
+  </span>
+);
+
+/**
+ * The popover positions itself relative to the trigger and flips automatically
+ * when there isn't room. Use the `placement` prop to set a preferred side.
+ */
+export const Placement = () => (
+  <div className="flex gap-8 text-base">
+    <Toggletip>
+      <ToggletipTrigger aria-label="Vis over">
+        <InfoCircle />
+      </ToggletipTrigger>
+      <ToggletipContent aria-label="Plassering over" placement="top">
+        Denne toggletippen foretrekker å åpne over triggeren.
+      </ToggletipContent>
+    </Toggletip>
+    <Toggletip>
+      <ToggletipTrigger aria-label="Vis til høyre">
+        <InfoCircle />
+      </ToggletipTrigger>
+      <ToggletipContent aria-label="Plassering til høyre" placement="right">
+        Denne toggletippen foretrekker å åpne til høyre for triggeren.
+      </ToggletipContent>
+    </Toggletip>
+  </div>
+);
+
+/**
+ * The content may include a link. Tabbing past the last focusable element closes
+ * the toggletip and returns focus to the trigger.
+ */
+export const WithLink = () => (
+  <p className="max-w-prose text-base">
+    Du kan lese mer om{' '}
+    <Toggletip>
+      <ToggletipTrigger variant="definition">andelsbolig</ToggletipTrigger>
+      <ToggletipContent aria-label="Forklaring av andelsbolig">
+        En andelsbolig er en bolig du eier gjennom en andel i et borettslag.{' '}
+        <a className="underline" href="https://www.obos.no" rel="noreferrer" target="_blank">
+          Les mer hos OBOS
+        </a>
+        .
+      </ToggletipContent>
+    </Toggletip>{' '}
+    på nettsidene våre.
+  </p>
+);

--- a/packages/react/src/toggletip/toggletip.stories.tsx
+++ b/packages/react/src/toggletip/toggletip.stories.tsx
@@ -37,19 +37,41 @@ export const Definition = () => (
 );
 
 /**
- * The `default` variant is an icon button (44x44 click area). Pass the icon as
+ * The `info` variant is an icon button (44x44 click area). Pass the icon as
  * children and remember an `aria-label`, since the button has no visible text.
  */
 export const IconTrigger = () => (
   <span className="inline-flex items-center gap-1 text-base">
     Felleskostnader
     <Toggletip>
-      <ToggletipTrigger aria-label="Mer om felleskostnader">
+      <ToggletipTrigger aria-label="Mer om felleskostnader" variant="info">
         <InfoCircle />
       </ToggletipTrigger>
       <ToggletipContent aria-label="Mer om felleskostnader">
         Felleskostnader dekker borettslagets felles utgifter, som vedlikehold, forsikring,
         renovasjon og eventuell felles gjeld.
+      </ToggletipContent>
+    </Toggletip>
+  </span>
+);
+
+/**
+ * Without a `variant`, `ToggletipTrigger` only carries the button behaviour and
+ * focus ring — the children and styling are entirely up to you. Here the trigger
+ * is a small custom-styled button.
+ */
+export const CustomTrigger = () => (
+  <span className="inline-flex items-center gap-2 text-base">
+    Leveringstid
+    <Toggletip>
+      <ToggletipTrigger
+        aria-label="Mer om leveringstid"
+        className="bg-blue-dark rounded-full px-2 py-0.5 text-sm text-white"
+      >
+        Hva betyr dette?
+      </ToggletipTrigger>
+      <ToggletipContent aria-label="Mer om leveringstid">
+        Leveringstid er antall virkedager fra bestilling til boligen er klar for innflytting.
       </ToggletipContent>
     </Toggletip>
   </span>
@@ -62,7 +84,7 @@ export const IconTrigger = () => (
 export const Placement = () => (
   <div className="flex gap-8 text-base">
     <Toggletip>
-      <ToggletipTrigger aria-label="Vis over">
+      <ToggletipTrigger aria-label="Vis over" variant="info">
         <InfoCircle />
       </ToggletipTrigger>
       <ToggletipContent aria-label="Plassering over" placement="top">
@@ -70,7 +92,7 @@ export const Placement = () => (
       </ToggletipContent>
     </Toggletip>
     <Toggletip>
-      <ToggletipTrigger aria-label="Vis til høyre">
+      <ToggletipTrigger aria-label="Vis til høyre" variant="info">
         <InfoCircle />
       </ToggletipTrigger>
       <ToggletipContent aria-label="Plassering til høyre" placement="right">

--- a/packages/react/src/toggletip/toggletip.stories.tsx
+++ b/packages/react/src/toggletip/toggletip.stories.tsx
@@ -100,3 +100,65 @@ export const WithLink = () => (
     på nettsidene våre.
   </p>
 );
+
+/**
+ * A `definition` toggletip placed roughly in the middle of a long running text
+ * (about 800px / 50rem tall), to check how the popover positions itself within a
+ * real document flow.
+ */
+export const InRunningText = () => (
+  <div className="max-w-prose text-base [&_p]:mb-4">
+    <p>
+      Å kjøpe sin første bolig er en av de største økonomiske beslutningene de fleste tar. Før du
+      legger inn bud, er det lurt å sette seg inn i hva slags eierform boligen har, hva
+      felleskostnadene dekker, og hvilke rettigheter og plikter som følger med. Eierformen påvirker
+      både prisen, finansieringen og hverdagen din som beboer.
+    </p>
+    <p>
+      I Norge er de to vanligste eierformene selveier og andel. En selveierbolig betyr at du eier
+      boligen din direkte, ofte som en seksjon i et eierseksjonssameie. Du står da fritt til å
+      selge, leie ut og pantsette boligen innenfor lovens rammer, og du betaler eiendomsskatt og
+      fellesutgifter til sameiet.
+    </p>
+    <p>
+      Boligen i dette eksempelet selges derimot som et{' '}
+      <Toggletip>
+        <ToggletipTrigger variant="definition">borettslag</ToggletipTrigger>
+        <ToggletipContent aria-label="Forklaring av borettslag">
+          Et borettslag er et selskap som eier en eller flere boligeiendommer, der du kjøper en
+          andel som gir deg borett til en bestemt bolig.
+        </ToggletipContent>
+      </Toggletip>
+      . Det betyr at du kjøper en andel i selskapet framfor selve boligen, og at andelen gir deg
+      rett til å bo i en bestemt leilighet. Denne forskjellen har betydning både for hvordan kjøpet
+      finansieres og for hvilke avgjørelser fellesskapet tar sammen.
+    </p>
+    <p>
+      Mange borettslag har det som kalles fellesgjeld. Det er lån som hele laget står ansvarlig for,
+      og din andel av denne gjelda betjenes gjennom de månedlige felleskostnadene. Prisen du ser i
+      en annonse, er gjerne innskuddet — det du faktisk betaler for andelen — mens den totale prisen
+      også inkluderer din andel av fellesgjelda. Det er derfor viktig å se på begge tallene når du
+      sammenligner boliger.
+    </p>
+    <p>
+      Felleskostnadene varierer mye fra lag til lag. De dekker som regel vedlikehold av
+      fellesarealer, forsikring av bygningene, renovasjon, og ofte oppvarming og vann. I noen lag
+      inngår også kabel-TV og internett. En lav felleskostnad er ikke nødvendigvis et godt tegn
+      dersom laget har et stort vedlikeholdsetterslep, for da kan kostnadene øke betydelig i årene
+      som kommer.
+    </p>
+    <p>
+      Før du kjøper, bør du lese gjennom årsregnskapet, vedtektene og eventuelle referater fra
+      generalforsamlingen. Disse dokumentene forteller mye om økonomien i laget, planlagte
+      prosjekter og hvordan fellesskapet fungerer. En godt drevet forening med en sunn økonomi gir
+      trygghet og forutsigbarhet, mens et lag med dårlig vedlikehold og høy gjeld kan gi ubehagelige
+      overraskelser.
+    </p>
+    <p>
+      Til slutt er det verdt å huske at du som andelseier også får et ansvar. Du deltar på
+      generalforsamlingen, er med på å bestemme hvordan laget skal driftes, og bidrar til
+      fellesskapet. For mange er nettopp dette en av fordelene med å bo i borettslag: du står ikke
+      alene om de store avgjørelsene, og vedlikeholdet av bygningene er et felles ansvar.
+    </p>
+  </div>
+);

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -1,6 +1,6 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import {
   Button as RACButton,
   type ButtonProps as RACButtonProps,
@@ -50,43 +50,6 @@ const ToggletipTrigger = ({ variant, className, ...restProps }: ToggletipTrigger
   />
 );
 
-const TABBABLE_SELECTOR =
-  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
-const useTabToClose = (close: () => void) => {
-  const dialogRef = useRef<HTMLElement>(null);
-
-  // RAC's Dialog focuses the dialog container; move focus to the close button.
-  useEffect(() => {
-    dialogRef.current?.querySelector<HTMLButtonElement>('button')?.focus();
-  }, []);
-
-  // Tab from the last element should close, not loop. RAC's FocusScope contains
-  // focus via a keydown listener on `document`; ours runs first (on the dialog)
-  // and stops propagation so it never reaches FocusScope.
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) {
-      return;
-    }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Tab' || event.shiftKey) {
-        return;
-      }
-      const tabbables = dialog.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
-      if (document.activeElement === tabbables[tabbables.length - 1]) {
-        event.preventDefault();
-        event.stopPropagation();
-        close();
-      }
-    };
-    dialog.addEventListener('keydown', handleKeyDown);
-    return () => dialog.removeEventListener('keydown', handleKeyDown);
-  }, [close]);
-
-  return dialogRef;
-};
-
 type ToggletipContentProps = Omit<RACPopoverProps, 'children'> & {
   /** Accessible label for the dialog. Required, since the content has no heading. */
   'aria-label': string;
@@ -99,16 +62,21 @@ const ToggletipDialog = ({
 }: Pick<ToggletipContentProps, 'aria-label' | 'children'>) => {
   const locale = useLocale();
   const state = useContext(OverlayTriggerStateContext);
-  const close = useCallback(() => state?.close(), [state]);
-  const dialogRef = useTabToClose(close);
+  const closeButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+
+  // RAC's Dialog focuses the dialog container; move focus to the close button.
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
   return (
-    <RACDialog aria-label={ariaLabel} data-slot="toggletip-dialog" ref={dialogRef}>
-      {/* First in the DOM so useTabToClose focuses it on open. */}
+    <RACDialog aria-label={ariaLabel} data-slot="toggletip-dialog">
       <Button
         aria-label={translations.close[locale]}
         color="white"
         isIconOnly
-        onPress={close}
+        onPress={() => state?.close()}
+        ref={closeButtonRef}
         variant="tertiary"
       >
         <Close />

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -34,27 +34,26 @@ const Toggletip = (props: ToggletipProps) => <RACDialogTrigger {...props} />;
 type ToggletipTriggerProps = Omit<RACButtonProps, 'children' | 'className'> & {
   children: React.ReactNode;
   /**
-   * Visual style of the trigger. `default` is a 44x44 icon button (pass the
-   * icon as children); `definition` is an inline term with a dashed underline.
-   * @default default
+   * Optional visual preset for the trigger:
+   * - `definition` — an inline term with a dashed underline, highlighted yellow
+   *   while the toggletip is open.
+   * - `info` — a 44x44 icon button (pass the icon as children).
+   *
+   * When omitted, the trigger only carries the base button behaviour and focus
+   * ring — the appearance and children are entirely up to the consumer. The
+   * value is exposed as `data-variant` for styling.
    */
-  variant?: 'default' | 'definition';
+  variant?: 'definition' | 'info';
   /** Additional class name for the trigger button. */
   className?: string;
 };
 
 /**
  * The button that toggles the toggletip. Always a `<button>` (toggling a dialog
- * is an action, not navigation). The `default` variant is an icon button and
- * needs an `aria-label`; the `definition` variant renders its children as an
- * inline, dashed-underlined term. The variant is exposed as `data-variant` for
- * styling.
+ * is an action, not navigation), and needs an accessible name — `aria-label`
+ * for an icon, or the visible text for a definition term.
  */
-const ToggletipTrigger = ({
-  variant = 'default',
-  className,
-  ...restProps
-}: ToggletipTriggerProps) => (
+const ToggletipTrigger = ({ variant, className, ...restProps }: ToggletipTriggerProps) => (
   <RACButton
     {...restProps}
     className={cx('gm-toggletip-trigger', className)}

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -48,10 +48,12 @@ const ToggletipTrigger = ({ variant, className, ...restProps }: ToggletipTrigger
   />
 );
 
-type ToggletipContentProps = Omit<RACPopoverProps, 'children'> & {
+type ToggletipContentProps = Omit<RACPopoverProps, 'children' | 'className'> & {
   /** Accessible label for the dialog. Required, since the content has no heading. */
   'aria-label': string;
   children: React.ReactNode;
+  /** Additional class name for the popover. */
+  className?: string;
 };
 
 /** The popover content of the toggletip: a `Dialog` (with `aria-label`) and a close button. */
@@ -63,11 +65,7 @@ const ToggletipContent = ({
 }: ToggletipContentProps) => {
   const locale = useLocale();
   return (
-    <RACPopover
-      {...restProps}
-      className={cx('gm-toggletip', className as string | undefined)}
-      offset={8}
-    >
+    <RACPopover {...restProps} className={cx('gm-toggletip', className)} offset={8}>
       <RACOverlayArrow data-slot="toggletip-arrow">
         <svg height={8} viewBox="0 0 16 8" width={16}>
           <path d="M0 8 L8 0 L16 8 Z" />

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -1,0 +1,208 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
+import { cva, cx, type VariantProps } from 'cva';
+import { useCallback, useContext, useEffect, useRef } from 'react';
+import {
+  Button as RACButton,
+  type ButtonProps as RACButtonProps,
+} from 'react-aria-components/Button';
+import {
+  Dialog as RACDialog,
+  DialogTrigger as RACDialogTrigger,
+  type DialogTriggerProps as RACDialogTriggerProps,
+  OverlayTriggerStateContext,
+} from 'react-aria-components/Dialog';
+import {
+  OverlayArrow as RACOverlayArrow,
+  Popover as RACPopover,
+  type PopoverProps as RACPopoverProps,
+} from 'react-aria-components/Popover';
+
+import { Button } from '../button';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
+
+type ToggletipProps = RACDialogTriggerProps;
+
+/**
+ * Root of the toggletip. Wraps a `<ToggletipTrigger>` and a `<ToggletipContent>`,
+ * and manages the open/close state. Only one toggletip can be open at a time:
+ * opening another (or clicking anywhere outside) dismisses the current one,
+ * which comes for free from the underlying popover's click-outside behaviour.
+ */
+const Toggletip = (props: ToggletipProps) => <RACDialogTrigger {...props} />;
+
+const triggerVariants = cva({
+  base: ['cursor-pointer outline-none', 'data-focus-visible:outline-focus-offset'],
+  variants: {
+    /**
+     * - `default`: a 44x44 icon button (pass the icon as children).
+     * - `definition`: an inline term with a dashed underline, highlighted
+     *   yellow while the toggletip is open.
+     * @default default
+     */
+    variant: {
+      default:
+        'text-blue-dark inline-grid size-11 place-content-center rounded-full [&>svg]:size-6',
+      definition:
+        'aria-expanded:bg-yellow rounded-xs underline decoration-dashed decoration-1 underline-offset-4',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+type ToggletipTriggerProps = Omit<RACButtonProps, 'children' | 'className'> &
+  VariantProps<typeof triggerVariants> & {
+    children: React.ReactNode;
+    /** Additional class name for the trigger button. */
+    className?: string;
+  };
+
+/**
+ * The button that toggles the toggletip. Always a `<button>` (toggling a dialog
+ * is an action, not navigation). The `default` variant is an icon button and
+ * needs an `aria-label`; the `definition` variant renders its children as an
+ * inline, dashed-underlined term.
+ */
+const ToggletipTrigger = ({
+  variant = 'default',
+  className,
+  ...restProps
+}: ToggletipTriggerProps) => (
+  <RACButton
+    {...restProps}
+    className={cx(triggerVariants({ variant }), className)}
+    data-variant={variant}
+  />
+);
+
+// Matches the elements RAC's FocusScope considers tabbable, so we can detect
+// when focus is on the last one.
+const TABBABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * RAC's `Dialog` wraps its content in a `FocusScope` that contains focus —
+ * `Tab` from the last element loops back to the first. For a toggletip we want
+ * the opposite: tabbing past the content dismisses it and returns focus to the
+ * trigger. FocusScope handles `Tab` via a `keydown` listener on `document` in
+ * the bubble phase. We attach our own listener on the dialog element (a
+ * descendant of `document`, so it fires first) and `stopPropagation()` to keep
+ * the event from reaching FocusScope — letting us close instead of looping.
+ */
+const useTabToClose = (close: () => void) => {
+  const dialogRef = useRef<HTMLElement>(null);
+
+  // RAC's Dialog moves initial focus to the dialog container. The spec wants
+  // the close button focused instead, so we move it there once on open. It's
+  // the first button in the dialog.
+  useEffect(() => {
+    dialogRef.current?.querySelector<HTMLButtonElement>('button')?.focus();
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || event.shiftKey) {
+        return;
+      }
+      const tabbables = dialog.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
+      const last = tabbables[tabbables.length - 1];
+      if (last && document.activeElement === last) {
+        event.preventDefault();
+        event.stopPropagation();
+        close();
+      }
+    };
+    dialog.addEventListener('keydown', handleKeyDown);
+    return () => dialog.removeEventListener('keydown', handleKeyDown);
+  }, [close]);
+  return dialogRef;
+};
+
+type ToggletipContentProps = Omit<RACPopoverProps, 'children'> & {
+  /** Accessible label for the dialog. Required, since the content is informational and has no heading. */
+  'aria-label': string;
+  children: React.ReactNode;
+};
+
+/**
+ * The dialog inside the popover. Reads the overlay state from context to wire up
+ * the close button and the tab-to-close handler. Split out from
+ * `ToggletipContent` so it can consume the context the `Popover` provides.
+ */
+const ToggletipDialog = ({
+  'aria-label': ariaLabel,
+  children,
+}: Pick<ToggletipContentProps, 'aria-label' | 'children'>) => {
+  const locale = useLocale();
+  const state = useContext(OverlayTriggerStateContext);
+  const close = useCallback(() => state?.close(), [state]);
+  // Tab from the last focusable element closes instead of looping (see useTabToClose).
+  const dialogRef = useTabToClose(close);
+  return (
+    <RACDialog
+      aria-label={ariaLabel}
+      className="bg-blue-dark relative rounded-lg p-4 pr-12 text-white outline-none"
+      ref={dialogRef}
+    >
+      {/* Rendered first so it's the close button useTabToClose focuses on open. */}
+      <Button
+        aria-label={translations.close[locale]}
+        className="absolute top-1 right-1"
+        color="white"
+        isIconOnly
+        onPress={close}
+        variant="tertiary"
+      >
+        <Close />
+      </Button>
+      {children}
+    </RACDialog>
+  );
+};
+
+/**
+ * The popover content of the toggletip. Renders a `Dialog` (with `aria-label`)
+ * inside a `Popover`, plus a close button that receives initial focus when the
+ * toggletip opens.
+ */
+const ToggletipContent = ({
+  'aria-label': ariaLabel,
+  children,
+  className,
+  ...restProps
+}: ToggletipContentProps) => (
+  <RACPopover
+    {...restProps}
+    className={cx(
+      'max-w-72', // 288px
+      'data-entering:fade-in data-exiting:fade-out data-entering:animate-in data-exiting:animate-out motion-reduce:animate-none',
+      className as string | undefined,
+    )}
+    // 8px gap between the trigger and the popover.
+    offset={8}
+  >
+    {/* The arrow points up by default (placement bottom); rotate it to point at
+        the trigger for the other placements. */}
+    <RACOverlayArrow className="data-[placement=left]:[&>svg]:rotate-90 data-[placement=right]:[&>svg]:-rotate-90 data-[placement=top]:[&>svg]:rotate-180">
+      <svg className="fill-blue-dark block" height={8} viewBox="0 0 16 8" width={16}>
+        <path d="M0 8 L8 0 L16 8 Z" />
+      </svg>
+    </RACOverlayArrow>
+    <ToggletipDialog aria-label={ariaLabel}>{children}</ToggletipDialog>
+  </RACPopover>
+);
+
+export {
+  Toggletip as UNSAFE_Toggletip,
+  ToggletipContent as UNSAFE_ToggletipContent,
+  ToggletipTrigger as UNSAFE_ToggletipTrigger,
+  type ToggletipContentProps as UNSAFE_ToggletipContentProps,
+  type ToggletipProps as UNSAFE_ToggletipProps,
+  type ToggletipTriggerProps as UNSAFE_ToggletipTriggerProps,
+};

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -66,11 +66,7 @@ const ToggletipContent = ({
   const locale = useLocale();
   return (
     <RACPopover {...restProps} className={cx('gm-toggletip', className)} offset={8}>
-      <RACOverlayArrow data-slot="toggletip-arrow">
-        <svg height={8} viewBox="0 0 16 8" width={16}>
-          <path d="M0 8 L8 0 L16 8 Z" />
-        </svg>
-      </RACOverlayArrow>
+      <RACOverlayArrow data-slot="toggletip-arrow" />
       <RACDialog aria-label={ariaLabel} data-slot="toggletip-dialog">
         {({ close }) => (
           <>

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -1,5 +1,5 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
-import { cva, cx, type VariantProps } from 'cva';
+import { cx } from 'cva';
 import { useCallback, useContext, useEffect, useRef } from 'react';
 import {
   Button as RACButton,
@@ -31,39 +31,24 @@ type ToggletipProps = RACDialogTriggerProps;
  */
 const Toggletip = (props: ToggletipProps) => <RACDialogTrigger {...props} />;
 
-const triggerVariants = cva({
-  base: ['cursor-pointer', 'data-focus-visible:outline-focus-offset'],
-  variants: {
-    /**
-     * - `default`: a 44x44 icon button (pass the icon as children).
-     * - `definition`: an inline term with a dashed underline, highlighted
-     *   yellow while the toggletip is open.
-     * @default default
-     */
-    variant: {
-      default:
-        'text-blue-dark inline-grid size-11 place-content-center rounded-full [&>svg]:size-6',
-      definition:
-        'aria-expanded:bg-yellow rounded-xs underline decoration-dashed decoration-1 underline-offset-4',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
-
-type ToggletipTriggerProps = Omit<RACButtonProps, 'children' | 'className'> &
-  VariantProps<typeof triggerVariants> & {
-    children: React.ReactNode;
-    /** Additional class name for the trigger button. */
-    className?: string;
-  };
+type ToggletipTriggerProps = Omit<RACButtonProps, 'children' | 'className'> & {
+  children: React.ReactNode;
+  /**
+   * Visual style of the trigger. `default` is a 44x44 icon button (pass the
+   * icon as children); `definition` is an inline term with a dashed underline.
+   * @default default
+   */
+  variant?: 'default' | 'definition';
+  /** Additional class name for the trigger button. */
+  className?: string;
+};
 
 /**
  * The button that toggles the toggletip. Always a `<button>` (toggling a dialog
  * is an action, not navigation). The `default` variant is an icon button and
  * needs an `aria-label`; the `definition` variant renders its children as an
- * inline, dashed-underlined term.
+ * inline, dashed-underlined term. The variant is exposed as `data-variant` for
+ * styling.
  */
 const ToggletipTrigger = ({
   variant = 'default',
@@ -72,7 +57,7 @@ const ToggletipTrigger = ({
 }: ToggletipTriggerProps) => (
   <RACButton
     {...restProps}
-    className={cx(triggerVariants({ variant }), className)}
+    className={cx('gm-toggletip-trigger', className)}
     data-variant={variant}
   />
 );
@@ -145,17 +130,10 @@ const ToggletipDialog = ({
   // Tab from the last focusable element closes instead of looping (see useTabToClose).
   const dialogRef = useTabToClose(close);
   return (
-    <RACDialog
-      aria-label={ariaLabel}
-      className="bg-blue-dark relative rounded-lg p-4 pr-12 text-white outline-none"
-      ref={dialogRef}
-    >
+    <RACDialog aria-label={ariaLabel} data-slot="toggletip-dialog" ref={dialogRef}>
       {/* Rendered first so it's the close button useTabToClose focuses on open. */}
       <Button
         aria-label={translations.close[locale]}
-        // Inset focus ring (white from color="white") so it sits inside the
-        // button, clear of the popover edge.
-        className="absolute top-1 right-1 focus-visible:-outline-offset-4!"
         color="white"
         isIconOnly
         onPress={close}
@@ -181,18 +159,11 @@ const ToggletipContent = ({
 }: ToggletipContentProps) => (
   <RACPopover
     {...restProps}
-    className={cx(
-      'max-w-72', // 288px
-      'data-entering:fade-in data-exiting:fade-out data-entering:animate-in data-exiting:animate-out motion-reduce:animate-none',
-      className as string | undefined,
-    )}
-    // 8px gap between the trigger and the popover.
+    className={cx('gm-toggletip', className as string | undefined)}
     offset={8}
   >
-    {/* The arrow points up by default (placement bottom); rotate it to point at
-        the trigger for the other placements. */}
-    <RACOverlayArrow className="data-[placement=left]:[&>svg]:rotate-90 data-[placement=right]:[&>svg]:-rotate-90 data-[placement=top]:[&>svg]:rotate-180">
-      <svg className="fill-blue-dark block" height={8} viewBox="0 0 16 8" width={16}>
+    <RACOverlayArrow data-slot="toggletip-arrow">
+      <svg height={8} viewBox="0 0 16 8" width={16}>
         <path d="M0 8 L8 0 L16 8 Z" />
       </svg>
     </RACOverlayArrow>

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -23,25 +23,15 @@ import { useLocale } from '../use-locale';
 
 type ToggletipProps = RACDialogTriggerProps;
 
-/**
- * Root of the toggletip. Wraps a `<ToggletipTrigger>` and a `<ToggletipContent>`,
- * and manages the open/close state. Only one toggletip can be open at a time:
- * opening another (or clicking anywhere outside) dismisses the current one,
- * which comes for free from the underlying popover's click-outside behaviour.
- */
+/** Root of the toggletip. Wraps a `<ToggletipTrigger>` and a `<ToggletipContent>`. */
 const Toggletip = (props: ToggletipProps) => <RACDialogTrigger {...props} />;
 
 type ToggletipTriggerProps = Omit<RACButtonProps, 'children' | 'className'> & {
   children: React.ReactNode;
   /**
-   * Optional visual preset for the trigger:
-   * - `definition` — an inline term with a dashed underline, highlighted yellow
-   *   while the toggletip is open.
-   * - `info` — a 44x44 icon button (pass the icon as children).
-   *
-   * When omitted, the trigger only carries the base button behaviour and focus
-   * ring — the appearance and children are entirely up to the consumer. The
-   * value is exposed as `data-variant` for styling.
+   * Visual preset: `definition` (an inline, dashed-underlined term) or `info`
+   * (a 44x44 icon button). Omit it to style the trigger yourself — children and
+   * appearance are then up to you.
    */
   variant?: 'definition' | 'info';
   /** Additional class name for the trigger button. */
@@ -49,8 +39,7 @@ type ToggletipTriggerProps = Omit<RACButtonProps, 'children' | 'className'> & {
 };
 
 /**
- * The button that toggles the toggletip. Always a `<button>` (toggling a dialog
- * is an action, not navigation), and needs an accessible name — `aria-label`
+ * The button that toggles the toggletip. Needs an accessible name — `aria-label`
  * for an icon, or the visible text for a definition term.
  */
 const ToggletipTrigger = ({ variant, className, ...restProps }: ToggletipTriggerProps) => (
@@ -61,30 +50,20 @@ const ToggletipTrigger = ({ variant, className, ...restProps }: ToggletipTrigger
   />
 );
 
-// Matches the elements RAC's FocusScope considers tabbable, so we can detect
-// when focus is on the last one.
 const TABBABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-/**
- * RAC's `Dialog` wraps its content in a `FocusScope` that contains focus —
- * `Tab` from the last element loops back to the first. For a toggletip we want
- * the opposite: tabbing past the content dismisses it and returns focus to the
- * trigger. FocusScope handles `Tab` via a `keydown` listener on `document` in
- * the bubble phase. We attach our own listener on the dialog element (a
- * descendant of `document`, so it fires first) and `stopPropagation()` to keep
- * the event from reaching FocusScope — letting us close instead of looping.
- */
 const useTabToClose = (close: () => void) => {
   const dialogRef = useRef<HTMLElement>(null);
 
-  // RAC's Dialog moves initial focus to the dialog container. The spec wants
-  // the close button focused instead, so we move it there once on open. It's
-  // the first button in the dialog.
+  // RAC's Dialog focuses the dialog container; move focus to the close button.
   useEffect(() => {
     dialogRef.current?.querySelector<HTMLButtonElement>('button')?.focus();
   }, []);
 
+  // Tab from the last element should close, not loop. RAC's FocusScope contains
+  // focus via a keydown listener on `document`; ours runs first (on the dialog)
+  // and stops propagation so it never reaches FocusScope.
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) {
@@ -95,8 +74,7 @@ const useTabToClose = (close: () => void) => {
         return;
       }
       const tabbables = dialog.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
-      const last = tabbables[tabbables.length - 1];
-      if (last && document.activeElement === last) {
+      if (document.activeElement === tabbables[tabbables.length - 1]) {
         event.preventDefault();
         event.stopPropagation();
         close();
@@ -105,20 +83,16 @@ const useTabToClose = (close: () => void) => {
     dialog.addEventListener('keydown', handleKeyDown);
     return () => dialog.removeEventListener('keydown', handleKeyDown);
   }, [close]);
+
   return dialogRef;
 };
 
 type ToggletipContentProps = Omit<RACPopoverProps, 'children'> & {
-  /** Accessible label for the dialog. Required, since the content is informational and has no heading. */
+  /** Accessible label for the dialog. Required, since the content has no heading. */
   'aria-label': string;
   children: React.ReactNode;
 };
 
-/**
- * The dialog inside the popover. Reads the overlay state from context to wire up
- * the close button and the tab-to-close handler. Split out from
- * `ToggletipContent` so it can consume the context the `Popover` provides.
- */
 const ToggletipDialog = ({
   'aria-label': ariaLabel,
   children,
@@ -126,11 +100,10 @@ const ToggletipDialog = ({
   const locale = useLocale();
   const state = useContext(OverlayTriggerStateContext);
   const close = useCallback(() => state?.close(), [state]);
-  // Tab from the last focusable element closes instead of looping (see useTabToClose).
   const dialogRef = useTabToClose(close);
   return (
     <RACDialog aria-label={ariaLabel} data-slot="toggletip-dialog" ref={dialogRef}>
-      {/* Rendered first so it's the close button useTabToClose focuses on open. */}
+      {/* First in the DOM so useTabToClose focuses it on open. */}
       <Button
         aria-label={translations.close[locale]}
         color="white"
@@ -145,11 +118,7 @@ const ToggletipDialog = ({
   );
 };
 
-/**
- * The popover content of the toggletip. Renders a `Dialog` (with `aria-label`)
- * inside a `Popover`, plus a close button that receives initial focus when the
- * toggletip opens.
- */
+/** The popover content of the toggletip: a `Dialog` (with `aria-label`) and a close button. */
 const ToggletipContent = ({
   'aria-label': ariaLabel,
   children,

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -1,6 +1,5 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { useContext, useEffect, useRef } from 'react';
 import {
   Button as RACButton,
   type ButtonProps as RACButtonProps,
@@ -9,7 +8,6 @@ import {
   Dialog as RACDialog,
   DialogTrigger as RACDialogTrigger,
   type DialogTriggerProps as RACDialogTriggerProps,
-  OverlayTriggerStateContext,
 } from 'react-aria-components/Dialog';
 import {
   OverlayArrow as RACOverlayArrow,
@@ -56,56 +54,44 @@ type ToggletipContentProps = Omit<RACPopoverProps, 'children'> & {
   children: React.ReactNode;
 };
 
-const ToggletipDialog = ({
-  'aria-label': ariaLabel,
-  children,
-}: Pick<ToggletipContentProps, 'aria-label' | 'children'>) => {
-  const locale = useLocale();
-  const state = useContext(OverlayTriggerStateContext);
-  const closeButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
-
-  // RAC's Dialog focuses the dialog container; move focus to the close button.
-  useEffect(() => {
-    closeButtonRef.current?.focus();
-  }, []);
-
-  return (
-    <RACDialog aria-label={ariaLabel} data-slot="toggletip-dialog">
-      <Button
-        aria-label={translations.close[locale]}
-        color="white"
-        isIconOnly
-        onPress={() => state?.close()}
-        ref={closeButtonRef}
-        variant="tertiary"
-      >
-        <Close />
-      </Button>
-      {children}
-    </RACDialog>
-  );
-};
-
 /** The popover content of the toggletip: a `Dialog` (with `aria-label`) and a close button. */
 const ToggletipContent = ({
   'aria-label': ariaLabel,
   children,
   className,
   ...restProps
-}: ToggletipContentProps) => (
-  <RACPopover
-    {...restProps}
-    className={cx('gm-toggletip', className as string | undefined)}
-    offset={8}
-  >
-    <RACOverlayArrow data-slot="toggletip-arrow">
-      <svg height={8} viewBox="0 0 16 8" width={16}>
-        <path d="M0 8 L8 0 L16 8 Z" />
-      </svg>
-    </RACOverlayArrow>
-    <ToggletipDialog aria-label={ariaLabel}>{children}</ToggletipDialog>
-  </RACPopover>
-);
+}: ToggletipContentProps) => {
+  const locale = useLocale();
+  return (
+    <RACPopover
+      {...restProps}
+      className={cx('gm-toggletip', className as string | undefined)}
+      offset={8}
+    >
+      <RACOverlayArrow data-slot="toggletip-arrow">
+        <svg height={8} viewBox="0 0 16 8" width={16}>
+          <path d="M0 8 L8 0 L16 8 Z" />
+        </svg>
+      </RACOverlayArrow>
+      <RACDialog aria-label={ariaLabel} data-slot="toggletip-dialog">
+        {({ close }) => (
+          <>
+            <Button
+              aria-label={translations.close[locale]}
+              color="white"
+              isIconOnly
+              onPress={close}
+              variant="tertiary"
+            >
+              <Close />
+            </Button>
+            {children}
+          </>
+        )}
+      </RACDialog>
+    </RACPopover>
+  );
+};
 
 export {
   Toggletip as UNSAFE_Toggletip,

--- a/packages/react/src/toggletip/toggletip.tsx
+++ b/packages/react/src/toggletip/toggletip.tsx
@@ -32,7 +32,7 @@ type ToggletipProps = RACDialogTriggerProps;
 const Toggletip = (props: ToggletipProps) => <RACDialogTrigger {...props} />;
 
 const triggerVariants = cva({
-  base: ['cursor-pointer outline-none', 'data-focus-visible:outline-focus-offset'],
+  base: ['cursor-pointer', 'data-focus-visible:outline-focus-offset'],
   variants: {
     /**
      * - `default`: a 44x44 icon button (pass the icon as children).
@@ -153,7 +153,9 @@ const ToggletipDialog = ({
       {/* Rendered first so it's the close button useTabToClose focuses on open. */}
       <Button
         aria-label={translations.close[locale]}
-        className="absolute top-1 right-1"
+        // Inset focus ring (white from color="white") so it sits inside the
+        // button, clear of the popover edge.
+        className="absolute top-1 right-1 focus-visible:-outline-offset-4!"
         color="white"
         isIconOnly
         onPress={close}

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -379,9 +379,13 @@
     @apply outline-focus-offset;
   }
 
-  /* Info variant — a 44×44 icon button. */
+  /* Info variant — a 44×44 icon button with an inset focus ring. */
   &[data-variant='info'] {
     @apply text-blue-dark inline-grid size-11 place-content-center rounded-full;
+
+    &[data-focus-visible] {
+      @apply outline-focus-inset;
+    }
 
     & > svg {
       @apply size-6;

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -379,8 +379,8 @@
     @apply outline-focus-offset;
   }
 
-  /* Icon-button variant — 44×44 click area. */
-  &[data-variant='default'] {
+  /* Info variant — a 44×44 icon button. */
+  &[data-variant='info'] {
     @apply text-blue-dark inline-grid size-11 place-content-center rounded-full;
 
     & > svg {

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -418,18 +418,25 @@
     @apply fade-out animate-out;
   }
 
-  /* The arrow points up by default (placement bottom); rotate it to point at
-     the trigger for the other placements. */
-  & [data-slot='toggletip-arrow'] > svg {
-    @apply fill-blue-dark block;
+  /* Arrow drawn in CSS (no inline SVG). A 16x8 triangle that points up by
+     default (placement bottom), rotated to point at the trigger for the other
+     placements. */
+  & [data-slot='toggletip-arrow'] {
+    @apply h-2 w-4;
+
+    &::before {
+      content: '';
+      @apply bg-blue-dark block size-full;
+      clip-path: polygon(0 100%, 50% 0, 100% 100%);
+    }
   }
-  & [data-slot='toggletip-arrow'][data-placement='top'] > svg {
+  & [data-slot='toggletip-arrow'][data-placement='top']::before {
     @apply rotate-180;
   }
-  & [data-slot='toggletip-arrow'][data-placement='left'] > svg {
+  & [data-slot='toggletip-arrow'][data-placement='left']::before {
     @apply rotate-90;
   }
-  & [data-slot='toggletip-arrow'][data-placement='right'] > svg {
+  & [data-slot='toggletip-arrow'][data-placement='right']::before {
     @apply -rotate-90;
   }
 

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -418,26 +418,32 @@
     @apply fade-out animate-out;
   }
 
-  /* Arrow drawn in CSS (no inline SVG). A 16x8 triangle that points up by
-     default (placement bottom), rotated to point at the trigger for the other
-     placements. */
+  /* Arrow drawn in CSS (no inline SVG). The element is sized per orientation
+     and the ::before is clipped to a triangle pointing at the trigger. Default
+     is placement=bottom (popover below the trigger, arrow points up). */
   & [data-slot='toggletip-arrow'] {
     @apply h-2 w-4;
 
     &::before {
       content: '';
       @apply bg-blue-dark block size-full;
-      clip-path: polygon(0 100%, 50% 0, 100% 100%);
+      clip-path: polygon(0 100%, 50% 0, 100% 100%); /* points up */
     }
   }
   & [data-slot='toggletip-arrow'][data-placement='top']::before {
-    @apply rotate-180;
+    clip-path: polygon(0 0, 50% 100%, 100% 0); /* points down */
+  }
+  /* Side placements: swap the box to 8x16 so the triangle base sits flush
+     against the popover edge (no gap). */
+  & [data-slot='toggletip-arrow'][data-placement='left'],
+  & [data-slot='toggletip-arrow'][data-placement='right'] {
+    @apply h-4 w-2;
   }
   & [data-slot='toggletip-arrow'][data-placement='left']::before {
-    @apply rotate-90;
+    clip-path: polygon(0 0, 100% 50%, 0 100%); /* points right */
   }
   & [data-slot='toggletip-arrow'][data-placement='right']::before {
-    @apply -rotate-90;
+    clip-path: polygon(100% 0, 0 50%, 100% 100%); /* points left */
   }
 
   /* Dialog body. */

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -404,7 +404,10 @@
 }
 
 @utility gm-toggletip {
-  @apply max-w-72; /* 288px */
+  /* Cap at the 288px design max, but never wider than the viewport (minus
+     12px each side) on narrow screens — RAC keeps the popover on-screen but
+     doesn't shrink its width. */
+  max-width: min(18rem, 100vw - 1.5rem);
   @apply motion-reduce:animate-none;
 
   &[data-entering] {

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -367,6 +367,81 @@
   }
 }
 
+/*** Toggletip component styles
+ *
+ * Like Pagination, these sit in the utilities layer because the close button is
+ * a Button whose cva-generated focus utility (outline-offset) we override — and
+ * rules in the components layer always lose the cascade to utilities. */
+@utility gm-toggletip-trigger {
+  @apply cursor-pointer;
+
+  &[data-focus-visible] {
+    @apply outline-focus-offset;
+  }
+
+  /* Icon-button variant — 44×44 click area. */
+  &[data-variant='default'] {
+    @apply text-blue-dark inline-grid size-11 place-content-center rounded-full;
+
+    & > svg {
+      @apply size-6;
+    }
+  }
+
+  /* Definition variant — an inline term with a dashed underline, highlighted
+     yellow while the toggletip is open. */
+  &[data-variant='definition'] {
+    @apply rounded-xs underline decoration-dashed decoration-1 underline-offset-4;
+
+    &[aria-expanded='true'] {
+      @apply bg-yellow;
+    }
+  }
+}
+
+@utility gm-toggletip {
+  @apply max-w-72; /* 288px */
+  @apply motion-reduce:animate-none;
+
+  &[data-entering] {
+    @apply fade-in animate-in;
+  }
+
+  &[data-exiting] {
+    @apply fade-out animate-out;
+  }
+
+  /* The arrow points up by default (placement bottom); rotate it to point at
+     the trigger for the other placements. */
+  & [data-slot='toggletip-arrow'] > svg {
+    @apply fill-blue-dark block;
+  }
+  & [data-slot='toggletip-arrow'][data-placement='top'] > svg {
+    @apply rotate-180;
+  }
+  & [data-slot='toggletip-arrow'][data-placement='left'] > svg {
+    @apply rotate-90;
+  }
+  & [data-slot='toggletip-arrow'][data-placement='right'] > svg {
+    @apply -rotate-90;
+  }
+
+  /* Dialog body. */
+  & [data-slot='toggletip-dialog'] {
+    @apply bg-blue-dark relative rounded-lg p-4 pr-12 text-white outline-none;
+  }
+
+  /* Close button — positioned top-right with an inset white focus ring (white
+     from color="white") so it sits inside the button, clear of the popover edge. */
+  & [data-slot='toggletip-dialog'] > [data-slot='button'] {
+    @apply absolute top-1 right-1;
+
+    &:focus-visible {
+      @apply -outline-offset-4;
+    }
+  }
+}
+
 /** Hides the scrollbar visually */
 @utility scrollbar-hidden {
   /* For IE, Edge and Firefox */


### PR DESCRIPTION
### Oppsummering

Det er behov fo en komponent som kan forklare et begrep i en liten popover — typisk en definisjonslenke i løpende tekst. En toggletip ser ut som en tooltip, men oppfører seg som en liten dialog, så den fungerer også på touch (i motsetning til en ren hover-tooltip). Komponenten legges til som beta (`UNSAFE_`-prefiks). Løser [AB#140905](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/140905).

### Endringer

- Ny komponent `UNSAFE_Toggletip` i `packages/react/src/toggletip/`, bygget på `DialogTrigger` + `Popover` + `Dialog` fra React Aria Components. Den gir focus scope, lukking med `Escape`, lukking ved klikk utenfor og touch-støtte ut av boksen.
- Komponenten består av tre deler: `Toggletip` (rot som styrer åpne/lukke-tilstand), `ToggletipTrigger` (knappen som åpner) og `ToggletipContent` (selve popover-innholdet).
- `ToggletipTrigger` har en valgfri `variant`-prop som settes som `data-variant` på knappen: `definition` er et inline-begrep med stiplet underlinje som får gul bakgrunn når toggletippen er åpen, og `info` er en 44x44 ikonknapp. Utelates `variant`, får triggeren kun basis-oppførsel og fokusring — children og styling er da helt opp til konsumenten.
- Popover-en har `blue-dark` bakgrunn, maks bredde 288px, 16px padding og 8px avstand til triggeren, med en pil som peker mot triggeren og roterer etter hvilken side popover-en åpner på.
- All styling bor i tailwind-pakken (`packages/tailwind/tailwind-base.css`), på samme måte som Pagination, fordelt på to utility-klasser: `gm-toggletip` (popover) og `gm-toggletip-trigger` (knappen). Inne i popoveren styres pil, dialog og lukkeknapp via `data-slot`-selektorer nestet under `gm-toggletip`. **Triggeren har en egen klasse fordi den ikke er en etterkommer av popoveren** — RAC portalerer popover-innholdet til et eget sted i DOM-en (utenfor triggeren), så en nestet `.gm-toggletip [data-slot="..."]`-selektor ville aldri truffet triggeren. React-komponenten har ingen inline utility-klasser. Klassene ligger i utilities-laget slik at lukkeknappens og info-variantens innfelte fokusring overstyrer Button sin cva-genererte outline.
- Universell utforming: `Dialog` har `aria-label` og bruker RAC sin innebygde fokuslås (samme mekanisme som Modal) — fokus settes til dialog-containeren ved åpning (skjermleser annonserer `aria-label`-en), holdes inne i popoveren, og returneres til triggeren ved lukking. `Escape` og klikk utenfor lukker. Ingen disabled-tilstander.
- Begge triggere er `button` (ikke `a`) — å åpne/lukke er en handling, ikke navigasjon. Kun én toggletip kan være åpen om gangen (klikk utenfor lukker den forrige).

### Avvik fra AC

To AC-punkter er bevisst droppet til fordel for RAC `Dialog` sin standardoppførsel — den samme Modal bruker — slik at vi ikke skriver skjør custom fokus-kode:

- **«`Tab` fra siste element lukker popover»**: ville krevd å overstyre dialogens fokuslås (FocusScope) ved å avlytte og stoppe RAC sin interne tastaturhåndtering — et antimønster. En dialog skal trappe fokus, ikke slippe det ut ved Tab. Vi bruker standard fokuslås (lukk med `Escape`, klikk utenfor eller lukkeknappen).
- **«Initialfokus settes til lukkeknapp»**: RAC setter allerede fokus til dialog-containeren ved åpning, som annonserer `aria-label`-en for skjermlesere. Å tvinge fokus til «Lukk» med en gang er en unødvendig overstyring og dårligere for brukeren.

Dette er samme mønster som GOV.UK, NRK og Adobe Spectrum bruker for tilsvarende komponenter.

### Hvorfor triggeren bruker React Aria Components' `Button`, ikke grunnmuren-`Button`

`ToggletipTrigger` rendrer den rå `Button` fra React Aria Components, mens lukkeknappen i popoveren bruker grunnmuren-`Button`. Det er et bevisst valg, ikke en forglemmelse:

- Grunnmuren-`Button` har styling for en *vanlig* knapp bakt inn i bunnen: fast minstehøyde på 44px, `font-medium`, avrundede hjørner, fargeoverganger, og en påkrevd variant (`primary`/`secondary`/`tertiary`) som legger på bakgrunn, kant eller understrek. Det passer ikke triggeren.
- **`definition`-varianten er et begrep inline i løpende tekst.** Den skal flyte med teksten i normal skriftvekt med en stiplet understrek — ikke være en 44px høy knapp i medium vekt med avrundede hjørner. Å bruke grunnmuren-`Button` her ville krevd å overstyre minstehøyde, visningstype, skriftvekt, padding, hjørner og variant-bakgrunnen, altså å nøytralisere det meste av komponenten. Uten tailwind-merge er slik overstyring dessuten skjør (rekkefølgen i cva avgjør hvem som vinner).
- **`info`-varianten (ikonknapp)** kunne nesten brukt grunnmuren-`Button`, men måtte uansett overstyre hjørnene (rund i stedet for avrundet rektangel) og fjerne tertiary-variantens understrek. Å la variantene ha hver sin knapp-base ville vært inkonsekvent.
- React Aria Components' `Button` gir en knapp helt uten styling, men med all oppførselen vi trenger: klikk/trykk, `aria-expanded`, fokus-håndtering og touch. Vi styler den fra `gm-toggletip-trigger` og gjenskaper fokusringen med samme `outline-focus`-tokenene som resten av designsystemet, så den er visuelt konsistent. Når `variant` utelates, får konsumenten denne rene knappen og styrer utseendet selv.
- **Lukkeknappen bruker grunnmuren-`Button`** (`tertiary` + `color="white"` + `isIconOnly`), fordi det er en helt vanlig ikonknapp som API-et dekker direkte — der er det ingen grunn til å gå rundt komponenten.

### Verifisering

Verifisert lokalt i Storybook med tastatur og mus: fokus settes til dialogen ved åpning, `Tab` sykler inne i popoveren (fokuslås), `Escape` og klikk utenfor (og lukkeknappen) lukker og returnerer fokus til trigger, fokusring vises på trigger og lukkeknapp (innfelt på info-varianten og lukkeknappen), og pilen peker mot triggeren for alle plasseringer (inkludert automatisk flip når det er for lite plass). En egen story (`InRunningText`) viser en definisjonslenke midt i en lang løpende tekst. Skjermbilder under.

### Skjermbilder


<img width="1520" height="920" alt="definition-open" src="https://github.com/user-attachments/assets/5f8ebd98-677a-4f09-b7ef-c26bed1d52bc"/>

<img width="1400" height="960" alt="icon-open" src="https://github.com/user-attachments/assets/af93d79c-caa9-48e9-8e20-96021139a375"/>

<img width="1520" height="920" alt="placement-right-open" src="https://github.com/user-attachments/assets/595af276-6c91-42c3-ace1-2790a655e609"/>


---
&gt; 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).