### PR TITLE
Eksponer treeColumn-propen i Table sin publiserte type

### DIFF
--- a/.changeset/table-tree-column-type.md
+++ b/.changeset/table-tree-column-type.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Expose the `treeColumn` prop on `Table`'s published type (it was runtime-only).

--- a/packages/react/src/table/table.tsx
+++ b/packages/react/src/table/table.tsx
@@ -9,6 +9,7 @@ import {
   type ColumnProps as RACColumnProps,
   ColumnResizer as RACColumnResizer,
   type ColumnResizerProps as RACColumnResizerProps,
+  type Key,
   Row as RACRow,
   type RowProps as RACRowProps,
   Table as RACTable,
@@ -56,6 +57,18 @@ type TableProps = Omit<RACTableProps, 'aria-label' | 'aria-labelledby'> &
      * @default 'default'
      */
     variant?: TableVariant;
+    /**
+     * The id of the column that displays hierarchical data. When set, the
+     * Table renders an expand/collapse control on that column for rows that
+     * have nested child rows.
+     *
+     * NOTE: `treeColumn` exists in react-aria-components / react-stately at
+     * runtime, but it is an inline member of react-stately's `TableProps` that
+     * gets dropped from our bundled declaration output. We re-declare it here so
+     * it stays part of the published type. Safe to remove if a future
+     * RAC/react-stately upgrade keeps it in the bundled `.d.mts`.
+     */
+    treeColumn?: Key;
   } & (
     | { 'aria-label': string; 'aria-labelledby'?: never }
     | { 'aria-label'?: never; 'aria-labelledby': string }


### PR DESCRIPTION
### Oppsummering

`Table` støtter expanderbare rader via `treeColumn`-propen, men propen manglet i den publiserte typen til `@obosbbl/grunnmuren-react` — den fungerte kun i runtime. Konsumenter måtte derfor utvide prop-typen lokalt (se [boligforvaltning-frontend#640](https://github.com/code-obos/boligforvaltning-frontend/pull/640)). Denne PR-en gjør `treeColumn` til en førsteklasses, dokumentert del av typen, slik at den utvidelsen kan fjernes.

### Bakgrunn (rotårsak)

`treeColumn` er definert som et eget felt direkte på react-stately sin `TableProps`, mens de beslektede propene `expandedKeys`/`onExpandedChange` arves via `Expandable`-interfacet. Når `bunchee` bygger den samlede typefilen vår (`dist/index.d.mts`), beholdes de arvede feltene, men det direkte `treeColumn`-feltet faller ut. Det er derfor kun `treeColumn` manglet i de publiserte typene.

### Endringer

- `packages/react/src/table/table.tsx`: deklarerer `treeColumn?: Key` eksplisitt på `TableProps`, med en forklarende kommentar om hvorfor re-deklarasjonen trengs. Importerer `Key`-typen fra `react-aria-components/Table`. Endringen er kun på typenivå og additiv — propen videresendes allerede til react-aria-components via `{...restProps}`, så ingen runtime-oppførsel endres.
- La til en patch-changeset.

### Verifisering

- Bygde pakken med `bunchee` og bekreftet at `treeColumn?: Key` nå finnes i `dist/index.d.mts` (manglet før endringen).
- `oxfmt` og `oxlint` grønt for `packages/react`.

---

> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).