### PR TITLE
add lead-sm typography utility

### DIFF
--- a/.changeset/lead-sm-utility.md
+++ b/.changeset/lead-sm-utility.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-tailwind": minor
+---
+
+Add a `lead-sm` typography utility — a smaller, supplementary lead (19px mobile / 22px desktop, regular weight) for the right size contrast against `heading-l`. Works both as a standalone utility and inside `prose`.

--- a/packages/react/src/__stories__/typography.stories.tsx
+++ b/packages/react/src/__stories__/typography.stories.tsx
@@ -55,6 +55,12 @@ export const Lead = () => (
   </p>
 );
 
+export const LeadSm = () => (
+  <p className="lead-sm">
+    Dokumentavgift er en avgift som du må betale til staten når du kjøper en fast eiendom.
+  </p>
+);
+
 export const Body = () => {
   return (
     <>

--- a/packages/tailwind/tailwind-base.css
+++ b/packages/tailwind/tailwind-base.css
@@ -267,6 +267,10 @@
   @apply text-[1.4375rem]/[2.25rem] font-medium lg:text-[1.625rem]/[2.5625rem];
 }
 
+@utility lead-sm {
+  @apply text-[1.1875rem]/[1.875rem] font-normal lg:text-[1.375rem]/[2.1875rem];
+}
+
 @utility blockquote {
   @apply before:font-display grid grid-cols-[2.6875rem_1fr] pt-4 text-[1.1875rem]/[1.875rem] font-medium italic before:text-[3.5625rem]/[1.5625rem] before:not-italic before:content-["“"] lg:grid-cols-[2.9375rem_1fr] lg:gap-x-[0.375rem] lg:text-[1.3125rem]/[2.125rem] lg:before:text-[3.9375rem]/[1.8125rem];
 }

--- a/packages/tailwind/tailwind-typography.css
+++ b/packages/tailwind/tailwind-typography.css
@@ -9,6 +9,8 @@
 ));
 @custom-variant prose-lead (&
 :is([class~="lead"]):not(:where([class~="not-prose"], [class~="not-prose"] *)));
+@custom-variant prose-lead-sm (&
+:is([class~="lead-sm"]):not(:where([class~="not-prose"], [class~="not-prose"] *)));
 @custom-variant prose-h1 (&
 :is(h1):not(:where([class~="not-prose"], [class~="not-prose"] *)));
 @custom-variant prose-h2 (&
@@ -94,6 +96,12 @@
 
     &:where([class~='lead']) {
       @apply text-[1.4375rem]/[2.25rem] font-medium lg:text-[1.625rem]/[2.5625rem];
+      margin-top: 1.2em;
+      margin-bottom: 1.2em;
+    }
+
+    &:where([class~='lead-sm']) {
+      @apply text-[1.1875rem]/[1.875rem] font-normal lg:text-[1.375rem]/[2.1875rem];
       margin-top: 1.2em;
       margin-bottom: 1.2em;
     }


### PR DESCRIPTION
Nytt supplementary lead-nivå med riktig størrelseskontrast mot heading-l. Løser [AB#144046](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/144046)

- ny `lead-sm` utility i tailwind-base: 19px mobil / 22px desktop
- weight er `font-normal` (regular) som ACen sier — merk at det avviker fra `lead` som er medium, så verdt en sjekk med designer
- line-height er ikke oppgitt i ticket, satte 30px mobil / 35px desktop (samme ratio ~1.58 som `lead`, og 30px matcher det skalaen alt bruker for 19px)
- støtte i prose også (`prose-lead-sm` + margins likt `lead`)
- LeadSm story under Typography


<img width="1090" height="544" alt="image" src="https://github.com/user-attachments/assets/792a4928-35a4-45e7-b619-899f2c614c11" />
