### PR TITLE
Flytt playknapp i VideoLoop til nedre venstre hjørne

### DIFF
--- a/.changeset/video-loop-accessible-play-control.md
+++ b/.changeset/video-loop-accessible-play-control.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Expose the `VideoLoop` play/pause control to assistive technology with a state-driven label, so keyboard and screen-reader users can pause the looping animation (WCAG 2.2.2).

--- a/.changeset/video-loop-corner-play-button.md
+++ b/.changeset/video-loop-corner-play-button.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": patch
 ---
 
-Move the `VideoLoop` play/pause button to the bottom-left corner in larger containers (centered in small ones) and render it with the grunnmuren `Button`.
+Move the `VideoLoop` play/pause button to the bottom-left corner in larger containers (centered in small ones) and render it with the grunnmuren `Button`. The control is now exposed to assistive technology with a state-driven label so keyboard and screen-reader users can pause the looping motion (WCAG 2.2.2).

--- a/.changeset/video-loop-corner-play-button.md
+++ b/.changeset/video-loop-corner-play-button.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Move the `VideoLoop` play/pause button to the bottom-left corner in larger containers (centered in small ones) and render it with the grunnmuren `Button`.

--- a/.changeset/video-loop-corner-play-button.md
+++ b/.changeset/video-loop-corner-play-button.md
@@ -2,4 +2,4 @@
 "@obosbbl/grunnmuren-react": patch
 ---
 
-Move the `VideoLoop` play/pause button to the bottom-left corner in larger containers (centered in small ones) and render it with the grunnmuren `Button`. The control is now exposed to assistive technology with a state-driven label so keyboard and screen-reader users can pause the looping motion (WCAG 2.2.2).
+Move the `VideoLoop` play/pause button to the bottom-left corner in larger containers (centered in small ones) and render it with the grunnmuren `Button`.

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -69,16 +69,10 @@ const variants = cva({
       ],
       'full-bleed': [
         oneColumnLayout,
-        // Position the media content to fill the entire viewport width.
-        // Skip the VideoLoop wrapper (`:has(video)`): instead of breaking out the whole wrapper
-        // (which would drag its play button to the viewport edge), we keep the wrapper at grid-container
-        // width and break out only the <video> below — so the button stays within the grid container,
-        // like the Carousel controls.
+        // Break media out to full viewport width — except the VideoLoop wrapper (`:has(video)`), which
+        // stays container-width so its play button anchors to the grid container (see the video rule below).
         '*:data-[slot=media]:*:not-has-[video]:absolute *:data-[slot=media]:*:not-has-[video]:left-0',
-        // Break the VideoLoop's <video> out to full viewport width while its wrapper stays
-        // container-width. The wrapper keeps its own `relative`, so the play button anchors to the
-        // grid container. The Carousel uses its own break-out (carousel-items-container) and no
-        // full-bleed story nests a VideoLoop in a Carousel, so matching every <video> is safe here.
+        // Break only the VideoLoop's video out to full width; the wrapper (and its button) stay in the container.
         '**:data-[slot=video]:relative **:data-[slot=video]:left-1/2 **:data-[slot=video]:min-w-screen **:data-[slot=video]:-translate-x-1/2',
         // Special case for Carousel, where the Media is nested inside a CarouselItem
         '*:data-[slot=carousel]:**:data-[slot=media]:w-full',

--- a/packages/react/src/hero/hero.tsx
+++ b/packages/react/src/hero/hero.tsx
@@ -69,8 +69,17 @@ const variants = cva({
       ],
       'full-bleed': [
         oneColumnLayout,
-        // Position the media and carousel content to fill the entire viewport width
-        '*:data-[slot=media]:*:absolute *:data-[slot=media]:*:left-0',
+        // Position the media content to fill the entire viewport width.
+        // Skip the VideoLoop wrapper (`:has(video)`): instead of breaking out the whole wrapper
+        // (which would drag its play button to the viewport edge), we keep the wrapper at grid-container
+        // width and break out only the <video> below — so the button stays within the grid container,
+        // like the Carousel controls.
+        '*:data-[slot=media]:*:not-has-[video]:absolute *:data-[slot=media]:*:not-has-[video]:left-0',
+        // Break the VideoLoop's <video> out to full viewport width while its wrapper stays
+        // container-width. The wrapper keeps its own `relative`, so the play button anchors to the
+        // grid container. The Carousel uses its own break-out (carousel-items-container) and no
+        // full-bleed story nests a VideoLoop in a Carousel, so matching every <video> is safe here.
+        '**:data-[slot=video]:relative **:data-[slot=video]:left-1/2 **:data-[slot=video]:min-w-screen **:data-[slot=video]:-translate-x-1/2',
         // Special case for Carousel, where the Media is nested inside a CarouselItem
         '*:data-[slot=carousel]:**:data-[slot=media]:w-full',
         // Match the heights of the <Media> or <Carousel> wrapper for the Media content (e.g. image, VideoLoop, video etc.)

--- a/packages/react/src/translations.ts
+++ b/packages/react/src/translations.ts
@@ -74,6 +74,16 @@ const translations: Translations = {
     sv: 'Slutförd',
     en: 'Completed',
   },
+  playAnimation: {
+    nb: 'Spill av animasjon',
+    sv: 'Spela upp animation',
+    en: 'Play animation',
+  },
+  pauseAnimation: {
+    nb: 'Pause animasjon',
+    sv: 'Pausa animation',
+    en: 'Pause animation',
+  },
 };
 
 export { translations, type Translation, type Translations };

--- a/packages/react/src/video-loop/video-loop.stories.tsx
+++ b/packages/react/src/video-loop/video-loop.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { VideoLoop } from './video-loop';
+
+const meta = {
+  title: 'VideoLoop',
+  component: VideoLoop,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    src: 'https://res.cloudinary.com/obosit-prd-ch-clry/video/upload/v1732199756/Mellom%20husene/Frysja_Loop2.mp4',
+    format: 'mp4',
+    alt: 'En postbil kjører rundt i det moderne nabolaget på Frysja. Her finnes det fine uteområder, med husker og kafeer.',
+  },
+} satisfies Meta<typeof VideoLoop>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** In a larger container the play/pause button sits in the bottom-left corner. */
+export const Default: Story = {
+  args: {
+    className: 'aspect-video w-[640px] max-w-[90vw] rounded-2xl',
+  },
+};
+
+/** In a small container the button stays centered. */
+export const SmallContainer: Story = {
+  args: {
+    className: 'aspect-video w-72 rounded-2xl',
+  },
+};

--- a/packages/react/src/video-loop/video-loop.stories.tsx
+++ b/packages/react/src/video-loop/video-loop.stories.tsx
@@ -22,13 +22,13 @@ type Story = StoryObj<typeof meta>;
 /** In a larger container the play/pause button sits in the bottom-left corner. */
 export const Default: Story = {
   args: {
-    className: 'aspect-video w-[640px] max-w-[90vw] rounded-2xl',
+    className: 'w-[640px] max-w-[90vw] rounded-2xl',
   },
 };
 
 /** In a small container the button stays centered. */
 export const SmallContainer: Story = {
   args: {
-    className: 'aspect-video w-72 rounded-2xl',
+    className: 'w-72 rounded-2xl',
   },
 };

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -92,6 +92,8 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
       >
         <source src={src} type={`video/${format}`} />
       </video>
+      {/* Rendered before the button so screen readers announce what the video shows before the playback control */}
+      {alt && <p className="sr-only">{alt}</p>}
       {prefersReducedMotion !== null && (
         <Button
           // The video itself is decorative (aria-hidden), but the playback control must stay
@@ -125,7 +127,6 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
           {isPlaying ? <PlayerPause /> : <PlayerPlay />}
         </Button>
       )}
-      {alt && <p className="sr-only">{alt}</p>}
     </div>
   );
 };

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -3,6 +3,8 @@ import { cx } from 'cva';
 import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '../button';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 import { usePrefersReducedMotion } from '../use-prefers-reduced-motion';
 
 type VideoLoopProps = {
@@ -55,6 +57,8 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
 
   const togglePlayback = () => setShouldPlay((prevState) => !prevState);
 
+  const locale = useLocale();
+
   return (
     <div
       className={cx(
@@ -90,9 +94,12 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
       </video>
       {prefersReducedMotion !== null && (
         <Button
-          // The video is decorative, so the playback control is hidden from screen readers
-          // oxlint-disable-next-line jsx-a11y/no-aria-hidden-on-focusable
-          aria-hidden
+          // The video itself is decorative (aria-hidden), but the playback control must stay
+          // exposed and labelled so keyboard/screen-reader users can pause the looping motion
+          // (WCAG 2.2.2). The label is state-driven and framed around the motion, since the video is muted.
+          aria-label={
+            isPlaying ? translations.pauseAnimation[locale] : translations.playAnimation[locale]
+          }
           isIconOnly
           variant="primary"
           color="white"

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -63,8 +63,7 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
     <div
       className={cx(
         className,
-        // `group` lets the corner button reveal on hover anywhere over the video,
-        // `@container` lets us move the button to the corner only in larger containers.
+        // group: hover anywhere reveals the button. @container: corner placement only when large.
         'group @container relative',
         prefersReducedMotion === null && 'opacity-0',
       )}
@@ -73,7 +72,7 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
       <video
         aria-hidden
         ref={videoRef}
-        // Clicking anywhere on the video toggles playback (like YouTube/Mux), in addition to the button below
+        // Click anywhere on the video to toggle playback (in addition to the button)
         className="size-full max-h-[inherit] cursor-pointer rounded-[inherit] object-cover"
         playsInline
         loop={prefersReducedMotion === false}
@@ -92,13 +91,10 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
       >
         <source src={src} type={`video/${format}`} />
       </video>
-      {/* Rendered before the button so screen readers announce what the video shows before the playback control */}
+      {/* Before the button so the description is read before the control */}
       {alt && <p className="sr-only">{alt}</p>}
       {prefersReducedMotion !== null && (
         <Button
-          // The video itself is decorative (aria-hidden), but the playback control must stay
-          // exposed and labelled so keyboard/screen-reader users can pause the looping motion
-          // (WCAG 2.2.2). The label is state-driven and framed around the motion, since the video is muted.
           aria-label={
             isPlaying ? translations.pauseAnimation[locale] : translations.playAnimation[locale]
           }
@@ -110,12 +106,9 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
             // Centered in small containers; moved to the bottom-left corner in larger ones
             'absolute inset-0 m-auto size-fit',
             '@md:inset-auto @md:bottom-4 @md:left-4',
-            // Restrict the transition to opacity only. The Button base has `transition-colors`,
-            // which would otherwise animate `outline-color` from the button's currentColor to the
-            // white focus outline, making the focus ring flash black→white. Keeping this here
-            // (not gated on `isPlaying`) ensures it applies in the paused/visible state too.
+            // Opacity-only transition; overrides Button's `transition-colors` so the focus outline doesn't flash black→white
             'transition-opacity duration-200',
-            // Setting the opacity to 0 before applying the transition above will ensure the button only fades in after the video has started playing
+            // Start hidden so the button fades in once the video plays
             shouldPlay && 'opacity-0',
             isPlaying && [
               // Only show the pause button when the video is hovered or focused

--- a/packages/react/src/video-loop/video-loop.tsx
+++ b/packages/react/src/video-loop/video-loop.tsx
@@ -2,6 +2,7 @@ import { PlayerPause, PlayerPlay } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { useEffect, useRef, useState } from 'react';
 
+import { Button } from '../button';
 import { usePrefersReducedMotion } from '../use-prefers-reduced-motion';
 
 type VideoLoopProps = {
@@ -52,20 +53,29 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
     }
   }, [shouldPlay]);
 
+  const togglePlayback = () => setShouldPlay((prevState) => !prevState);
+
   return (
     <div
-      className={cx(className, 'relative', prefersReducedMotion === null && 'opacity-0')}
+      className={cx(
+        className,
+        // `group` lets the corner button reveal on hover anywhere over the video,
+        // `@container` lets us move the button to the corner only in larger containers.
+        'group @container relative',
+        prefersReducedMotion === null && 'opacity-0',
+      )}
       data-slot="video-loop"
     >
       <video
         aria-hidden
         ref={videoRef}
-        // cursor-pointer is not working on the button below, so we add it here for the same effect
+        // Clicking anywhere on the video toggles playback (like YouTube/Mux), in addition to the button below
         className="size-full max-h-[inherit] cursor-pointer rounded-[inherit] object-cover"
         playsInline
         loop={prefersReducedMotion === false}
         autoPlay={prefersReducedMotion === false}
         muted
+        onClick={togglePlayback}
         onEnded={(event) => {
           if (prefersReducedMotion) {
             // Reset the video to the beginning if the user prefers reduced motion, since the video will not loop
@@ -79,30 +89,34 @@ export const VideoLoop = ({ src, format, alt, className }: VideoLoopProps) => {
         <source src={src} type={`video/${format}`} />
       </video>
       {prefersReducedMotion !== null && (
-        <button
-          data-slot="video-loop-button"
+        <Button
+          // The video is decorative, so the playback control is hidden from screen readers
           // oxlint-disable-next-line jsx-a11y/no-aria-hidden-on-focusable
           aria-hidden
-          type="button"
-          onClick={() => setShouldPlay((prevState) => !prevState)}
+          isIconOnly
+          variant="primary"
+          color="white"
+          onPress={togglePlayback}
           className={cx(
-            'absolute inset-0 m-auto grid place-items-center',
-            'focus-visible:outline-focus focus-visible:outline-focus-offset',
-            'rounded-[inherit]',
-            // Setting the opacity to 0 before applying the transition below will ensure the button only fades in after the video has started playing
+            // Centered in small containers; moved to the bottom-left corner in larger ones
+            'absolute inset-0 m-auto size-fit',
+            '@md:inset-auto @md:bottom-4 @md:left-4',
+            // Restrict the transition to opacity only. The Button base has `transition-colors`,
+            // which would otherwise animate `outline-color` from the button's currentColor to the
+            // white focus outline, making the focus ring flash black→white. Keeping this here
+            // (not gated on `isPlaying`) ensures it applies in the paused/visible state too.
+            'transition-opacity duration-200',
+            // Setting the opacity to 0 before applying the transition above will ensure the button only fades in after the video has started playing
             shouldPlay && 'opacity-0',
             isPlaying && [
-              'transition-opacity duration-200',
               // Only show the pause button when the video is hovered or focused
               'focus-visible:opacity-100',
-              'hover:opacity-100',
+              'group-hover:opacity-100',
             ],
           )}
         >
-          <span className="grid size-12 place-items-center rounded-full bg-white outline-hidden">
-            {isPlaying ? <PlayerPause /> : <PlayerPlay />}
-          </span>
-        </button>
+          {isPlaying ? <PlayerPause /> : <PlayerPlay />}
+        </Button>
       )}
       {alt && <p className="sr-only">{alt}</p>}
     </div>


### PR DESCRIPTION
### Oppsummering

Play-/pauseknappen i `VideoLoop` lå sentrert oppå hele videoen, noe som ser malplassert ut i store containere (f.eks. full-bleed Hero). Knappen er nå en diskret ikonknapp som ligger nede til venstre i større containere og forblir sentrert i små. Den bruker `Button` fra grunnmuren-react med samme styling som forrige-/neste-knappene i Carousel (hvit, `isIconOnly`), bare venstrejustert. Løser [AB#143487](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/143487).

### Endringer

- **`video-loop.tsx`:** Erstattet den egendefinerte sentrerte knappen med grunnmuren-`Button` (`isIconOnly`, `variant="primary"`, `color="white"`). Knappen er sentrert i små containere og flyttes til nedre venstre hjørne i større via en container query (`@container` + `@md`). Hele videoen er fortsatt klikkbar for å spille/pause (klikk-håndteringen ligger nå på `video`-elementet), i tillegg til knappen.
- **Universell utforming:** Knappen var tidligere `aria-hidden` men fortsatt fokuserbar (phantom focus, WCAG 4.1.2), og skjermleser-/tastaturbrukere (som ser) hadde ingen måte å pause den autospillende videoen på (WCAG 2.2.2). Fjernet `aria-hidden` og gitt knappen en tilstandsstyrt `aria-label` («Spill av animasjon» / «Pause animasjon», via `translations`) — formulert rundt bevegelse siden videoen er lydløs. `video`-elementet forblir `aria-hidden` (dekorativt), og `prefers-reduced-motion`-gatingen beholdes. Den skjulte tekstbeskrivelsen (`sr-only`) rendres nå før knappen i DOM, slik at skjermlesere leser hva videoen viser før selve avspillingskontrollen.
- **Fokus-outline:** Begrenset knappens transition til kun `opacity`. `Button`-basen har `transition-colors`, som ellers animerte `outline-color` slik at fokusringen blinket fra svart til hvit. Nå vises den hvite ringen uten blink.
- **`hero.tsx` (kun `full-bleed`):** Tidligere ble hele `VideoLoop`-wrapperen brutt ut til full bredde, noe som dro knappen helt ut til viewport-kanten. Nå brytes kun selve `video`-elementet ut til full bredde (`min-w-screen` + sentrering), mens wrapperen blir værende i grid-containeren — så knappen havner på container-kanten, på samme måte som Carousel-kontrollene. Bilder og MuxPlayer beholder dagens utbrudd.
- **Storybook:** Lagt til en egen story-fil for `VideoLoop` (`Default` med stor container → hjørneknapp, og `Small Container` → sentrert knapp). Tidligere fantes komponenten kun via Hero-stories.

### Skjermbilder

**Før:**

<img width="1440" height="700" alt="before_videoloop_1440" src="https://github.com/user-attachments/assets/30bacc30-54ba-4bfc-8563-0de60f27457d"/>

<img width="390" height="700" alt="before_videoloop_390" src="https://github.com/user-attachments/assets/3902c67f-245a-4da1-a5a6-837cca3a0042"/>


**Etter:**

<img width="1440" height="700" alt="fb_videoloop_1440" src="https://github.com/user-attachments/assets/56be20af-55fe-4191-ad5f-70b3e2483071"/>

<img width="390" height="700" alt="fb_videoloop_390" src="https://github.com/user-attachments/assets/24d33a4a-a80e-47e6-af4e-f88ead4132bc"/>
