### PR TITLE
Hold bildet inntil kanten på liggende kort uansett rekkefølge

### DIFF
--- a/.changeset/card-horizontal-media-fill-height.md
+++ b/.changeset/card-horizontal-media-fill-height.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fix horizontal `Card` so the media stays flush to the card edges regardless of Media/Content order (including reordering with CSS `order`) and fills the full card height when the content is the taller column.

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -80,19 +80,26 @@ const cardVariants = cva({
         '**:data-[slot="media"]:rounded-t-2xl', // Both Top corners are rounded
       ],
       horizontal: [
-        // Use more gap for horizontal cards that have media
-        // Since this does not affect the layout before the flex direction is set (at breakpoint @2xl for Card with Media), we can set it here
-        'has-data-[slot=media]:layout-gap-x not-has-data-[slot=media]:gap-x-4',
+        // Column gap between media and content (only takes effect at @2xl, when the direction is row).
+        // Content adds its own 12px inner padding on top, so the visible image→text gap reads ~36px.
+        'not-has-data-[slot=media]:gap-x-4 has-data-[slot=media]:gap-x-6',
         // **** With Media ****
         '[&:has(>[data-slot="media"]:last-child)]:flex-col-reverse', // Always display the media at the top of the card
         'has-data-[slot=media]:@2xl:flex-row!', // We need !important to override the specificity (first-/last-child) of the flex-col-reverse and flex-col classes
 
-        '*:data-[slot=media]:@2xl:h-fit', // Fail-safe for rounded corners on media content
-        'has-data-[slot=media]:*:@2xl:basis-1/2', // Ensures a 50/50 split of the media and content on medium screens
-        // Position media at the edges of the card
-        '*:data-[slot=media]:@2xl:mb-[calc(theme(space.3)*-1-theme(borderWidth.DEFAULT))]',
-        '*:data-[slot=media]:first:@2xl:mr-0',
-        '*:data-[slot=media]:last:@2xl:ml-0',
+        // 50/50 split. flex-1 (not basis-1/2) so the columns fill the space after the gap and the
+        // media's negative margin reaches the edge (basis-1/2 would overflow and get shrunk back).
+        'has-data-[slot=media]:*:@2xl:flex-1',
+
+        // Inset via Content instead of the card, so the media stays flush to the edges no matter the
+        // Media/Content order (incl. CSS `order`) — no first/last-child margins. Card drops its
+        // padding, media bleeds just the 1px border (symmetric), Content carries the padding.
+        'has-data-[slot=media]:@2xl:p-0',
+        'has-data-[slot=media]:@2xl:**:data-[slot=content]:p-3',
+        '*:data-[slot=media]:@2xl:-m-px!', // !important to beat the base media margins (which assume the card padding)
+        // Media stretches to full height and the image fills via min-h-full, so it reaches top/bottom
+        // even when Content is taller. Keeps its 3:2 aspect as min height, so short cards are unchanged.
+        '[&_[data-slot=media]>img]:@2xl:min-h-full',
 
         // Make sure the card link is clickable when the media is on the right side
         // This is necessary because the media content is positioned after the card link in the DOM


### PR DESCRIPTION
### Oppsummering

Liggende `Card` med bilde la på `p-3` rundt hele kortet og dro bildet ut til kanten igjen med negative marginer, der den indre siden (mot innholdet) ble nullstilt ut fra om `Media` var første eller siste barn i DOM. Det gjorde at hvis en konsument byttet visuell rekkefølge på `Media` og `Content` med CSS `order`, ble feil side nullstilt – og det oppsto luft mellom bildet og kanten på kortet. I tillegg brukte bildet `h-fit`, så når innholdskolonnen var høyere enn bildets 3:2-forhold, fylte ikke bildet hele kortets høyde (tomrom under bildet).

### Endringer

Alle endringene gjelder kun liggende kort med bilde ved `@2xl` (der kortet faktisk legger seg side-om-side). Under `@2xl` brekker kortet fortsatt til stående, uendret.

- **Flyttet innrykket fra kortet til `Content`.** Ved `@2xl` fjernes kortets egen padding (`p-0`), og `Content` får paddingen i stedet (`p-3`). Da ligger bildet flush mot kortkanten helt av seg selv, uten side-spesifikke marginer – og det holder uansett rekkefølge, også når `Media`/`Content` byttes om med CSS `order`.
- **Bildet dekker nå bare 1px-borderen**, symmetrisk på alle sider, i stedet for de gamle `first`/`last`-avhengige marginene. Ingen side behandles spesielt, så DOM-rekkefølgen spiller ingen rolle. De to kolonnene bruker `flex-1` slik at bildet når helt ut til kanten selv med kolonne-gap.
- **Bildekolonnen strekker seg til full korthøyde** (flexboxens `align-items: stretch`), og bildet fyller høyden via `min-h-full`. Dermed når bildet både topp- og bunnkanten selv når innholdet er den høyeste kolonnen. Bildet beholder 3:2-forholdet som minstehøyde, så kort med lite innhold ser likt ut som før.
- Changeset (patch) for `@obosbbl/grunnmuren-react`.

### Gjenstår

- For `outlined`-varianten styres avrundingen av bildets hjørner fortsatt av `first`/`last-child` (uendret i denne PR-en). Selve luft-problemet er løst for begge varianter, men ved CSS `order`-bytte på et `outlined` liggende kort kan bildets hjørneavrunding havne på feil side. Kan tas som en egen oppfølging om det er ønskelig.

### Skjermbilder

**Før** (media har fått `order-1`):

<img width="1077" height="366" alt="Screenshot 2026-07-03 at 14 13 37" src="https://github.com/user-attachments/assets/074ce0d0-16a3-480d-802d-27b4ef8b053a" />

**Etter**  (media har fått `order-1`):

<img width="966" height="347" alt="Screenshot 2026-07-03 at 14 14 21" src="https://github.com/user-attachments/assets/08399ead-c84d-403b-af9e-9322110f46f6" />

---
> 🤖 Generert med Claude Code, kvalitetssikret av Oscar Carlström (kan være manuelt redigert).