### PR TITLE
chore: ignore .agents folder in oxlint and oxfmt

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -1,6 +1,12 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["sanity.types.ts", "routeTree.gen.ts", "CHANGELOG.md", ".changeset/*.md"],
+  "ignorePatterns": [
+    "sanity.types.ts",
+    "routeTree.gen.ts",
+    "CHANGELOG.md",
+    ".changeset/*.md",
+    ".agents",
+  ],
   "singleQuote": true,
   "sortPackageJson": {
     "sortScripts": true,

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,7 +14,7 @@
     "node"
   ],
   "jsPlugins": ["eslint-plugin-better-tailwindcss"],
-  "ignorePatterns": ["sanity.types.ts", "routeTree.gen.ts"],
+  "ignorePatterns": ["sanity.types.ts", "routeTree.gen.ts", ".agents"],
   "options": {
     "typeAware": true,
     "typeCheck": true


### PR DESCRIPTION
Excludes the .agents folder from linting and formatting checks to prevent CI failures due to formatting issues in generated agent configurations.