### PR TITLE
fix accordion icons rotating with the chevron

### DIFF
--- a/.changeset/accordion-heading-icon-rotation.md
+++ b/.changeset/accordion-heading-icon-rotation.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/grunnmuren-react": patch
+---
+
+Fix `Accordion`/`Disclosure` so only the chevron rotates when expanding. Icons placed in the heading no longer flip upside down along with it.

--- a/packages/react/src/accordion/accordion.stories.tsx
+++ b/packages/react/src/accordion/accordion.stories.tsx
@@ -1,3 +1,4 @@
+import { CreditCard, House } from '@obosbbl/grunnmuren-icons-react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useReducer } from 'react';
 
@@ -159,6 +160,42 @@ const ColoredStandaloneTemplate = (args: AccordionItemProps) => {
   );
 };
 
+// Icons in the heading should stay put when the accordion expands, only the chevron flips
+const WithIconsInHeadingTemplate = (args: AccordionItemProps) => {
+  return (
+    <Accordion>
+      <AccordionItem
+        onExpandedChange={args.onExpandedChange}
+        defaultExpanded={args.defaultExpanded}
+      >
+        <Heading level={2}>
+          <span className="flex items-center gap-2">
+            <CreditCard className="flex-none" />
+            Prisinformasjon
+          </span>
+        </Heading>
+        <Content className="prose">
+          <p>Felleskostnader og andre kostnader knyttet til boligen.</p>
+        </Content>
+      </AccordionItem>
+      <AccordionItem
+        onExpandedChange={args.onExpandedChange}
+        defaultExpanded={args.defaultExpanded}
+      >
+        <Heading level={2}>
+          <span className="flex items-center gap-2">
+            <House className="flex-none" />
+            Størrelse
+          </span>
+        </Heading>
+        <Content className="prose">
+          <p>BRA-i: 79 m&sup2;</p>
+        </Content>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
 const meta = {
   title: 'Accordion',
   component: AccordionItem,
@@ -197,5 +234,13 @@ export const ColoredStandalone: Story = {
   render: ColoredStandaloneTemplate,
   args: {
     ...defaultProps,
+  },
+};
+
+export const WithIconsInHeading: Story = {
+  render: WithIconsInHeadingTemplate,
+  args: {
+    ...defaultProps,
+    defaultExpanded: true,
   },
 };

--- a/packages/react/src/disclosure/disclosure.tsx
+++ b/packages/react/src/disclosure/disclosure.tsx
@@ -35,10 +35,6 @@ const disclosureButtonVariants = cva({
     'data-accordion:-m-2.5',
   ],
   variants: {
-    withChevron: {
-      true: '[&[aria-expanded="true"]_svg]:rotate-180',
-      false: null,
-    },
     /**
      * When the button is without text, but with a single icon.
      * @default false
@@ -49,7 +45,6 @@ const disclosureButtonVariants = cva({
     },
   },
   defaultVariants: {
-    withChevron: false,
     isIconOnly: false,
   },
 });
@@ -57,6 +52,11 @@ const disclosureButtonVariants = cva({
 type DisclosureButtonProps = Omit<ButtonProps, 'children'> &
   VariantProps<typeof disclosureButtonVariants> & {
     children?: React.ReactNode;
+    /**
+     * Renders a chevron that flips when the disclosure is expanded.
+     * @default false
+     */
+    withChevron?: boolean;
   } & RefAttributes<HTMLButtonElement>;
 
 const DisclosureButton = ({
@@ -81,14 +81,13 @@ const DisclosureButton = ({
       ref={ref}
       className={disclosureButtonVariants({
         className,
-        withChevron,
         isIconOnly,
       })}
       slot={hasContext ? 'trigger' : undefined}
     >
       {children}
       {withChevron && (
-        <ChevronDown className="flex-none transition-transform duration-300 motion-reduce:transition-none" />
+        <ChevronDown className="flex-none transition-transform duration-300 in-aria-expanded:rotate-180 motion-reduce:transition-none" />
       )}
     </Button>
   );


### PR DESCRIPTION
fix [AB#145577](https://dev.azure.com/obosbbl/95fe6e68-b1c5-4e8e-9ebb-fff9d8eeb377/_workitems/edit/145577)

Ikoner som ligger i headingen snurra 180 grader sammen med chevronen når man åpna en accordion. Rotasjonen lå som en descendant-selector på selve knappen (`[&[aria-expanded="true"]_svg]:rotate-180`), så den traff alle svg-er inni knappen — ikke bare chevronen.

- flytter rotasjonen til chevronen selv med `in-aria-expanded:rotate-180`
- fjerner `withChevron` fra cva-variantene siden den bare fantes for den selectoren, deklarerer den som vanlig prop i stedet
- ny `WithIconsInHeading` story med `defaultExpanded` sånn at vi fanger opp regresjonen neste gang
