### PR TITLE
Legg til Header-komponent i Modal/Drawer

### DIFF
--- a/.changeset/modal-drawer-header.md
+++ b/.changeset/modal-drawer-header.md
@@ -2,13 +2,14 @@
 "@obosbbl/grunnmuren-react": minor
 ---
 
-Add a `Header` component so the header and footer of `Modal`/`Drawer` (beta) can be styled freely via `className`, e.g. made sticky or given a background. A `Heading` inside `Header` no longer needs `slot="title"` — the title styling and the dialog's accessible name are wired automatically.
+Add a `Header` component for `Modal`/`Drawer` (beta) so the header and footer can be styled freely via `className` (e.g. made sticky or given a background). A `Heading` inside `Header` no longer needs `slot="title"` — the title styling and the dialog's accessible name (`aria-labelledby`) are wired automatically. The close button is no longer auto-injected; place a bare `<Button slot="close" />` inside the `Header` and its icon, variant and `aria-label` are injected for you.
 
-Migration (beta): wrap the title in `Header` and drop `slot="title"`.
+Migration (beta): wrap the title in `Header`, drop `slot="title"`, and add a `<Button slot="close" />`.
 
 ```diff
 - <Heading slot="title" level={2}>Tittel</Heading>
 + <Header>
 +   <Heading level={2}>Tittel</Heading>
++   <Button slot="close" />
 + </Header>
 ```

--- a/.changeset/modal-drawer-header.md
+++ b/.changeset/modal-drawer-header.md
@@ -1,0 +1,14 @@
+---
+"@obosbbl/grunnmuren-react": minor
+---
+
+Add a `Header` component so the header and footer of `Modal`/`Drawer` (beta) can be styled freely via `className`, e.g. made sticky or given a background. A `Heading` inside `Header` no longer needs `slot="title"` — the title styling and the dialog's accessible name are wired automatically.
+
+Migration (beta): wrap the title in `Header` and drop `slot="title"`.
+
+```diff
+- <Heading slot="title" level={2}>Tittel</Heading>
++ <Header>
++   <Heading level={2}>Tittel</Heading>
++ </Header>
+```

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,12 +1,6 @@
 import { cva, cx, type VariantProps } from 'cva';
 import { createContext, type HTMLProps, type ReactNode, type Ref } from 'react';
-import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
-import {
-  type ContextValue,
-  Provider,
-  useContextProps,
-  useSlottedContext,
-} from 'react-aria-components/slots';
+import { type ContextValue, Provider, useContextProps } from 'react-aria-components/slots';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -146,6 +140,8 @@ type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
   /** @private Used by Modal/Drawer to inject the close button into the header */
   _action?: ReactNode;
+  /** @private Set by Modal/Drawer to the dialog's title id, wired onto the heading for `aria-labelledby` */
+  _titleId?: string;
   /** Ref for the element. */
   ref?: Ref<HTMLDivElement>;
 };
@@ -156,22 +152,18 @@ const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivEl
  * Wraps the title (and optional close button) of a Modal/Drawer.
  *
  * Renders a `data-slot="header"` element that consumers can style freely,
- * e.g. `className="sticky top-0 bg-white"`. A `Heading` placed inside
- * automatically gets the title styling and is wired as the dialog's accessible
- * name, so no `slot="title"` is needed.
+ * e.g. `className="sticky top-0 bg-white"`. A `Heading` placed inside gets the
+ * title styling, and — inside a Modal/Drawer — the dialog's accessible name is
+ * wired up automatically (via the injected `_titleId`), so no `slot="title"` is
+ * needed.
  */
 const Header = ({ ref = null, ...props }: HeaderProps) => {
   [props, ref] = useContextProps(props, ref, HeaderContext);
-  const { children, className, _action: action, ...restProps } = props;
-
-  // React Aria's Dialog exposes the generated title id through its own
-  // HeadingContext. We forward it to our Heading so the dialog gets an
-  // accessible name via aria-labelledby.
-  const racTitle = useSlottedContext(RACHeadingContext, 'title');
+  const { children, className, _action: action, _titleId: titleId, ...restProps } = props;
 
   return (
     <div ref={ref} {...restProps} className={className} data-slot="header">
-      <Provider values={[[HeadingContext, { className: 'heading-s', id: racTitle?.id }]]}>
+      <Provider values={[[HeadingContext, { className: 'heading-s', id: titleId }]]}>
         {children}
       </Provider>
       {action}

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,5 +1,5 @@
 import { cva, cx, type VariantProps } from 'cva';
-import { createContext, type HTMLProps, type Ref } from 'react';
+import { createContext, type HTMLProps, type Ref, useContext } from 'react';
 import { type ContextValue, useContextProps } from 'react-aria-components/slots';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
@@ -140,17 +140,29 @@ type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
 };
 
+const HeaderContext = createContext<{
+  /** @private Set by Modal/Drawer to wrap the header content in the contexts it needs */
+  _wrap?: (children: React.ReactNode) => React.ReactNode;
+}>({});
+
 /**
  * Wraps the title of a Modal/Drawer (and, optionally, a `<Button slot="close" />`).
  *
  * A `data-slot="header"` element the consumer can style freely, e.g.
- * `className="sticky top-0 bg-white"`. Inside a Modal/Drawer the dialog wires the
- * title's accessible name (`aria-labelledby`) and injects the close button's icon
- * and styling, so the consumer only writes a `Heading` and a bare
- * `<Button slot="close" />` — no `slot="title"` needed. `Header` must be a direct
- * child of the dialog content for that wiring to apply.
+ * `className="sticky top-0 bg-white"`. Inside a Modal/Drawer the dialog injects a
+ * wrapper (via `HeaderContext`) that wires the title's accessible name
+ * (`aria-labelledby`) and the close button's icon and styling, so the consumer
+ * only writes a `Heading` and a bare `<Button slot="close" />` — no `slot="title"`
+ * needed.
  */
-const Header = (props: HeaderProps) => <div {...props} data-slot="header" />;
+const Header = ({ children, ...props }: HeaderProps) => {
+  const { _wrap } = useContext(HeaderContext);
+  return (
+    <div {...props} data-slot="header">
+      {_wrap ? _wrap(children) : children}
+    </div>
+  );
+};
 
 export {
   Caption,
@@ -158,6 +170,7 @@ export {
   ContentContext,
   Footer,
   Header,
+  HeaderContext,
   Heading,
   HeadingContext,
   Media,

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,6 +1,5 @@
-import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
-import { createContext, type HTMLProps, type Ref } from 'react';
+import { createContext, type HTMLProps, type ReactNode, type Ref } from 'react';
 import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
 import {
   type ContextValue,
@@ -8,10 +7,6 @@ import {
   useContextProps,
   useSlottedContext,
 } from 'react-aria-components/slots';
-
-import { Button } from '../button';
-import { translations } from '../translations';
-import { useLocale } from '../use-locale';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -149,8 +144,8 @@ const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
 type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
-  /** @private Set by Modal/Drawer to render a dismiss button when the dialog is dismissable */
-  _onClose?: () => void;
+  /** @private Used by Modal/Drawer to inject the close button into the header */
+  _action?: ReactNode;
   /** Ref for the element. */
   ref?: Ref<HTMLDivElement>;
 };
@@ -167,8 +162,7 @@ const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivEl
  */
 const Header = ({ ref = null, ...props }: HeaderProps) => {
   [props, ref] = useContextProps(props, ref, HeaderContext);
-  const { children, className, _onClose: onClose, ...restProps } = props;
-  const locale = useLocale();
+  const { children, className, _action: action, ...restProps } = props;
 
   // React Aria's Dialog exposes the generated title id through its own
   // HeadingContext. We forward it to our Heading so the dialog gets an
@@ -180,18 +174,7 @@ const Header = ({ ref = null, ...props }: HeaderProps) => {
       <Provider values={[[HeadingContext, { className: 'heading-s', id: racTitle?.id }]]}>
         {children}
       </Provider>
-      {onClose && (
-        <Button
-          // RAC Dialog supports one "close" slot out of the box, which we utilize here.
-          slot="close"
-          variant="tertiary"
-          className="data-focus-visible:outline-focus-inset px-2.5!"
-          aria-label={translations.close[locale]}
-          onPress={onClose}
-        >
-          <Close />
-        </Button>
-      )}
+      {action}
     </div>
   );
 };

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,11 +1,13 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
 import { createContext, type HTMLProps, type Ref } from 'react';
+import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
 import {
   DEFAULT_SLOT,
   type ContextValue,
   Provider,
   useContextProps,
+  useSlottedContext,
 } from 'react-aria-components/slots';
 
 import { ButtonContext } from '../button';
@@ -148,34 +150,28 @@ const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
 type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
-  /** @private Set by Modal/Drawer to the dialog's title id, wired onto the heading for `aria-labelledby` */
-  _titleId?: string;
-  /** Ref for the element. */
-  ref?: Ref<HTMLDivElement>;
 };
-
-const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivElement>>({});
 
 /**
  * Wraps the title of a Modal/Drawer (and, optionally, a `<Button slot="close" />`).
  *
- * Renders a `data-slot="header"` element that consumers can style freely,
- * e.g. `className="sticky top-0 bg-white"`. A `Heading` placed inside gets the
- * title styling, and — inside a Modal/Drawer — the dialog's accessible name is
- * wired up automatically (via the injected `_titleId`), so no `slot="title"` is
- * needed. A `<Button slot="close" />` inside gets its icon and styling injected,
- * so the consumer only writes the bare button.
+ * Renders a `data-slot="header"` element consumers can style freely, e.g.
+ * `className="sticky top-0 bg-white"`. A `Heading` inside gets the title styling,
+ * and — inside a Modal/Drawer — is wired as the dialog's accessible name
+ * automatically (no `slot="title"` needed). A bare `<Button slot="close" />`
+ * inside gets its icon and styling injected.
  */
-const Header = ({ ref = null, ...props }: HeaderProps) => {
-  [props, ref] = useContextProps(props, ref, HeaderContext);
-  const { children, className, _titleId: titleId, ...restProps } = props;
+const Header = ({ children, ...props }: HeaderProps) => {
+  // React Aria's Dialog exposes the generated title id through its HeadingContext;
+  // we read it and wire it onto the heading for `aria-labelledby`.
+  const racTitle = useSlottedContext(RACHeadingContext, 'title');
   const locale = useLocale();
 
   return (
-    <div ref={ref} {...restProps} className={className} data-slot="header">
+    <div {...props} data-slot="header">
       <Provider
         values={[
-          [HeadingContext, { className: 'heading-s', id: titleId }],
+          [HeadingContext, { className: 'heading-s', id: racTitle?.id }],
           // Appearance for a bare `<Button slot="close" />` inside the header. The
           // close behaviour (onPress) is provided by the Modal/Drawer's Dialog.
           [
@@ -206,7 +202,6 @@ export {
   ContentContext,
   Footer,
   Header,
-  HeaderContext,
   Heading,
   HeadingContext,
   Media,

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,5 +1,6 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
-import { createContext, type HTMLProps, type ReactNode, type Ref } from 'react';
+import { createContext, type HTMLProps, type Ref } from 'react';
 import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
 import {
   type ContextValue,
@@ -7,6 +8,10 @@ import {
   useContextProps,
   useSlottedContext,
 } from 'react-aria-components/slots';
+
+import { Button } from '../button';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -144,8 +149,8 @@ const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
 type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
-  /** @private Used by Modal/Drawer to inject the close button into the header */
-  _action?: ReactNode;
+  /** @private Set by Modal/Drawer to render a dismiss button when the dialog is dismissable */
+  _onClose?: () => void;
   /** Ref for the element. */
   ref?: Ref<HTMLDivElement>;
 };
@@ -162,7 +167,8 @@ const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivEl
  */
 const Header = ({ ref = null, ...props }: HeaderProps) => {
   [props, ref] = useContextProps(props, ref, HeaderContext);
-  const { children, className, _action: action, ...restProps } = props;
+  const { children, className, _onClose: onClose, ...restProps } = props;
+  const locale = useLocale();
 
   // React Aria's Dialog exposes the generated title id through its own
   // HeadingContext. We forward it to our Heading so the dialog gets an
@@ -174,7 +180,18 @@ const Header = ({ ref = null, ...props }: HeaderProps) => {
       <Provider values={[[HeadingContext, { className: 'heading-s', id: racTitle?.id }]]}>
         {children}
       </Provider>
-      {action}
+      {onClose && (
+        <Button
+          // RAC Dialog supports one "close" slot out of the box, which we utilize here.
+          slot="close"
+          variant="tertiary"
+          className="data-focus-visible:outline-focus-inset px-2.5!"
+          aria-label={translations.close[locale]}
+          onPress={onClose}
+        >
+          <Close />
+        </Button>
+      )}
     </div>
   );
 };

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,6 +1,13 @@
 import { cva, cx, type VariantProps } from 'cva';
-import { createContext, type HTMLProps, type Ref, useContext } from 'react';
-import { type ContextValue, useContextProps } from 'react-aria-components/slots';
+import { createContext, type HTMLProps, type Ref } from 'react';
+import {
+  DEFAULT_SLOT,
+  type ContextValue,
+  Provider,
+  useContextProps,
+} from 'react-aria-components/slots';
+
+import { ButtonContext, type ButtonProps } from '../button';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -138,28 +145,40 @@ const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
 type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
+  /** @private Set by Modal/Drawer to the dialog's title id, wired onto the heading for `aria-labelledby` */
+  _titleId?: string;
+  /** @private Set by Modal/Drawer with the appearance for a `<Button slot="close" />` placed inside */
+  _closeButton?: Partial<ButtonProps>;
+  /** Ref for the element. */
+  ref?: Ref<HTMLDivElement>;
 };
 
-const HeaderContext = createContext<{
-  /** @private Set by Modal/Drawer to wrap the header content in the contexts it needs */
-  _wrap?: (children: React.ReactNode) => React.ReactNode;
-}>({});
+const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivElement>>({});
 
 /**
  * Wraps the title of a Modal/Drawer (and, optionally, a `<Button slot="close" />`).
  *
- * A `data-slot="header"` element the consumer can style freely, e.g.
- * `className="sticky top-0 bg-white"`. Inside a Modal/Drawer the dialog injects a
- * wrapper (via `HeaderContext`) that wires the title's accessible name
- * (`aria-labelledby`) and the close button's icon and styling, so the consumer
- * only writes a `Heading` and a bare `<Button slot="close" />` — no `slot="title"`
- * needed.
+ * Renders a `data-slot="header"` element that consumers can style freely,
+ * e.g. `className="sticky top-0 bg-white"`. A `Heading` placed inside gets the
+ * title styling, and — inside a Modal/Drawer — the dialog's accessible name is
+ * wired up automatically (via the injected `_titleId`), so no `slot="title"` is
+ * needed. A `<Button slot="close" />` inside gets its icon and styling injected,
+ * so the consumer only writes the bare button.
  */
-const Header = ({ children, ...props }: HeaderProps) => {
-  const { _wrap } = useContext(HeaderContext);
+const Header = ({ ref = null, ...props }: HeaderProps) => {
+  [props, ref] = useContextProps(props, ref, HeaderContext);
+  const { children, className, _titleId: titleId, _closeButton: closeButton, ...restProps } = props;
+
   return (
-    <div {...props} data-slot="header">
-      {_wrap ? _wrap(children) : children}
+    <div ref={ref} {...restProps} className={className} data-slot="header">
+      <Provider
+        values={[
+          [HeadingContext, { className: 'heading-s', id: titleId }],
+          [ButtonContext, { slots: { [DEFAULT_SLOT]: {}, close: closeButton ?? {} } }],
+        ]}
+      >
+        {children}
+      </Provider>
     </div>
   );
 };

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,13 +1,6 @@
 import { cva, cx, type VariantProps } from 'cva';
 import { createContext, type HTMLProps, type Ref } from 'react';
-import {
-  DEFAULT_SLOT,
-  type ContextValue,
-  Provider,
-  useContextProps,
-} from 'react-aria-components/slots';
-
-import { ButtonContext, type ButtonProps } from '../button';
+import { type ContextValue, useContextProps } from 'react-aria-components/slots';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -145,43 +138,19 @@ const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
 type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
-  /** @private Set by Modal/Drawer to the dialog's title id, wired onto the heading for `aria-labelledby` */
-  _titleId?: string;
-  /** @private Set by Modal/Drawer with the appearance for a `<Button slot="close" />` placed inside */
-  _closeButton?: Partial<ButtonProps>;
-  /** Ref for the element. */
-  ref?: Ref<HTMLDivElement>;
 };
-
-const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivElement>>({});
 
 /**
  * Wraps the title of a Modal/Drawer (and, optionally, a `<Button slot="close" />`).
  *
- * Renders a `data-slot="header"` element that consumers can style freely,
- * e.g. `className="sticky top-0 bg-white"`. A `Heading` placed inside gets the
- * title styling, and — inside a Modal/Drawer — the dialog's accessible name is
- * wired up automatically (via the injected `_titleId`), so no `slot="title"` is
- * needed. A `<Button slot="close" />` inside gets its icon and styling injected,
- * so the consumer only writes the bare button.
+ * A `data-slot="header"` element the consumer can style freely, e.g.
+ * `className="sticky top-0 bg-white"`. Inside a Modal/Drawer the dialog wires the
+ * title's accessible name (`aria-labelledby`) and injects the close button's icon
+ * and styling, so the consumer only writes a `Heading` and a bare
+ * `<Button slot="close" />` — no `slot="title"` needed. `Header` must be a direct
+ * child of the dialog content for that wiring to apply.
  */
-const Header = ({ ref = null, ...props }: HeaderProps) => {
-  [props, ref] = useContextProps(props, ref, HeaderContext);
-  const { children, className, _titleId: titleId, _closeButton: closeButton, ...restProps } = props;
-
-  return (
-    <div ref={ref} {...restProps} className={className} data-slot="header">
-      <Provider
-        values={[
-          [HeadingContext, { className: 'heading-s', id: titleId }],
-          [ButtonContext, { slots: { [DEFAULT_SLOT]: {}, close: closeButton ?? {} } }],
-        ]}
-      >
-        {children}
-      </Provider>
-    </div>
-  );
-};
+const Header = (props: HeaderProps) => <div {...props} data-slot="header" />;
 
 export {
   Caption,
@@ -189,7 +158,6 @@ export {
   ContentContext,
   Footer,
   Header,
-  HeaderContext,
   Heading,
   HeadingContext,
   Media,

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,18 +1,8 @@
-import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
-import { createContext, type HTMLProps, type Ref } from 'react';
-import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
-import {
-  DEFAULT_SLOT,
-  type ContextValue,
-  Provider,
-  useContextProps,
-  useSlottedContext,
-} from 'react-aria-components/slots';
+import { createContext, type HTMLProps, type Ref, useContext } from 'react';
+import { type ContextValue, Provider, useContextProps } from 'react-aria-components/slots';
 
-import { ButtonContext } from '../button';
-import { translations } from '../translations';
-import { useLocale } from '../use-locale';
+import { ButtonContext, type ButtonProps } from '../button';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -152,46 +142,33 @@ type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
 };
 
+// The two contexts a Modal/Drawer wraps the header content in (typed explicitly
+// so the values pass through context and into `Provider` without casts).
+type HeaderProviderValues = [
+  [typeof HeadingContext, ContextValue<Partial<HeadingProps>, HTMLHeadingElement>],
+  [typeof ButtonContext, ContextValue<ButtonProps, HTMLButtonElement | HTMLAnchorElement>],
+];
+
+const HeaderContext = createContext<{
+  /** @private Set by Modal/Drawer with the contexts to wrap the header content in */
+  _providerValues?: HeaderProviderValues;
+}>({});
+
 /**
  * Wraps the title of a Modal/Drawer (and, optionally, a `<Button slot="close" />`).
  *
  * Renders a `data-slot="header"` element consumers can style freely, e.g.
- * `className="sticky top-0 bg-white"`. A `Heading` inside gets the title styling,
- * and — inside a Modal/Drawer — is wired as the dialog's accessible name
- * automatically (no `slot="title"` needed). A bare `<Button slot="close" />`
- * inside gets its icon and styling injected.
+ * `className="sticky top-0 bg-white"`. Inside a Modal/Drawer the dialog provides
+ * (via `HeaderContext`) the contexts to wrap the content in — wiring the title's
+ * accessible name (`aria-labelledby`) and the close button's appearance — so the
+ * consumer only writes a `Heading` and a bare `<Button slot="close" />`, with no
+ * `slot="title"` needed.
  */
 const Header = ({ children, ...props }: HeaderProps) => {
-  // React Aria's Dialog exposes the generated title id through its HeadingContext;
-  // we read it and wire it onto the heading for `aria-labelledby`.
-  const racTitle = useSlottedContext(RACHeadingContext, 'title');
-  const locale = useLocale();
-
+  const { _providerValues } = useContext(HeaderContext);
   return (
     <div {...props} data-slot="header">
-      <Provider
-        values={[
-          [HeadingContext, { className: 'heading-s', id: racTitle?.id }],
-          // Appearance for a bare `<Button slot="close" />` inside the header. The
-          // close behaviour (onPress) is provided by the Modal/Drawer's Dialog.
-          [
-            ButtonContext,
-            {
-              slots: {
-                [DEFAULT_SLOT]: {},
-                close: {
-                  variant: 'tertiary',
-                  'aria-label': translations.close[locale],
-                  className: 'data-focus-visible:outline-focus-inset px-2.5!',
-                  children: <Close />,
-                },
-              },
-            },
-          ],
-        ]}
-      >
-        {children}
-      </Provider>
+      {_providerValues ? <Provider values={_providerValues}>{children}</Provider> : children}
     </div>
   );
 };
@@ -202,6 +179,7 @@ export {
   ContentContext,
   Footer,
   Header,
+  HeaderContext,
   Heading,
   HeadingContext,
   Media,

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,6 +1,12 @@
 import { cva, cx, type VariantProps } from 'cva';
-import { createContext, type HTMLProps, type Ref } from 'react';
-import { type ContextValue, useContextProps } from 'react-aria-components/slots';
+import { createContext, type HTMLProps, type ReactNode, type Ref } from 'react';
+import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
+import {
+  type ContextValue,
+  Provider,
+  useContextProps,
+  useSlottedContext,
+} from 'react-aria-components/slots';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -136,11 +142,50 @@ const Caption = ({ className, ...restProps }: CaptionProps) => (
 
 const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
+type HeaderProps = HTMLProps<HTMLDivElement> & {
+  children: React.ReactNode;
+  /** @private Used by Modal/Drawer to inject the close button into the header */
+  _action?: ReactNode;
+  /** Ref for the element. */
+  ref?: Ref<HTMLDivElement>;
+};
+
+const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivElement>>({});
+
+/**
+ * Wraps the title (and optional close button) of a Modal/Drawer.
+ *
+ * Renders a `data-slot="header"` element that consumers can style freely,
+ * e.g. `className="sticky top-0 bg-white"`. A `Heading` placed inside
+ * automatically gets the title styling and is wired as the dialog's accessible
+ * name, so no `slot="title"` is needed.
+ */
+const Header = ({ ref = null, ...props }: HeaderProps) => {
+  [props, ref] = useContextProps(props, ref, HeaderContext);
+  const { children, className, _action: action, ...restProps } = props;
+
+  // React Aria's Dialog exposes the generated title id through its own
+  // HeadingContext. We forward it to our Heading so the dialog gets an
+  // accessible name via aria-labelledby.
+  const racTitle = useSlottedContext(RACHeadingContext, 'title');
+
+  return (
+    <div ref={ref} {...restProps} className={className} data-slot="header">
+      <Provider values={[[HeadingContext, { className: 'heading-s', id: racTitle?.id }]]}>
+        {children}
+      </Provider>
+      {action}
+    </div>
+  );
+};
+
 export {
   Caption,
   Content,
   ContentContext,
   Footer,
+  Header,
+  HeaderContext,
   Heading,
   HeadingContext,
   Media,
@@ -148,6 +193,7 @@ export {
   type CaptionProps,
   type ContentProps,
   type FooterProps,
+  type HeaderProps,
   type HeadingProps,
   type MediaProps,
 };

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,6 +1,13 @@
 import { cva, cx, type VariantProps } from 'cva';
-import { createContext, type HTMLProps, type ReactNode, type Ref } from 'react';
-import { type ContextValue, Provider, useContextProps } from 'react-aria-components/slots';
+import { createContext, type HTMLProps, type Ref } from 'react';
+import {
+  DEFAULT_SLOT,
+  type ContextValue,
+  Provider,
+  useContextProps,
+} from 'react-aria-components/slots';
+
+import { ButtonContext, type ButtonProps } from '../button';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -138,10 +145,10 @@ const Footer = (props: FooterProps) => <div {...props} data-slot="footer" />;
 
 type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
-  /** @private Used by Modal/Drawer to inject the close button into the header */
-  _action?: ReactNode;
   /** @private Set by Modal/Drawer to the dialog's title id, wired onto the heading for `aria-labelledby` */
   _titleId?: string;
+  /** @private Set by Modal/Drawer with the appearance for a `<Button slot="close" />` placed inside */
+  _closeButton?: Partial<ButtonProps>;
   /** Ref for the element. */
   ref?: Ref<HTMLDivElement>;
 };
@@ -149,24 +156,29 @@ type HeaderProps = HTMLProps<HTMLDivElement> & {
 const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivElement>>({});
 
 /**
- * Wraps the title (and optional close button) of a Modal/Drawer.
+ * Wraps the title of a Modal/Drawer (and, optionally, a `<Button slot="close" />`).
  *
  * Renders a `data-slot="header"` element that consumers can style freely,
  * e.g. `className="sticky top-0 bg-white"`. A `Heading` placed inside gets the
  * title styling, and — inside a Modal/Drawer — the dialog's accessible name is
  * wired up automatically (via the injected `_titleId`), so no `slot="title"` is
- * needed.
+ * needed. A `<Button slot="close" />` inside gets its icon and styling injected,
+ * so the consumer only writes the bare button.
  */
 const Header = ({ ref = null, ...props }: HeaderProps) => {
   [props, ref] = useContextProps(props, ref, HeaderContext);
-  const { children, className, _action: action, _titleId: titleId, ...restProps } = props;
+  const { children, className, _titleId: titleId, _closeButton: closeButton, ...restProps } = props;
 
   return (
     <div ref={ref} {...restProps} className={className} data-slot="header">
-      <Provider values={[[HeadingContext, { className: 'heading-s', id: titleId }]]}>
+      <Provider
+        values={[
+          [HeadingContext, { className: 'heading-s', id: titleId }],
+          [ButtonContext, { slots: { [DEFAULT_SLOT]: {}, close: closeButton ?? {} } }],
+        ]}
+      >
         {children}
       </Provider>
-      {action}
     </div>
   );
 };

--- a/packages/react/src/content/content.tsx
+++ b/packages/react/src/content/content.tsx
@@ -1,3 +1,4 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
 import { createContext, type HTMLProps, type Ref } from 'react';
 import {
@@ -7,7 +8,9 @@ import {
   useContextProps,
 } from 'react-aria-components/slots';
 
-import { ButtonContext, type ButtonProps } from '../button';
+import { ButtonContext } from '../button';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 type HeadingProps = Omit<HTMLProps<HTMLHeadingElement>, 'size'> &
   VariantProps<typeof headingVariants> & {
@@ -147,8 +150,6 @@ type HeaderProps = HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
   /** @private Set by Modal/Drawer to the dialog's title id, wired onto the heading for `aria-labelledby` */
   _titleId?: string;
-  /** @private Set by Modal/Drawer with the appearance for a `<Button slot="close" />` placed inside */
-  _closeButton?: Partial<ButtonProps>;
   /** Ref for the element. */
   ref?: Ref<HTMLDivElement>;
 };
@@ -167,14 +168,30 @@ const HeaderContext = createContext<ContextValue<Partial<HeaderProps>, HTMLDivEl
  */
 const Header = ({ ref = null, ...props }: HeaderProps) => {
   [props, ref] = useContextProps(props, ref, HeaderContext);
-  const { children, className, _titleId: titleId, _closeButton: closeButton, ...restProps } = props;
+  const { children, className, _titleId: titleId, ...restProps } = props;
+  const locale = useLocale();
 
   return (
     <div ref={ref} {...restProps} className={className} data-slot="header">
       <Provider
         values={[
           [HeadingContext, { className: 'heading-s', id: titleId }],
-          [ButtonContext, { slots: { [DEFAULT_SLOT]: {}, close: closeButton ?? {} } }],
+          // Appearance for a bare `<Button slot="close" />` inside the header. The
+          // close behaviour (onPress) is provided by the Modal/Drawer's Dialog.
+          [
+            ButtonContext,
+            {
+              slots: {
+                [DEFAULT_SLOT]: {},
+                close: {
+                  variant: 'tertiary',
+                  'aria-label': translations.close[locale],
+                  className: 'data-focus-visible:outline-focus-inset px-2.5!',
+                  children: <Close />,
+                },
+              },
+            },
+          ],
         ]}
       >
         {children}

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -241,7 +241,7 @@ export const StickyHeaderFooter: Story = {
         <Button>Åpne skjema</Button>
         <Drawer>
           <Dialog>
-            <Header className="sticky top-0 z-10 -mx-4 -mt-4 bg-white p-4 ">
+            <Header className="sticky top-0 z-10 -mx-4 -mt-4 bg-white p-4">
               <Heading level={2}>Meld interesse</Heading>
             </Header>
             {Array.from({ length: 12 }).map((_, i) => (
@@ -250,7 +250,7 @@ export const StickyHeaderFooter: Story = {
                 slik at draweren må scrolles, og du kan se at header og footer blir værende synlige.
               </p>
             ))}
-            <Footer className="sticky bottom-0 z-10 -mx-4 -mb-4 bg-white p-4 ">
+            <Footer className="sticky bottom-0 z-10 -mx-4 -mb-4 bg-white p-4">
               <Button slot="close">Send inn</Button>
               <Button variant="tertiary" slot="close">
                 Avbryt

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -241,7 +241,7 @@ export const StickyHeaderFooter: Story = {
         <Button>Åpne skjema</Button>
         <Drawer>
           <Dialog>
-            <Header className="sticky top-0 z-10 -mx-4 -mt-4 bg-white px-4 pt-4">
+            <Header className="sticky top-0 z-10 -mx-4 -mt-4 bg-white p-4 ">
               <Heading level={2}>Meld interesse</Heading>
             </Header>
             {Array.from({ length: 12 }).map((_, i) => (
@@ -250,7 +250,7 @@ export const StickyHeaderFooter: Story = {
                 slik at draweren må scrolles, og du kan se at header og footer blir værende synlige.
               </p>
             ))}
-            <Footer className="sticky bottom-0 z-10 -mx-4 -mb-4 bg-white px-4 pb-4">
+            <Footer className="sticky bottom-0 z-10 -mx-4 -mb-4 bg-white p-4 ">
               <Button slot="close">Send inn</Button>
               <Button variant="tertiary" slot="close">
                 Avbryt

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 import { Button } from '../button';
-import { Footer, Heading } from '../content';
+import { Footer, Header, Heading } from '../content';
 import { UNSAFE_Dialog as Dialog, UNSAFE_DialogTrigger as DialogTrigger } from '../modal';
 import { UNSAFE_Drawer as Drawer } from './drawer';
 
@@ -18,9 +18,9 @@ const meta = {
         <Button>Åpne</Button>
         <Drawer>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Hvitevarer
-            </Heading>
+            <Header>
+              <Heading level={2}>Hvitevarer</Heading>
+            </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
               tørketrommel, oppvaskmaskin eller å avstå dette tilbudet.
@@ -54,9 +54,9 @@ export const Left: Story = {
         <Button>Åpne fra venstre</Button>
         <Drawer placement="left">
           <Dialog>
-            <Heading slot="title" level={2}>
-              Filter
-            </Heading>
+            <Header>
+              <Heading level={2}>Filter</Heading>
+            </Header>
             <p>Drawer fra venstre side. Vanlig brukt for navigasjon eller filtre.</p>
             <Button slot="close">Lukk</Button>
           </Dialog>
@@ -73,9 +73,9 @@ export const Top: Story = {
         <Button>Åpne fra toppen</Button>
         <Drawer placement="top">
           <Dialog>
-            <Heading slot="title" level={2}>
-              Varsel
-            </Heading>
+            <Header>
+              <Heading level={2}>Varsel</Heading>
+            </Header>
             <p>Drawer fra toppen, for eksempel for varsler eller hurtigvalg.</p>
             <Button slot="close">Lukk</Button>
           </Dialog>
@@ -92,9 +92,9 @@ export const Bottom: Story = {
         <Button>Åpne fra bunnen</Button>
         <Drawer placement="bottom">
           <Dialog>
-            <Heading slot="title" level={2}>
-              Detaljer
-            </Heading>
+            <Header>
+              <Heading level={2}>Detaljer</Heading>
+            </Header>
             <p>Drawer fra bunnen — fungerer godt på mobil for sekundære handlinger.</p>
             <Footer>
               <Button slot="close">Lagre</Button>
@@ -116,9 +116,9 @@ export const MultipleActions: Story = {
         <Button>Åpne</Button>
         <Drawer>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Hvitevarer
-            </Heading>
+            <Header>
+              <Heading level={2}>Hvitevarer</Heading>
+            </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
               tørketrommel, oppvaskmaskin eller å avstå dette tilbudet.
@@ -146,9 +146,9 @@ export const Controlled: Story = {
         <Button onPress={() => setIsOpen(true)}>Åpne Drawer</Button>
         <Drawer isOpen={isOpen} onOpenChange={setIsOpen}>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Tittel
-            </Heading>
+            <Header>
+              <Heading level={2}>Tittel</Heading>
+            </Header>
             <p>Denne drawer er controlled.</p>
             <Button onPress={() => setIsOpen(false)} slot="close">
               Lukk
@@ -168,9 +168,9 @@ export const NotDismissable: Story = {
         <Button onPress={() => setIsOpen(true)}>Åpne</Button>
         <Drawer isOpen={isOpen} onOpenChange={setIsOpen} isDismissable={false}>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Bekreft handlingen
-            </Heading>
+            <Header>
+              <Heading level={2}>Bekreft handlingen</Heading>
+            </Header>
             <p>
               Klikk utenfor og <kbd>Escape</kbd> lukker ikke denne drawer, og close-knappen vises
               ikke automatisk i headeren.
@@ -190,9 +190,11 @@ export const CustomBackground: Story = {
         <Button>Åpne</Button>
         <Drawer className="bg-blue-dark! text-mint-light">
           <Dialog>
-            <Heading slot="title" level={2} className="text-mint">
-              Mørk drawer
-            </Heading>
+            <Header>
+              <Heading level={2} className="text-mint">
+                Mørk drawer
+              </Heading>
+            </Header>
             <p>
               Bakgrunnsfargen kan inntil videre overstyres med `!`-prefiks, og innholdsfarger settes
               på `Heading` og tekstelementer etter behov.
@@ -214,11 +216,46 @@ export const CustomZIndex: Story = {
         <Button>Åpne</Button>
         <Drawer zIndex={50}>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Custom z-index
-            </Heading>
+            <Header>
+              <Heading level={2}>Custom z-index</Heading>
+            </Header>
             <p>Drawer med z-index 50.</p>
             <Button slot="close">Lukk</Button>
+          </Dialog>
+        </Drawer>
+      </DialogTrigger>
+    </div>
+  ),
+};
+
+/**
+ * Sticky header og footer er konsumentens ansvar via `className` — komponenten
+ * implementerer det ikke selv. Her er `Header` og `Footer` gjort `position: sticky`,
+ * og de negative marginene (`-mx-4` m.m.) lar bakgrunnen dekke hele bredden til
+ * tross for paddingen på `Dialog`.
+ */
+export const StickyHeaderFooter: Story = {
+  render: () => (
+    <div className="p-4">
+      <DialogTrigger>
+        <Button>Åpne skjema</Button>
+        <Drawer>
+          <Dialog>
+            <Header className="sticky top-0 z-10 -mx-4 -mt-4 bg-white px-4 pt-4">
+              <Heading level={2}>Meld interesse</Heading>
+            </Header>
+            {Array.from({ length: 12 }).map((_, i) => (
+              <p key={i}>
+                Avsnitt {i + 1}: Fyll inn skjemaet for å melde interesse. Innholdet er bevisst langt
+                slik at draweren må scrolles, og du kan se at header og footer blir værende synlige.
+              </p>
+            ))}
+            <Footer className="sticky bottom-0 z-10 -mx-4 -mb-4 bg-white px-4 pb-4">
+              <Button slot="close">Send inn</Button>
+              <Button variant="tertiary" slot="close">
+                Avbryt
+              </Button>
+            </Footer>
           </Dialog>
         </Drawer>
       </DialogTrigger>

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -241,7 +241,7 @@ export const StickyHeaderFooter: Story = {
         <Button>Åpne skjema</Button>
         <Drawer>
           <Dialog>
-            <Header className="sticky top-0 z-10 -mx-4 -mt-4 bg-white p-4">
+            <Header className="sticky top-0 z-10 -m-4 bg-white p-4">
               <Heading level={2}>Meld interesse</Heading>
             </Header>
             {Array.from({ length: 12 }).map((_, i) => (

--- a/packages/react/src/drawer/drawer.stories.tsx
+++ b/packages/react/src/drawer/drawer.stories.tsx
@@ -20,6 +20,7 @@ const meta = {
           <Dialog>
             <Header>
               <Heading level={2}>Hvitevarer</Heading>
+              <Button slot="close" />
             </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
@@ -56,6 +57,7 @@ export const Left: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Filter</Heading>
+              <Button slot="close" />
             </Header>
             <p>Drawer fra venstre side. Vanlig brukt for navigasjon eller filtre.</p>
             <Button slot="close">Lukk</Button>
@@ -75,6 +77,7 @@ export const Top: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Varsel</Heading>
+              <Button slot="close" />
             </Header>
             <p>Drawer fra toppen, for eksempel for varsler eller hurtigvalg.</p>
             <Button slot="close">Lukk</Button>
@@ -94,6 +97,7 @@ export const Bottom: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Detaljer</Heading>
+              <Button slot="close" />
             </Header>
             <p>Drawer fra bunnen — fungerer godt på mobil for sekundære handlinger.</p>
             <Footer>
@@ -118,6 +122,7 @@ export const MultipleActions: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Hvitevarer</Heading>
+              <Button slot="close" />
             </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
@@ -148,6 +153,7 @@ export const Controlled: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Tittel</Heading>
+              <Button slot="close" />
             </Header>
             <p>Denne drawer er controlled.</p>
             <Button onPress={() => setIsOpen(false)} slot="close">
@@ -172,8 +178,8 @@ export const NotDismissable: Story = {
               <Heading level={2}>Bekreft handlingen</Heading>
             </Header>
             <p>
-              Klikk utenfor og <kbd>Escape</kbd> lukker ikke denne drawer, og close-knappen vises
-              ikke automatisk i headeren.
+              Klikk utenfor og <kbd>Escape</kbd> lukker ikke denne drawer, og vi utelater
+              lukkeknappen i headeren.
             </p>
             <Button onPress={() => setIsOpen(false)}>Bekreft</Button>
           </Dialog>
@@ -194,6 +200,7 @@ export const CustomBackground: Story = {
               <Heading level={2} className="text-mint">
                 Mørk drawer
               </Heading>
+              <Button slot="close" color="mint" />
             </Header>
             <p>
               Bakgrunnsfargen kan inntil videre overstyres med `!`-prefiks, og innholdsfarger settes
@@ -218,6 +225,7 @@ export const CustomZIndex: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Custom z-index</Heading>
+              <Button slot="close" />
             </Header>
             <p>Drawer med z-index 50.</p>
             <Button slot="close">Lukk</Button>
@@ -231,7 +239,7 @@ export const CustomZIndex: Story = {
 /**
  * Sticky header og footer er konsumentens ansvar via `className` — komponenten
  * implementerer det ikke selv. Her er `Header` og `Footer` gjort `position: sticky`,
- * og de negative marginene (`-mx-4` m.m.) lar bakgrunnen dekke hele bredden til
+ * og de negative marginene (`-m-4` m.m.) lar bakgrunnen dekke hele bredden til
  * tross for paddingen på `Dialog`.
  */
 export const StickyHeaderFooter: Story = {
@@ -243,6 +251,7 @@ export const StickyHeaderFooter: Story = {
           <Dialog>
             <Header className="sticky top-0 z-10 -m-4 bg-white p-4">
               <Heading level={2}>Meld interesse</Heading>
+              <Button slot="close" />
             </Header>
             {Array.from({ length: 12 }).map((_, i) => (
               <p key={i}>

--- a/packages/react/src/drawer/drawer.tsx
+++ b/packages/react/src/drawer/drawer.tsx
@@ -5,10 +5,10 @@ import {
   ModalOverlay as RACModalOverlay,
   type ModalOverlayProps as RACModalOverlayProps,
 } from 'react-aria-components/Modal';
-import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
+import { Provider } from 'react-aria-components/slots';
 
 import { Button } from '../button';
-import { HeadingContext } from '../content';
+import { HeaderContext } from '../content';
 import { translations } from '../translations';
 import { useLocale } from '../use-locale';
 
@@ -66,30 +66,21 @@ const Drawer = ({
     <Provider
       values={[
         [
-          HeadingContext,
+          HeaderContext,
           {
-            slots: {
-              [DEFAULT_SLOT]: {}, // RAC requires a default slot in order to support non-slotted components
-              title: {
-                className: 'heading-s',
-                _outerWrapper: (children) => (
-                  <div className="flex items-center justify-between gap-x-2">
-                    {children}
-                    {isDismissable && (
-                      <Button
-                        slot="close" // RAC Dialog supports one close button out of the box, so we utilize that here
-                        variant="tertiary"
-                        className="data-focus-visible:outline-focus-inset px-2.5!"
-                        aria-label={translations.close[locale]}
-                        onPress={() => onOpenChange?.(false)}
-                      >
-                        <Close />
-                      </Button>
-                    )}
-                  </div>
-                ),
-              },
-            },
+            // The close button is injected into the Header. RAC Dialog supports
+            // one "close" slot out of the box, which we utilize here.
+            _action: isDismissable ? (
+              <Button
+                slot="close"
+                variant="tertiary"
+                className="data-focus-visible:outline-focus-inset px-2.5!"
+                aria-label={translations.close[locale]}
+                onPress={() => onOpenChange?.(false)}
+              >
+                <Close />
+              </Button>
+            ) : undefined,
           },
         ],
       ]}

--- a/packages/react/src/drawer/drawer.tsx
+++ b/packages/react/src/drawer/drawer.tsx
@@ -1,3 +1,4 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
 import {
   Modal as RACModal,
@@ -6,7 +7,10 @@ import {
 } from 'react-aria-components/Modal';
 import { Provider } from 'react-aria-components/slots';
 
+import { Button } from '../button';
 import { HeaderContext } from '../content';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 const drawerVariants = cva({
   base: ['fixed overflow-auto bg-white text-left shadow-xl', 'motion-reduce:animate-none'],
@@ -57,14 +61,26 @@ const Drawer = ({
   style = {},
   ...restProps
 }: DrawerProps) => {
+  const locale = useLocale();
   return (
     <Provider
       values={[
         [
           HeaderContext,
           {
-            // Header renders the dismiss button itself; we only pass the close handler.
-            _onClose: isDismissable ? () => onOpenChange?.(false) : undefined,
+            // The close button is injected into the Header. RAC Dialog supports
+            // one "close" slot out of the box, which we utilize here.
+            _action: isDismissable ? (
+              <Button
+                slot="close"
+                variant="tertiary"
+                className="data-focus-visible:outline-focus-inset px-2.5!"
+                aria-label={translations.close[locale]}
+                onPress={() => onOpenChange?.(false)}
+              >
+                <Close />
+              </Button>
+            ) : undefined,
           },
         ],
       ]}

--- a/packages/react/src/drawer/drawer.tsx
+++ b/packages/react/src/drawer/drawer.tsx
@@ -1,16 +1,9 @@
-import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
 import {
   Modal as RACModal,
   ModalOverlay as RACModalOverlay,
   type ModalOverlayProps as RACModalOverlayProps,
 } from 'react-aria-components/Modal';
-import { Provider } from 'react-aria-components/slots';
-
-import { Button } from '../button';
-import { HeaderContext } from '../content';
-import { translations } from '../translations';
-import { useLocale } from '../use-locale';
 
 const drawerVariants = cva({
   base: ['fixed overflow-auto bg-white text-left shadow-xl', 'motion-reduce:animate-none'],
@@ -60,57 +53,31 @@ const Drawer = ({
   placement = 'right',
   style = {},
   ...restProps
-}: DrawerProps) => {
-  const locale = useLocale();
-  return (
-    <Provider
-      values={[
-        [
-          HeaderContext,
-          {
-            // The close button is injected into the Header. RAC Dialog supports
-            // one "close" slot out of the box, which we utilize here.
-            _action: isDismissable ? (
-              <Button
-                slot="close"
-                variant="tertiary"
-                className="data-focus-visible:outline-focus-inset px-2.5!"
-                aria-label={translations.close[locale]}
-                onPress={() => onOpenChange?.(false)}
-              >
-                <Close />
-              </Button>
-            ) : undefined,
-          },
-        ],
-      ]}
-    >
-      <RACModalOverlay
-        isOpen={isOpen}
-        onOpenChange={onOpenChange}
-        defaultOpen={defaultOpen}
-        isDismissable={isDismissable}
-        isKeyboardDismissDisabled={!isDismissable}
-        style={{ zIndex, ...style }}
-        className={({ isEntering, isExiting }) =>
-          cx(
-            'fixed inset-0 bg-black/25 backdrop-blur-sm',
-            isEntering && 'fade-in animate-in duration-300 ease-out',
-            isExiting && 'fade-out animate-out duration-200 ease-in',
-            // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
-            'motion-reduce:animate-none',
-          )
-        }
-      >
-        <RACModal
-          {...restProps}
-          className={({ isEntering, isExiting }) =>
-            drawerVariants({ placement, isEntering, isExiting, className })
-          }
-        />
-      </RACModalOverlay>
-    </Provider>
-  );
-};
+}: DrawerProps) => (
+  <RACModalOverlay
+    isOpen={isOpen}
+    onOpenChange={onOpenChange}
+    defaultOpen={defaultOpen}
+    isDismissable={isDismissable}
+    isKeyboardDismissDisabled={!isDismissable}
+    style={{ zIndex, ...style }}
+    className={({ isEntering, isExiting }) =>
+      cx(
+        'fixed inset-0 bg-black/25 backdrop-blur-sm',
+        isEntering && 'fade-in animate-in duration-300 ease-out',
+        isExiting && 'fade-out animate-out duration-200 ease-in',
+        // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
+        'motion-reduce:animate-none',
+      )
+    }
+  >
+    <RACModal
+      {...restProps}
+      className={({ isEntering, isExiting }) =>
+        drawerVariants({ placement, isEntering, isExiting, className })
+      }
+    />
+  </RACModalOverlay>
+);
 
 export { Drawer as UNSAFE_Drawer, type DrawerProps as UNSAFE_DrawerProps };

--- a/packages/react/src/drawer/drawer.tsx
+++ b/packages/react/src/drawer/drawer.tsx
@@ -1,4 +1,3 @@
-import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cva, cx, type VariantProps } from 'cva';
 import {
   Modal as RACModal,
@@ -7,10 +6,7 @@ import {
 } from 'react-aria-components/Modal';
 import { Provider } from 'react-aria-components/slots';
 
-import { Button } from '../button';
 import { HeaderContext } from '../content';
-import { translations } from '../translations';
-import { useLocale } from '../use-locale';
 
 const drawerVariants = cva({
   base: ['fixed overflow-auto bg-white text-left shadow-xl', 'motion-reduce:animate-none'],
@@ -61,26 +57,14 @@ const Drawer = ({
   style = {},
   ...restProps
 }: DrawerProps) => {
-  const locale = useLocale();
   return (
     <Provider
       values={[
         [
           HeaderContext,
           {
-            // The close button is injected into the Header. RAC Dialog supports
-            // one "close" slot out of the box, which we utilize here.
-            _action: isDismissable ? (
-              <Button
-                slot="close"
-                variant="tertiary"
-                className="data-focus-visible:outline-focus-inset px-2.5!"
-                aria-label={translations.close[locale]}
-                onPress={() => onOpenChange?.(false)}
-              >
-                <Close />
-              </Button>
-            ) : undefined,
+            // Header renders the dismiss button itself; we only pass the close handler.
+            _onClose: isDismissable ? () => onOpenChange?.(false) : undefined,
           },
         ],
       ]}

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { Button } from '../button';
 import { TabbedImageGallery } from '../carousel/carousel.stories';
-import { Footer, Heading } from '../content';
+import { Footer, Header, Heading } from '../content';
 import {
   UNSAFE_Dialog as Dialog,
   UNSAFE_DialogTrigger as DialogTrigger,
@@ -23,9 +23,9 @@ const meta = {
           <Button>Åpne</Button>
           <Modal>
             <Dialog>
-              <Heading slot="title" level={2}>
-                Hvitevarer
-              </Heading>
+              <Header>
+                <Heading level={2}>Hvitevarer</Heading>
+              </Header>
               <p>
                 Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
                 tørketrommel, oppvaskmaskin eller å avstå dette tilbudet.
@@ -65,9 +65,9 @@ export const MultipleActions: Story = {
         <Button>Åpne</Button>
         <Modal>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Hvitevarer
-            </Heading>
+            <Header>
+              <Heading level={2}>Hvitevarer</Heading>
+            </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
               tørketrommel, oppvaskmaskin eller å avstå dette tilbudet.
@@ -96,9 +96,9 @@ export const Controlled: Story = {
           <Button onPress={() => setIsOpen(true)}>Open Modal</Button>
           <Modal isOpen={isOpen} onOpenChange={setIsOpen}>
             <Dialog>
-              <Heading slot="title" level={2}>
-                Tittel
-              </Heading>
+              <Header>
+                <Heading level={2}>Tittel</Heading>
+              </Header>
               <p>Denne modalen er controlled.</p>
               <Button onPress={() => setIsOpen(false)} slot="close">
                 Lukk
@@ -142,9 +142,9 @@ export const AsyncControlled: Story = {
           <Button onPress={() => setIsOpen(true)}>Open Modal</Button>
           <Modal isOpen={isOpen} onOpenChange={setIsOpen} isDismissable={false}>
             <Dialog>
-              <Heading slot="title" level={2}>
-                Tittel
-              </Heading>
+              <Header>
+                <Heading level={2}>Tittel</Heading>
+              </Header>
               <p>Denne modalen er controlled.</p>
               {countdown > 0 && <strong>Lukkes om {countdown} s.</strong>}
               <Button onPress={handleClose}>Lukk</Button>
@@ -163,9 +163,9 @@ export const CustomZIndex: Story = {
         <Button>Åpne</Button>
         <Modal zIndex={50}>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Hvitevarer
-            </Heading>
+            <Header>
+              <Heading level={2}>Hvitevarer</Heading>
+            </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
               tørketrommel, oppvaskmaskin eller å avstå dette tilbudet.
@@ -198,9 +198,9 @@ export const Fullscreen: Story = {
         <Button>Åpne fullskjerm</Button>
         <Modal fullscreen>
           <Dialog>
-            <Heading slot="title" level={2}>
-              Fullskjerm modal
-            </Heading>
+            <Header>
+              <Heading level={2}>Fullskjerm modal</Heading>
+            </Header>
             <p>Denne modalen dekker hele skjermen.</p>
             <Button slot="close">Lukk</Button>
           </Dialog>
@@ -217,9 +217,9 @@ export const ImageGalleryModal: Story = {
         <Button>Åpne bildegalleri</Button>
         <Modal fullscreen>
           <Dialog className="container h-full">
-            <Heading slot="title" level={2}>
-              Bildegalleri - Eksempel
-            </Heading>
+            <Header>
+              <Heading level={2}>Bildegalleri - Eksempel</Heading>
+            </Header>
             <TabbedImageGallery />
           </Dialog>
         </Modal>

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -25,6 +25,7 @@ const meta = {
             <Dialog>
               <Header>
                 <Heading level={2}>Hvitevarer</Heading>
+                <Button slot="close" />
               </Header>
               <p>
                 Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
@@ -67,6 +68,7 @@ export const MultipleActions: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Hvitevarer</Heading>
+              <Button slot="close" />
             </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
@@ -98,6 +100,7 @@ export const Controlled: Story = {
             <Dialog>
               <Header>
                 <Heading level={2}>Tittel</Heading>
+                <Button slot="close" />
               </Header>
               <p>Denne modalen er controlled.</p>
               <Button onPress={() => setIsOpen(false)} slot="close">
@@ -165,6 +168,7 @@ export const CustomZIndex: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Hvitevarer</Heading>
+              <Button slot="close" />
             </Header>
             <p>
               Denne boligen har tilvalg om hvitevarer fra HTH. Mulighet for vaskemaskin,
@@ -200,6 +204,7 @@ export const Fullscreen: Story = {
           <Dialog>
             <Header>
               <Heading level={2}>Fullskjerm modal</Heading>
+              <Button slot="close" />
             </Header>
             <p>Denne modalen dekker hele skjermen.</p>
             <Button slot="close">Lukk</Button>
@@ -219,6 +224,7 @@ export const ImageGalleryModal: Story = {
           <Dialog className="container h-full">
             <Header>
               <Heading level={2}>Bildegalleri - Eksempel</Heading>
+              <Button slot="close" />
             </Header>
             <TabbedImageGallery />
           </Dialog>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,6 +1,7 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { useContext } from 'react';
-import { ButtonContext } from 'react-aria-components/Button';
+import { ButtonContext as RACButtonContext } from 'react-aria-components/Button';
 import {
   OverlayTriggerStateContext,
   Dialog as RACDialog,
@@ -8,12 +9,18 @@ import {
   DialogTrigger as RACDialogTrigger,
   type DialogTriggerProps as RACDialogTriggerProps,
 } from 'react-aria-components/Dialog';
+import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
 import {
   Modal as RACModal,
   ModalOverlay as RACModalOverlay,
   type ModalOverlayProps as RACModalOverlayProps,
 } from 'react-aria-components/Modal';
-import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
+import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
+
+import { ButtonContext } from '../button';
+import { HeaderContext, HeadingContext } from '../content';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 type DialogTriggerProps = RACDialogTriggerProps;
 
@@ -90,6 +97,49 @@ const Modal = ({
   </_ModalOverlay>
 );
 
+/**
+ * Rendered inside RACDialog (where React Aria exposes the generated title id via
+ * its HeadingContext). Builds the contexts the header content needs and hands them
+ * to `Header` through `HeaderContext`, so `Header` only has to render a `Provider`
+ * around its own children — no knowledge of the dialog, close icon or locale.
+ */
+const HeaderTitle = ({ children }: { children: React.ReactNode }) => {
+  const racTitle = useSlottedContext(RACHeadingContext, 'title');
+  const locale = useLocale();
+  return (
+    <Provider
+      values={[
+        [
+          HeaderContext,
+          {
+            _providerValues: [
+              [HeadingContext, { className: 'heading-s', id: racTitle?.id }],
+              [
+                ButtonContext,
+                {
+                  slots: {
+                    [DEFAULT_SLOT]: {},
+                    // Appearance for a bare `<Button slot="close" />`; the close
+                    // behaviour (onPress) comes from the Dialog's ButtonContext below.
+                    close: {
+                      variant: 'tertiary',
+                      'aria-label': translations.close[locale],
+                      className: 'data-focus-visible:outline-focus-inset px-2.5!',
+                      children: <Close />,
+                    },
+                  },
+                },
+              ],
+            ],
+          },
+        ],
+      ]}
+    >
+      {children}
+    </Provider>
+  );
+};
+
 type DialogProps = RACDialogProps & {
   children: React.ReactNode;
 };
@@ -110,7 +160,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
       <Provider
         values={[
           [
-            ButtonContext,
+            RACButtonContext,
             {
               // This is necessary to support multiple close buttons
               slots: {
@@ -127,7 +177,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
           ],
         ]}
       >
-        {children}
+        <HeaderTitle>{children}</HeaderTitle>
       </Provider>
     )}
   </RACDialog>
@@ -141,7 +191,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
 export const _ModalButtonContextReset = ({ children }: { children: React.ReactNode }) => {
   const isInsideOverlay = !!useContext(OverlayTriggerStateContext);
   return isInsideOverlay ? (
-    <Provider values={[[ButtonContext, null]]}>{children}</Provider>
+    <Provider values={[[RACButtonContext, null]]}>{children}</Provider>
   ) : (
     children
   );

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -9,12 +9,13 @@ import {
   DialogTrigger as RACDialogTrigger,
   type DialogTriggerProps as RACDialogTriggerProps,
 } from 'react-aria-components/Dialog';
+import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
 import {
   Modal as RACModal,
   ModalOverlay as RACModalOverlay,
   type ModalOverlayProps as RACModalOverlayProps,
 } from 'react-aria-components/Modal';
-import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
+import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
 
 import { Button } from '../button';
 import { HeaderContext } from '../content';
@@ -122,6 +123,22 @@ const Modal = ({
   );
 };
 
+/**
+ * Rendered inside RACDialog, where React Aria exposes the generated title id
+ * through its HeadingContext. We read it here and forward it to our Header via
+ * HeaderContext, so Header stays agnostic of React Aria's Dialog and only needs
+ * to wire the id onto its heading (for `aria-labelledby`).
+ */
+const HeaderTitle = ({ children }: { children: React.ReactNode }) => {
+  const racTitle = useSlottedContext(RACHeadingContext, 'title');
+  const header = useContext(HeaderContext) as { _action?: React.ReactNode } | null;
+  return (
+    <Provider values={[[HeaderContext, { ...header, _titleId: racTitle?.id }]]}>
+      {children}
+    </Provider>
+  );
+};
+
 type DialogProps = RACDialogProps & {
   children: React.ReactNode;
 };
@@ -159,7 +176,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
           ],
         ]}
       >
-        {children}
+        <HeaderTitle>{children}</HeaderTitle>
       </Provider>
     )}
   </RACDialog>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -8,15 +8,12 @@ import {
   DialogTrigger as RACDialogTrigger,
   type DialogTriggerProps as RACDialogTriggerProps,
 } from 'react-aria-components/Dialog';
-import { HeadingContext as RACHeadingContext } from 'react-aria-components/Heading';
 import {
   Modal as RACModal,
   ModalOverlay as RACModalOverlay,
   type ModalOverlayProps as RACModalOverlayProps,
 } from 'react-aria-components/Modal';
-import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
-
-import { HeaderContext } from '../content';
+import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
 
 type DialogTriggerProps = RACDialogTriggerProps;
 
@@ -93,17 +90,6 @@ const Modal = ({
   </_ModalOverlay>
 );
 
-/**
- * Rendered inside RACDialog, where React Aria exposes the generated title id
- * through its HeadingContext. We read it here and forward it to our Header via
- * HeaderContext, so Header stays agnostic of React Aria's Dialog and only needs
- * to wire the id onto its heading (for `aria-labelledby`).
- */
-const HeaderTitle = ({ children }: { children: React.ReactNode }) => {
-  const racTitle = useSlottedContext(RACHeadingContext, 'title');
-  return <Provider values={[[HeaderContext, { _titleId: racTitle?.id }]]}>{children}</Provider>;
-};
-
 type DialogProps = RACDialogProps & {
   children: React.ReactNode;
 };
@@ -141,7 +127,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
           ],
         ]}
       >
-        <HeaderTitle>{children}</HeaderTitle>
+        {children}
       </Provider>
     )}
   </RACDialog>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,3 +1,4 @@
+import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { useContext } from 'react';
 import { ButtonContext } from 'react-aria-components/Button';
@@ -15,7 +16,10 @@ import {
 } from 'react-aria-components/Modal';
 import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
 
+import { Button } from '../button';
 import { HeaderContext } from '../content';
+import { translations } from '../translations';
+import { useLocale } from '../use-locale';
 
 type DialogTriggerProps = RACDialogTriggerProps;
 
@@ -66,14 +70,26 @@ const Modal = ({
   fullscreen = false,
   ...restProps
 }: ModalProps) => {
+  const locale = useLocale();
   return (
     <Provider
       values={[
         [
           HeaderContext,
           {
-            // Header renders the dismiss button itself; we only pass the close handler.
-            _onClose: isDismissable ? () => onOpenChange?.(false) : undefined,
+            // The close button is injected into the Header. RAC Dialog supports
+            // one "close" slot out of the box, which we utilize here.
+            _action: isDismissable ? (
+              <Button
+                slot="close"
+                variant="tertiary"
+                className="data-focus-visible:outline-focus-inset px-2.5!"
+                aria-label={translations.close[locale]}
+                onPress={() => onOpenChange?.(false)}
+              >
+                <Close />
+              </Button>
+            ) : undefined,
           },
         ],
       ]}

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,4 +1,3 @@
-import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { useContext } from 'react';
 import { ButtonContext } from 'react-aria-components/Button';
@@ -18,8 +17,6 @@ import {
 import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
 
 import { HeaderContext } from '../content';
-import { translations } from '../translations';
-import { useLocale } from '../use-locale';
 
 type DialogTriggerProps = RACDialogTriggerProps;
 
@@ -104,30 +101,7 @@ const Modal = ({
  */
 const HeaderTitle = ({ children }: { children: React.ReactNode }) => {
   const racTitle = useSlottedContext(RACHeadingContext, 'title');
-  const locale = useLocale();
-  return (
-    <Provider
-      values={[
-        [
-          HeaderContext,
-          {
-            _titleId: racTitle?.id,
-            // Defaults for a `<Button slot="close" />` placed inside the Header.
-            // The close behaviour (onPress) comes from the Dialog's ButtonContext;
-            // here we only inject the appearance and the accessible name.
-            _closeButton: {
-              variant: 'tertiary',
-              'aria-label': translations.close[locale],
-              className: 'data-focus-visible:outline-focus-inset px-2.5!',
-              children: <Close />,
-            },
-          },
-        ],
-      ]}
-    >
-      {children}
-    </Provider>
-  );
+  return <Provider values={[[HeaderContext, { _titleId: racTitle?.id }]]}>{children}</Provider>;
 };
 
 type DialogProps = RACDialogProps & {

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,7 +1,7 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { useContext } from 'react';
-import { ButtonContext as RACButtonContext } from 'react-aria-components/Button';
+import { ButtonContext } from 'react-aria-components/Button';
 import {
   OverlayTriggerStateContext,
   Dialog as RACDialog,
@@ -17,8 +17,7 @@ import {
 } from 'react-aria-components/Modal';
 import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
 
-import { ButtonContext } from '../button';
-import { HeaderContext, HeadingContext } from '../content';
+import { HeaderContext } from '../content';
 import { translations } from '../translations';
 import { useLocale } from '../use-locale';
 
@@ -98,15 +97,12 @@ const Modal = ({
 );
 
 /**
- * Wraps the `Header` element among the dialog's children in the contexts it needs:
- * the title id (from React Aria's Dialog, for `aria-labelledby`) and the close
- * button's appearance. Scoped to `Header` so body headings and footer buttons are
- * unaffected — which means `Header` must be a direct child of the dialog content.
- *
- * The close behaviour (`onPress`) still comes from the Dialog's RAC ButtonContext;
- * here we only inject the appearance (icon, variant) and the accessible name.
+ * Rendered inside RACDialog, where React Aria exposes the generated title id
+ * through its HeadingContext. We read it here and forward it to our Header via
+ * HeaderContext, so Header stays agnostic of React Aria's Dialog and only needs
+ * to wire the id onto its heading (for `aria-labelledby`).
  */
-const DialogHeader = ({ children }: { children: React.ReactNode }) => {
+const HeaderTitle = ({ children }: { children: React.ReactNode }) => {
   const racTitle = useSlottedContext(RACHeadingContext, 'title');
   const locale = useLocale();
   return (
@@ -115,33 +111,16 @@ const DialogHeader = ({ children }: { children: React.ReactNode }) => {
         [
           HeaderContext,
           {
-            // Header applies this around its own children, so the wiring is scoped
-            // to the header without matching on the Header element type. We inject
-            // the title id (for aria-labelledby) and the close button's appearance;
-            // the close behaviour (onPress) comes from the Dialog's ButtonContext.
-            _wrap: (headerChildren) => (
-              <Provider
-                values={[
-                  [HeadingContext, { className: 'heading-s', id: racTitle?.id }],
-                  [
-                    ButtonContext,
-                    {
-                      slots: {
-                        [DEFAULT_SLOT]: {},
-                        close: {
-                          variant: 'tertiary',
-                          'aria-label': translations.close[locale],
-                          className: 'data-focus-visible:outline-focus-inset px-2.5!',
-                          children: <Close />,
-                        },
-                      },
-                    },
-                  ],
-                ]}
-              >
-                {headerChildren}
-              </Provider>
-            ),
+            _titleId: racTitle?.id,
+            // Defaults for a `<Button slot="close" />` placed inside the Header.
+            // The close behaviour (onPress) comes from the Dialog's ButtonContext;
+            // here we only inject the appearance and the accessible name.
+            _closeButton: {
+              variant: 'tertiary',
+              'aria-label': translations.close[locale],
+              className: 'data-focus-visible:outline-focus-inset px-2.5!',
+              children: <Close />,
+            },
           },
         ],
       ]}
@@ -171,7 +150,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
       <Provider
         values={[
           [
-            RACButtonContext,
+            ButtonContext,
             {
               // This is necessary to support multiple close buttons
               slots: {
@@ -188,7 +167,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
           ],
         ]}
       >
-        <DialogHeader>{children}</DialogHeader>
+        <HeaderTitle>{children}</HeaderTitle>
       </Provider>
     )}
   </RACDialog>
@@ -202,7 +181,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
 export const _ModalButtonContextReset = ({ children }: { children: React.ReactNode }) => {
   const isInsideOverlay = !!useContext(OverlayTriggerStateContext);
   return isInsideOverlay ? (
-    <Provider values={[[RACButtonContext, null]]}>{children}</Provider>
+    <Provider values={[[ButtonContext, null]]}>{children}</Provider>
   ) : (
     children
   );

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,7 +1,7 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { useContext } from 'react';
-import { ButtonContext } from 'react-aria-components/Button';
+import { Children, isValidElement, useContext } from 'react';
+import { ButtonContext as RACButtonContext } from 'react-aria-components/Button';
 import {
   OverlayTriggerStateContext,
   Dialog as RACDialog,
@@ -17,7 +17,8 @@ import {
 } from 'react-aria-components/Modal';
 import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
 
-import { HeaderContext } from '../content';
+import { ButtonContext } from '../button';
+import { Header, HeadingContext } from '../content';
 import { translations } from '../translations';
 import { useLocale } from '../use-locale';
 
@@ -97,36 +98,43 @@ const Modal = ({
 );
 
 /**
- * Rendered inside RACDialog, where React Aria exposes the generated title id
- * through its HeadingContext. We read it here and forward it to our Header via
- * HeaderContext, so Header stays agnostic of React Aria's Dialog and only needs
- * to wire the id onto its heading (for `aria-labelledby`).
+ * Wraps the `Header` element among the dialog's children in the contexts it needs:
+ * the title id (from React Aria's Dialog, for `aria-labelledby`) and the close
+ * button's appearance. Scoped to `Header` so body headings and footer buttons are
+ * unaffected — which means `Header` must be a direct child of the dialog content.
+ *
+ * The close behaviour (`onPress`) still comes from the Dialog's RAC ButtonContext;
+ * here we only inject the appearance (icon, variant) and the accessible name.
  */
-const HeaderTitle = ({ children }: { children: React.ReactNode }) => {
+const DialogHeader = ({ children }: { children: React.ReactNode }) => {
   const racTitle = useSlottedContext(RACHeadingContext, 'title');
   const locale = useLocale();
-  return (
-    <Provider
-      values={[
-        [
-          HeaderContext,
-          {
-            _titleId: racTitle?.id,
-            // Defaults for a `<Button slot="close" />` placed inside the Header.
-            // The close behaviour (onPress) comes from the Dialog's ButtonContext;
-            // here we only inject the appearance and the accessible name.
-            _closeButton: {
-              variant: 'tertiary',
-              'aria-label': translations.close[locale],
-              className: 'data-focus-visible:outline-focus-inset px-2.5!',
-              children: <Close />,
+  return Children.map(children, (child) =>
+    isValidElement(child) && child.type === Header ? (
+      <Provider
+        values={[
+          [HeadingContext, { className: 'heading-s', id: racTitle?.id }],
+          [
+            ButtonContext,
+            {
+              slots: {
+                [DEFAULT_SLOT]: {},
+                close: {
+                  variant: 'tertiary',
+                  'aria-label': translations.close[locale],
+                  className: 'data-focus-visible:outline-focus-inset px-2.5!',
+                  children: <Close />,
+                },
+              },
             },
-          },
-        ],
-      ]}
-    >
-      {children}
-    </Provider>
+          ],
+        ]}
+      >
+        {child}
+      </Provider>
+    ) : (
+      child
+    ),
   );
 };
 
@@ -150,7 +158,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
       <Provider
         values={[
           [
-            ButtonContext,
+            RACButtonContext,
             {
               // This is necessary to support multiple close buttons
               slots: {
@@ -167,7 +175,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
           ],
         ]}
       >
-        <HeaderTitle>{children}</HeaderTitle>
+        <DialogHeader>{children}</DialogHeader>
       </Provider>
     )}
   </RACDialog>
@@ -181,7 +189,7 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
 export const _ModalButtonContextReset = ({ children }: { children: React.ReactNode }) => {
   const isInsideOverlay = !!useContext(OverlayTriggerStateContext);
   return isInsideOverlay ? (
-    <Provider values={[[ButtonContext, null]]}>{children}</Provider>
+    <Provider values={[[RACButtonContext, null]]}>{children}</Provider>
   ) : (
     children
   );

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,4 +1,3 @@
-import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
 import { useContext } from 'react';
 import { ButtonContext } from 'react-aria-components/Button';
@@ -16,10 +15,7 @@ import {
 } from 'react-aria-components/Modal';
 import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
 
-import { Button } from '../button';
 import { HeaderContext } from '../content';
-import { translations } from '../translations';
-import { useLocale } from '../use-locale';
 
 type DialogTriggerProps = RACDialogTriggerProps;
 
@@ -70,26 +66,14 @@ const Modal = ({
   fullscreen = false,
   ...restProps
 }: ModalProps) => {
-  const locale = useLocale();
   return (
     <Provider
       values={[
         [
           HeaderContext,
           {
-            // The close button is injected into the Header. RAC Dialog supports
-            // one "close" slot out of the box, which we utilize here.
-            _action: isDismissable ? (
-              <Button
-                slot="close"
-                variant="tertiary"
-                className="data-focus-visible:outline-focus-inset px-2.5!"
-                aria-label={translations.close[locale]}
-                onPress={() => onOpenChange?.(false)}
-              >
-                <Close />
-              </Button>
-            ) : undefined,
+            // Header renders the dismiss button itself; we only pass the close handler.
+            _onClose: isDismissable ? () => onOpenChange?.(false) : undefined,
           },
         ],
       ]}

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -17,7 +17,6 @@ import {
 } from 'react-aria-components/Modal';
 import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
 
-import { Button } from '../button';
 import { HeaderContext } from '../content';
 import { translations } from '../translations';
 import { useLocale } from '../use-locale';
@@ -70,58 +69,32 @@ const Modal = ({
   zIndex,
   fullscreen = false,
   ...restProps
-}: ModalProps) => {
-  const locale = useLocale();
-  return (
-    <Provider
-      values={[
-        [
-          HeaderContext,
-          {
-            // The close button is injected into the Header. RAC Dialog supports
-            // one "close" slot out of the box, which we utilize here.
-            _action: isDismissable ? (
-              <Button
-                slot="close"
-                variant="tertiary"
-                className="data-focus-visible:outline-focus-inset px-2.5!"
-                aria-label={translations.close[locale]}
-                onPress={() => onOpenChange?.(false)}
-              >
-                <Close />
-              </Button>
-            ) : undefined,
-          },
-        ],
-      ]}
-    >
-      <_ModalOverlay
-        isOpen={isOpen}
-        onOpenChange={onOpenChange}
-        defaultOpen={defaultOpen}
-        isDismissable={isDismissable}
-        isKeyboardDismissDisabled={!isDismissable}
-        zIndex={zIndex}
-        fullscreen={fullscreen}
-      >
-        <RACModal
-          {...restProps}
-          className={({ isEntering, isExiting }) =>
-            cx(
-              className,
-              'overflow-auto bg-white text-left shadow-xl',
-              fullscreen ? 'fixed inset-0' : 'w-full max-w-md rounded-2xl align-middle',
-              isEntering && 'zoom-in-95 animate-in duration-300 ease-out',
-              isExiting && 'zoom-out-95 animate-out duration-200 ease-in',
-              // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
-              'motion-reduce:animate-none',
-            )
-          }
-        />
-      </_ModalOverlay>
-    </Provider>
-  );
-};
+}: ModalProps) => (
+  <_ModalOverlay
+    isOpen={isOpen}
+    onOpenChange={onOpenChange}
+    defaultOpen={defaultOpen}
+    isDismissable={isDismissable}
+    isKeyboardDismissDisabled={!isDismissable}
+    zIndex={zIndex}
+    fullscreen={fullscreen}
+  >
+    <RACModal
+      {...restProps}
+      className={({ isEntering, isExiting }) =>
+        cx(
+          className,
+          'overflow-auto bg-white text-left shadow-xl',
+          fullscreen ? 'fixed inset-0' : 'w-full max-w-md rounded-2xl align-middle',
+          isEntering && 'zoom-in-95 animate-in duration-300 ease-out',
+          isExiting && 'zoom-out-95 animate-out duration-200 ease-in',
+          // Using the motion-safe class does not work, so we use motion-reduce to overwrite instead
+          'motion-reduce:animate-none',
+        )
+      }
+    />
+  </_ModalOverlay>
+);
 
 /**
  * Rendered inside RACDialog, where React Aria exposes the generated title id
@@ -131,9 +104,27 @@ const Modal = ({
  */
 const HeaderTitle = ({ children }: { children: React.ReactNode }) => {
   const racTitle = useSlottedContext(RACHeadingContext, 'title');
-  const header = useContext(HeaderContext) as { _action?: React.ReactNode } | null;
+  const locale = useLocale();
   return (
-    <Provider values={[[HeaderContext, { ...header, _titleId: racTitle?.id }]]}>
+    <Provider
+      values={[
+        [
+          HeaderContext,
+          {
+            _titleId: racTitle?.id,
+            // Defaults for a `<Button slot="close" />` placed inside the Header.
+            // The close behaviour (onPress) comes from the Dialog's ButtonContext;
+            // here we only inject the appearance and the accessible name.
+            _closeButton: {
+              variant: 'tertiary',
+              'aria-label': translations.close[locale],
+              className: 'data-focus-visible:outline-focus-inset px-2.5!',
+              children: <Close />,
+            },
+          },
+        ],
+      ]}
+    >
       {children}
     </Provider>
   );

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -17,7 +17,7 @@ import {
 import { DEFAULT_SLOT, Provider } from 'react-aria-components/slots';
 
 import { Button } from '../button';
-import { HeadingContext } from '../content';
+import { HeaderContext } from '../content';
 import { translations } from '../translations';
 import { useLocale } from '../use-locale';
 
@@ -75,30 +75,21 @@ const Modal = ({
     <Provider
       values={[
         [
-          HeadingContext,
+          HeaderContext,
           {
-            slots: {
-              [DEFAULT_SLOT]: {}, // RAC requires a default slot in order to support non-slotted components
-              title: {
-                className: 'heading-s',
-                _outerWrapper: (children) => (
-                  <div className="flex items-center justify-between gap-x-2">
-                    {children}
-                    {isDismissable && (
-                      <Button
-                        slot="close" // RAC Dialog supports one close button out of the box, so we utilize that here. For other close buttons we use ButtonContext
-                        variant="tertiary"
-                        className="data-focus-visible:outline-focus-inset px-2.5!"
-                        aria-label={translations.close[locale]}
-                        onPress={() => onOpenChange?.(false)}
-                      >
-                        <Close />
-                      </Button>
-                    )}
-                  </div>
-                ),
-              },
-            },
+            // The close button is injected into the Header. RAC Dialog supports
+            // one "close" slot out of the box, which we utilize here.
+            _action: isDismissable ? (
+              <Button
+                slot="close"
+                variant="tertiary"
+                className="data-focus-visible:outline-focus-inset px-2.5!"
+                aria-label={translations.close[locale]}
+                onPress={() => onOpenChange?.(false)}
+              >
+                <Close />
+              </Button>
+            ) : undefined,
           },
         ],
       ]}
@@ -141,6 +132,8 @@ const Dialog = ({ className, children, ...restProps }: DialogProps) => (
     className={cx(
       className,
       'relative flex flex-col gap-y-5 p-4 outline-none',
+      // Header
+      '**:data-[slot="header"]:flex **:data-[slot="header"]:items-center **:data-[slot="header"]:justify-between **:data-[slot="header"]:gap-x-2',
       // Footer
       '**:data-[slot="footer"]:flex **:data-[slot="footer"]:gap-x-2',
     )}

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -1,6 +1,6 @@
 import { Close } from '@obosbbl/grunnmuren-icons-react';
 import { cx } from 'cva';
-import { Children, isValidElement, useContext } from 'react';
+import { useContext } from 'react';
 import { ButtonContext as RACButtonContext } from 'react-aria-components/Button';
 import {
   OverlayTriggerStateContext,
@@ -18,7 +18,7 @@ import {
 import { DEFAULT_SLOT, Provider, useSlottedContext } from 'react-aria-components/slots';
 
 import { ButtonContext } from '../button';
-import { Header, HeadingContext } from '../content';
+import { HeaderContext, HeadingContext } from '../content';
 import { translations } from '../translations';
 import { useLocale } from '../use-locale';
 
@@ -109,32 +109,45 @@ const Modal = ({
 const DialogHeader = ({ children }: { children: React.ReactNode }) => {
   const racTitle = useSlottedContext(RACHeadingContext, 'title');
   const locale = useLocale();
-  return Children.map(children, (child) =>
-    isValidElement(child) && child.type === Header ? (
-      <Provider
-        values={[
-          [HeadingContext, { className: 'heading-s', id: racTitle?.id }],
-          [
-            ButtonContext,
-            {
-              slots: {
-                [DEFAULT_SLOT]: {},
-                close: {
-                  variant: 'tertiary',
-                  'aria-label': translations.close[locale],
-                  className: 'data-focus-visible:outline-focus-inset px-2.5!',
-                  children: <Close />,
-                },
-              },
-            },
-          ],
-        ]}
-      >
-        {child}
-      </Provider>
-    ) : (
-      child
-    ),
+  return (
+    <Provider
+      values={[
+        [
+          HeaderContext,
+          {
+            // Header applies this around its own children, so the wiring is scoped
+            // to the header without matching on the Header element type. We inject
+            // the title id (for aria-labelledby) and the close button's appearance;
+            // the close behaviour (onPress) comes from the Dialog's ButtonContext.
+            _wrap: (headerChildren) => (
+              <Provider
+                values={[
+                  [HeadingContext, { className: 'heading-s', id: racTitle?.id }],
+                  [
+                    ButtonContext,
+                    {
+                      slots: {
+                        [DEFAULT_SLOT]: {},
+                        close: {
+                          variant: 'tertiary',
+                          'aria-label': translations.close[locale],
+                          className: 'data-focus-visible:outline-focus-inset px-2.5!',
+                          children: <Close />,
+                        },
+                      },
+                    },
+                  ],
+                ]}
+              >
+                {headerChildren}
+              </Provider>
+            ),
+          },
+        ],
+      ]}
+    >
+      {children}
+    </Provider>
   );
 };
 


### PR DESCRIPTION
### Oppsummering

Boligdrøm meldte inn at de ønsket å gjøre header og footer i en Drawer «sticky», slik at tittel + lukkeknapp og CTA blir værende synlige når brukeren scroller. Løsningen er å la konsumenten styre dette selv: komponenten implementerer ikke sticky/fixed, men `Footer` (som fra før) og en ny `Header` kan nå styles fritt via `className`. Løser [AB#142627](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/142627).

### Endringer

- Ny `Header`-komponent i `content.tsx` — en tynn wrapper rundt et `div` med `data-slot="header"`, på linje med `Footer`. Konsumenten kan gi den `className`, for eksempel `sticky top-0 bg-white`.
- Inne i en Modal/Drawer bygger den delte `Dialog` contextene headeren trenger — tittelstørrelse + id på `Heading` (for `aria-labelledby`), og utseendet (× ikon, `tertiary`-variant, lokalisert `aria-label`) på en bar `Button` med `slot="close"` — og sender dem til `Header` via `HeaderContext`. `Header` rendrer bare en `Provider` med disse rundt sine egne `children`. Dermed holder det å skrive en `Heading` og en bar `Button slot="close"` — verken `slot="title"` eller manuell styling av lukkeknappen trengs. `aria-labelledby` manglet faktisk fra før (den egne `Heading`-en plukket ikke opp React Arias tittel-id), så dette er også en a11y-forbedring.
- Fordi `Header` kun pakker sine egne `children`, er contextene scopet til headeren — brødtekst-overskrifter og footer-knapper (som også bruker `slot="close"`) er uberørt. `Header` kjenner verken til React Aria, lukke-ikonet eller språk — alt bygges i `Dialog`. Selve lukke-oppførselen (`onPress`) kommer også fra `Dialog`.
- `Dialog` styler `data-slot="header"` på samme måte som `footer` fra før — flex-layout med tittel til venstre og lukkeknapp til høyre.
- Migrerte alle Modal- og Drawer-stories til det nye API-et, og la til en `StickyHeaderFooter`-story som viser sticky header + footer. Storyen inkluderer oppskriften med negative marginer (`-m-4`) som lar bakgrunnen dekke hele bredden og holder avstanden til brødteksten jevn, til tross for paddingen på `Dialog`.

### Merk

`Modal`/`Drawer` er fortsatt beta (`UNSAFE_`-prefiks), og dette er et lite breaking change i det API-et: tittelen må nå pakkes i `Header`, `slot="title"` fjernes, og lukkeknappen legges til eksplisitt som en `Button` med `slot="close"`. Migrasjon er beskrevet i changesetet.

### Verifisering

Verifisert lokalt i Storybook (automatiske DOM-sjekker via headless browser, 11/11): tittelen rendres med riktig størrelse, `aria-labelledby` peker på den, en bar lukkeknapp får injisert ikon + `aria-label` og lukker dialogen ved klikk, lukkeknappen uteblir ved `isDismissable={false}` (konsumenten utelater den), og sticky header/footer fungerer ved scroll i `StickyHeaderFooter`-storyen.

### Skjermbilder

Ingen «Før» — eksisterende stories ser visuelt likt ut (header er fortsatt tittel + lukkeknapp). Det nye er sticky-muligheten, vist under.

https://github.com/user-attachments/assets/86bf50ef-dad1-4cdf-a1df-0bbc3641fd36

### Utenfor scope
Vi har gått over på å flytte all styling over i egne klasser/selektorer i tailwind-pakken for alle komponentene. Men det er utenfor scopet til denne PR-en. Og blir heller en del av bl.a. [AB#130235](https://dev.azure.com/obosbbl/Content%20hub/_boards/board/t/Designsystem%20-%20Grunnmuren/Stories?workitem=130235) - når vi tar komponentene ut av beta

---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).